### PR TITLE
Avoid constant address resolution via a pointer in memory.c without -flto

### DIFF
--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -70,7 +70,7 @@ DPS_register dps_register;
 
 ALIGN(16, unsigned int rdram[0x800000/4]);
 
-unsigned char *rdramb = (unsigned char *)(rdram);
+unsigned char *const rdramb = (unsigned char *)(rdram);
 unsigned int SP_DMEM[0x1000/4*2];
 unsigned int *SP_IMEM = SP_DMEM+0x1000/4;
 unsigned char *SP_DMEMb = (unsigned char *)(SP_DMEM);

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -215,7 +215,7 @@ extern AI_register ai_register;
 extern DPC_register dpc_register;
 extern DPS_register dps_register;
 
-extern unsigned char *rdramb;
+extern unsigned char *const rdramb;
 
 #ifndef M64P_BIG_ENDIAN
 #define sl(mot) \


### PR DESCRIPTION
GCC cannot identify the rdramb pointer as const and therefore not remove any
indirection when using it without link-time optimization. The missing const
reduces the performance slightly in (read|write)_rdram[bhd]? because extra
instructions have to be generated to get the value of rdramb from memory.

Reported-by: Nebuleon Fumika
