### PR TITLE
Change struct breakpoint to m64p_breakpoint.

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus_v2.0_Core_Debugger.txt
+++ b/doc/emuwiki-api-doc/Mupen64Plus_v2.0_Core_Debugger.txt
@@ -214,18 +214,18 @@ Most libmupen64plus functions return an <tt>m64p_error</tt> return code, which i
 <br />
 {| border="1"
 |Prototype
-|'''<tt>int DebugBreakpointCommand(m64p_dbg_bkp_command command, unsigned int index, void *ptr)</tt>'''
+|'''<tt>int DebugBreakpointCommand(m64p_dbg_bkp_command command, unsigned int index, m64p_breakpoint *bkp)</tt>'''
 |-
 |Input Parameters
 |'''<tt>command</tt>''' Enumerated value specifying the breakpoint command to execute<br />
 '''<tt>index</tt>''' Purpose varies by command, see table below<br />
-'''<tt>ptr</tt>''' Purpose varies by command, see table below
+'''<tt>bkp</tt>''' Pointer to breakpoint for certain commands, see table below
 |-
 |Requirements
 |The Mupen64Plus library must be built with debugger support and must be initialized before calling this function.
 |-
 |Usage
-|This function is used to process common breakpoint commands, such as adding, removing, or searching the breakpoints.  The meanings of the '''<tt>index</tt>''' and '''<tt>ptr</tt>''' input parameters vary by command, and are given in the table below.  The '''<tt>m64p_dbg_bkp_command</tt>''' type is enumerated in [[Mupen64Plus v2.0 headers#m64p_types.h|m64p_types.h]].
+|This function is used to process common breakpoint commands, such as adding, removing, or searching the breakpoints.  The meanings of the '''<tt>index</tt>''' and '''<tt>bkp</tt>''' input parameters vary by command, and are given in the table below.  The '''<tt>m64p_dbg_bkp_command</tt>''' type is enumerated in [[Mupen64Plus v2.0 headers#m64p_types.h|m64p_types.h]].
 |}
 <br />
 {| border="1"

--- a/doc/emuwiki-api-doc/Mupen64Plus_v2.0_headers.txt
+++ b/doc/emuwiki-api-doc/Mupen64Plus_v2.0_headers.txt
@@ -281,12 +281,11 @@
  #define BPT_CLEAR_FLAG(a, b)  a.flags = (a.flags & (~b));
  #define BPT_TOGGLE_FLAG(a, b) a.flags = (a.flags ^ b);
  
- typedef struct _breakpoint {
-     unsigned int address; 
-     unsigned int endaddr;
-     unsigned int flags;
-     //unsigned int condition;  //Placeholder for breakpoint condition
-     } breakpoint;
+ typedef struct {
+   unsigned int address;
+   unsigned int endaddr;
+   unsigned int flags;
+ } m64p_breakpoint;
  
  /* ------------------------------------------------- */
  /* Structures and Types for Core Video Extension API */

--- a/src/api/debugger.c
+++ b/src/api/debugger.c
@@ -355,7 +355,7 @@ EXPORT int CALL DebugBreakpointLookup(unsigned int address, unsigned int size, u
 #endif
 }
 
-EXPORT int CALL DebugBreakpointCommand(m64p_dbg_bkp_command command, unsigned int index, void *ptr)
+EXPORT int CALL DebugBreakpointCommand(m64p_dbg_bkp_command command, unsigned int index, m64p_breakpoint *bkp)
 {
 #ifdef DBG
     switch (command)
@@ -363,9 +363,9 @@ EXPORT int CALL DebugBreakpointCommand(m64p_dbg_bkp_command command, unsigned in
         case M64P_BKP_CMD_ADD_ADDR:
             return add_breakpoint(index);
         case M64P_BKP_CMD_ADD_STRUCT:
-            return add_breakpoint_struct((breakpoint *) ptr);
+            return add_breakpoint_struct(bkp);
         case M64P_BKP_CMD_REPLACE:
-            replace_breakpoint_num(index, (breakpoint *) ptr);
+            replace_breakpoint_num(index, bkp);
             return 0;
         case M64P_BKP_CMD_REMOVE_ADDR:
             remove_breakpoint_by_address(index);

--- a/src/api/m64p_debugger.h
+++ b/src/api/m64p_debugger.h
@@ -189,9 +189,9 @@ EXPORT int CALL DebugBreakpointLookup(unsigned int, unsigned int, unsigned int);
  * removing, or searching the breakpoints. The meanings of the index and ptr
  * input parameters vary by command.
  */
-typedef int (*ptr_DebugBreakpointCommand)(m64p_dbg_bkp_command, unsigned int, void *);
+typedef int (*ptr_DebugBreakpointCommand)(m64p_dbg_bkp_command, unsigned int, m64p_breakpoint *);
 #if defined(M64P_CORE_PROTOTYPES)
-EXPORT int CALL DebugBreakpointCommand(m64p_dbg_bkp_command, unsigned int, void *);
+EXPORT int CALL DebugBreakpointCommand(m64p_dbg_bkp_command, unsigned int, m64p_breakpoint *);
 #endif
 
 #ifdef __cplusplus

--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -303,14 +303,11 @@ typedef enum {
 #define BPT_CLEAR_FLAG(a, b)  a.flags = (a.flags & (~b));
 #define BPT_TOGGLE_FLAG(a, b) a.flags = (a.flags ^ b);
 
-typedef struct _breakpoint {
-    unsigned int address; 
-    unsigned int endaddr;
-    unsigned int flags;
-#if 0 /* placeholder for breakpoint condition */
-    unsigned int condition;
-#endif
-    } breakpoint;
+typedef struct {
+  unsigned int address;
+  unsigned int endaddr;
+  unsigned int flags;
+} m64p_breakpoint;
 
 /* ------------------------------------------------- */
 /* Structures and Types for Core Video Extension API */

--- a/src/debugger/dbg_breakpoints.c
+++ b/src/debugger/dbg_breakpoints.c
@@ -31,7 +31,7 @@
 #include "api/callbacks.h"
 
 int g_NumBreakpoints=0;
-breakpoint g_Breakpoints[BREAKPOINTS_MAX_NUMBER];
+m64p_breakpoint g_Breakpoints[BREAKPOINTS_MAX_NUMBER];
 
 
 int add_breakpoint( uint32 address )
@@ -49,14 +49,14 @@ int add_breakpoint( uint32 address )
     return g_NumBreakpoints++;
 }
 
-int add_breakpoint_struct(breakpoint* newbp)
+int add_breakpoint_struct(m64p_breakpoint *newbp)
 {
      if( g_NumBreakpoints == BREAKPOINTS_MAX_NUMBER ) {
         DebugMessage(M64MSG_ERROR, "BREAKPOINTS_MAX_NUMBER have been reached.");
         return -1;
     }
 
-    memcpy(&g_Breakpoints[g_NumBreakpoints], newbp, sizeof(breakpoint));
+    memcpy(&g_Breakpoints[g_NumBreakpoints], newbp, sizeof(m64p_breakpoint));
 
     if(BPT_CHECK_FLAG(g_Breakpoints[g_NumBreakpoints], BPT_FLAG_ENABLED))
     {
@@ -69,7 +69,7 @@ int add_breakpoint_struct(breakpoint* newbp)
 
 void enable_breakpoint( int bpt)
 {
-    breakpoint *curBpt = g_Breakpoints + bpt;
+    m64p_breakpoint *curBpt = g_Breakpoints + bpt;
     uint64 bptAddr;
     
     if(BPT_CHECK_FLAG((*curBpt), BPT_FLAG_READ)) {
@@ -89,7 +89,7 @@ void enable_breakpoint( int bpt)
 
 void disable_breakpoint( int bpt )
 {
-    breakpoint *curBpt = g_Breakpoints + bpt;
+    m64p_breakpoint *curBpt = g_Breakpoints + bpt;
     uint64 bptAddr;
 
     BPT_CLEAR_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED);
@@ -133,13 +133,13 @@ void remove_breakpoint_by_address( uint32 address )
         remove_breakpoint_by_num( bpt );
 }
 
-void replace_breakpoint_num( int bpt, breakpoint* copyofnew )
+void replace_breakpoint_num( int bpt, m64p_breakpoint *copyofnew )
 {
     
     if(BPT_CHECK_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED))
         disable_breakpoint( bpt );
 
-    memcpy(&(g_Breakpoints[bpt]), copyofnew, sizeof(breakpoint));
+    memcpy(&g_Breakpoints[bpt], copyofnew, sizeof(m64p_breakpoint));
 
     if(BPT_CHECK_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED))
     {

--- a/src/debugger/dbg_breakpoints.h
+++ b/src/debugger/dbg_breakpoints.h
@@ -25,10 +25,10 @@
 #include "../api/m64p_types.h"
 
 extern int g_NumBreakpoints;
-extern breakpoint g_Breakpoints[];
+extern m64p_breakpoint g_Breakpoints[];
 
 int add_breakpoint( uint32 address );
-int add_breakpoint_struct(breakpoint* newbp);
+int add_breakpoint_struct(m64p_breakpoint *newbp);
 void remove_breakpoint_by_address( uint32 address );
 void remove_breakpoint_by_num( int bpt );
 void enable_breakpoint( int breakpoint );
@@ -37,7 +37,7 @@ int check_breakpoints( uint32 address );
 int check_breakpoints_on_mem_access( uint32 pc, uint32 address, uint32 size, uint32 flags );
 int lookup_breakpoint( uint32 address, uint32 size, uint32 flags );
 int log_breakpoint(uint32 PC, uint32 Flag, uint32 Access);
-void replace_breakpoint_num( int, breakpoint* );
+void replace_breakpoint_num( int, m64p_breakpoint * );
 
 #endif  /* __BREAKPOINTS_H__ */
 


### PR DESCRIPTION
The breakpoint struct name was inconsistent with the rest of the `m64p' prefixed
declarations.

The API DebugBreakpointCommand was also changed to specify a m64p_breakpoint
pointer instead of a void pointer. There are no uses for the pointer other than
for referencing a breakpoint.
