### PR TITLE
Wrap breakpoint flags into m64p_dbg_bkp_flags enum.

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus_v2.0_headers.txt
+++ b/doc/emuwiki-api-doc/Mupen64Plus_v2.0_headers.txt
@@ -268,13 +268,13 @@
  
  #define BREAKPOINTS_MAX_NUMBER  128
  
- #define BPT_FLAG_ENABLED        0x01
- #define BPT_FLAG_CONDITIONAL    0x02
- #define BPT_FLAG_COUNTER        0x04
- #define BPT_FLAG_READ           0x08
- #define BPT_FLAG_WRITE          0x10
- #define BPT_FLAG_EXEC           0x20
- #define BPT_FLAG_LOG            0x40 //Log to the console when this breakpoint hits.
+ typedef enum {
+   M64P_BKP_FLAG_ENABLED = 0x01,
+   M64P_BKP_FLAG_READ = 0x02,
+   M64P_BKP_FLAG_WRITE = 0x04,
+   M64P_BKP_FLAG_EXEC = 0x08,
+   M64P_BKP_FLAG_LOG = 0x10 /* Log to the console when this breakpoint hits. */
+ } m64p_dbg_bkp_flags;
  
  #define BPT_CHECK_FLAG(a, b)  ((a.flags & b) == b)
  #define BPT_SET_FLAG(a, b)    a.flags = (a.flags | b);

--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -290,13 +290,13 @@ typedef enum {
 
 #define BREAKPOINTS_MAX_NUMBER  128
 
-#define BPT_FLAG_ENABLED        0x01
-#define BPT_FLAG_CONDITIONAL    0x02
-#define BPT_FLAG_COUNTER        0x04
-#define BPT_FLAG_READ           0x08
-#define BPT_FLAG_WRITE          0x10
-#define BPT_FLAG_EXEC           0x20
-#define BPT_FLAG_LOG            0x40 /* Log to the console when this breakpoint hits */
+typedef enum {
+  M64P_BKP_FLAG_ENABLED = 0x01,
+  M64P_BKP_FLAG_READ = 0x02,
+  M64P_BKP_FLAG_WRITE = 0x04,
+  M64P_BKP_FLAG_EXEC = 0x08,
+  M64P_BKP_FLAG_LOG = 0x10 /* Log to the console when this breakpoint hits */
+} m64p_dbg_bkp_flags;
 
 #define BPT_CHECK_FLAG(a, b)  ((a.flags & b) == b)
 #define BPT_SET_FLAG(a, b)    a.flags = (a.flags | b);

--- a/src/debugger/dbg_breakpoints.c
+++ b/src/debugger/dbg_breakpoints.c
@@ -42,7 +42,7 @@ int add_breakpoint( uint32 address )
     }
     g_Breakpoints[g_NumBreakpoints].address=address;
     g_Breakpoints[g_NumBreakpoints].endaddr=address;
-    BPT_SET_FLAG(g_Breakpoints[g_NumBreakpoints], BPT_FLAG_EXEC);
+    BPT_SET_FLAG(g_Breakpoints[g_NumBreakpoints], M64P_BKP_FLAG_EXEC);
 
     enable_breakpoint(g_NumBreakpoints);
 
@@ -58,9 +58,8 @@ int add_breakpoint_struct(breakpoint* newbp)
 
     memcpy(&g_Breakpoints[g_NumBreakpoints], newbp, sizeof(breakpoint));
 
-    if(BPT_CHECK_FLAG(g_Breakpoints[g_NumBreakpoints], BPT_FLAG_ENABLED))
-    {
-        BPT_CLEAR_FLAG(g_Breakpoints[g_NumBreakpoints], BPT_FLAG_ENABLED);
+    if (BPT_CHECK_FLAG(g_Breakpoints[g_NumBreakpoints], M64P_BKP_FLAG_ENABLED)) {
+        BPT_CLEAR_FLAG(g_Breakpoints[g_NumBreakpoints], M64P_BKP_FLAG_ENABLED);
         enable_breakpoint( g_NumBreakpoints );
     }
     
@@ -72,19 +71,19 @@ void enable_breakpoint( int bpt)
     breakpoint *curBpt = g_Breakpoints + bpt;
     uint64 bptAddr;
     
-    if(BPT_CHECK_FLAG((*curBpt), BPT_FLAG_READ)) {
-        for(bptAddr = curBpt->address; bptAddr <= (curBpt->endaddr | 0xFFFF); bptAddr+=0x10000)
-            if(lookup_breakpoint((uint32) bptAddr & 0xFFFF0000, 0x10000, BPT_FLAG_ENABLED | BPT_FLAG_READ) == -1)
+    if (BPT_CHECK_FLAG((*curBpt), M64P_BKP_FLAG_READ)) {
+        for (bptAddr = curBpt->address; bptAddr <= (curBpt->endaddr | 0xFFFF); bptAddr+=0x10000)
+            if (lookup_breakpoint((uint32) bptAddr & 0xFFFF0000, 0x10000, M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) == -1)
                 activate_memory_break_read((uint32) bptAddr);
     }
 
-    if(BPT_CHECK_FLAG((*curBpt), BPT_FLAG_WRITE)) {
-        for(bptAddr = curBpt->address; bptAddr <= (curBpt->endaddr | 0xFFFF); bptAddr+=0x10000)
-            if(lookup_breakpoint((uint32) bptAddr & 0xFFFF0000, 0x10000, BPT_FLAG_ENABLED | BPT_FLAG_WRITE) == -1)
+    if (BPT_CHECK_FLAG((*curBpt), M64P_BKP_FLAG_WRITE)) {
+        for (bptAddr = curBpt->address; bptAddr <= (curBpt->endaddr | 0xFFFF); bptAddr+=0x10000)
+            if (lookup_breakpoint((uint32) bptAddr & 0xFFFF0000, 0x10000, M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) == -1)
                 activate_memory_break_write((uint32) bptAddr);
     }
     
-    BPT_SET_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED);
+    BPT_SET_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_ENABLED);
 }
 
 void disable_breakpoint( int bpt )
@@ -92,28 +91,28 @@ void disable_breakpoint( int bpt )
     breakpoint *curBpt = g_Breakpoints + bpt;
     uint64 bptAddr;
 
-    BPT_CLEAR_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED);
+    BPT_CLEAR_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_ENABLED);
 
-    if(BPT_CHECK_FLAG((*curBpt), BPT_FLAG_READ)) {
-        for(bptAddr = curBpt->address; bptAddr <= ((unsigned long)(curBpt->endaddr | 0xFFFF)); bptAddr+=0x10000)
-            if(lookup_breakpoint((uint32) bptAddr & 0xFFFF0000, 0x10000, BPT_FLAG_ENABLED | BPT_FLAG_READ) == -1)
+    if (BPT_CHECK_FLAG((*curBpt), M64P_BKP_FLAG_READ)) {
+        for (bptAddr = curBpt->address; bptAddr <= ((unsigned long)(curBpt->endaddr | 0xFFFF)); bptAddr+=0x10000)
+            if (lookup_breakpoint((uint32) bptAddr & 0xFFFF0000, 0x10000, M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) == -1)
                 deactivate_memory_break_read((uint32) bptAddr);
     }
 
-    if(BPT_CHECK_FLAG((*curBpt), BPT_FLAG_WRITE)) {
-        for(bptAddr = curBpt->address; bptAddr <= ((unsigned long)(curBpt->endaddr | 0xFFFF)); bptAddr+=0x10000)
-            if(lookup_breakpoint((uint32) bptAddr & 0xFFFF0000, 0x10000, BPT_FLAG_ENABLED | BPT_FLAG_WRITE) == -1)
+    if (BPT_CHECK_FLAG((*curBpt), M64P_BKP_FLAG_WRITE)) {
+        for (bptAddr = curBpt->address; bptAddr <= ((unsigned long)(curBpt->endaddr | 0xFFFF)); bptAddr+=0x10000)
+            if (lookup_breakpoint((uint32) bptAddr & 0xFFFF0000, 0x10000, M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) == -1)
                 deactivate_memory_break_write((uint32) bptAddr);
     }
 
-    BPT_CLEAR_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED);
+    BPT_CLEAR_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_ENABLED);
 }
 
 void remove_breakpoint_by_num( int bpt )
 {
     int curBpt;
     
-    if(BPT_CHECK_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED))
+    if (BPT_CHECK_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_ENABLED))
         disable_breakpoint( bpt );
 
     for(curBpt=bpt+1; curBpt<g_NumBreakpoints; curBpt++)
@@ -135,16 +134,14 @@ void remove_breakpoint_by_address( uint32 address )
 
 void replace_breakpoint_num( int bpt, breakpoint* copyofnew )
 {
-    
-    if(BPT_CHECK_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED))
-        disable_breakpoint( bpt );
+    if (BPT_CHECK_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_ENABLED))
+        disable_breakpoint(bpt);
 
     memcpy(&(g_Breakpoints[bpt]), copyofnew, sizeof(breakpoint));
 
-    if(BPT_CHECK_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED))
-    {
-        BPT_CLEAR_FLAG(g_Breakpoints[bpt], BPT_FLAG_ENABLED);
-        enable_breakpoint( bpt );
+    if (BPT_CHECK_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_ENABLED)) {
+        BPT_CLEAR_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_ENABLED);
+        enable_breakpoint(bpt);
     }
 }
 
@@ -176,7 +173,7 @@ int lookup_breakpoint( uint32 address, uint32 size, uint32 flags)
 
 int check_breakpoints( uint32 address )
 {
-    return lookup_breakpoint( address, 1, BPT_FLAG_ENABLED | BPT_FLAG_EXEC );
+    return lookup_breakpoint(address, 1, M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_EXEC);
 }
 
 
@@ -192,7 +189,7 @@ int check_breakpoints_on_mem_access( uint32 pc, uint32 address, uint32 size, uin
         bpt=lookup_breakpoint( address, size, flags );
         if(bpt != -1)
         {
-            if(BPT_CHECK_FLAG(g_Breakpoints[bpt], BPT_FLAG_LOG))
+            if (BPT_CHECK_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_LOG))
                 log_breakpoint(pc, flags, address);
             
             run = 0;
@@ -207,10 +204,12 @@ int check_breakpoints_on_mem_access( uint32 pc, uint32 address, uint32 size, uin
 int log_breakpoint(uint32 PC, uint32 Flag, uint32 Access)
 {
     char msg[32];
-    
-    if(Flag & BPT_FLAG_READ) sprintf(msg, "0x%08X read 0x%08X", PC, Access);
-    else if(Flag & BPT_FLAG_WRITE) sprintf(msg, "0x%08X wrote 0x%08X", PC, Access);
-    else sprintf(msg, "0x%08X executed", PC);
+    if (Flag & M64P_BKP_FLAG_READ)
+        sprintf(msg, "0x%08X read 0x%08X", PC, Access);
+    else if (Flag & M64P_BKP_FLAG_WRITE)
+        sprintf(msg, "0x%08X wrote 0x%08X", PC, Access);
+    else
+        sprintf(msg, "0x%08X executed", PC);
     DebugMessage(M64MSG_INFO, "BPT: %s", msg);
     return 0;
 }

--- a/src/debugger/dbg_memory.h
+++ b/src/debugger/dbg_memory.h
@@ -31,13 +31,13 @@
 
 #define MEMBREAKREAD(name,size) \
     void name##_break(void) { \
-        check_breakpoints_on_mem_access((PC->addr)-0x4, address, size, BPT_FLAG_ENABLED | BPT_FLAG_READ); \
+        check_breakpoints_on_mem_access((PC->addr)-0x4, address, size, M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ); \
         name (); \
     }
 
 #define MEMBREAKWRITE(name,size) \
     void name##_break(void) { \
-        check_breakpoints_on_mem_access((PC->addr)-0x4, address, size, BPT_FLAG_ENABLED | BPT_FLAG_WRITE); \
+        check_breakpoints_on_mem_access((PC->addr)-0x4, address, size, M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE); \
         name (); \
     }
 

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -74,9 +74,9 @@ void update_debugger(uint32 pc)
         bpt = check_breakpoints(pc);
         if( bpt!=-1 ) {
             run = 0;
-            
-            if(BPT_CHECK_FLAG(g_Breakpoints[bpt], BPT_FLAG_LOG))
-                log_breakpoint(pc, BPT_FLAG_EXEC, 0);
+
+            if (BPT_CHECK_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_LOG))
+                log_breakpoint(pc, M64P_BKP_FLAG_EXEC, 0);
         }
     }
 

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -1191,7 +1191,7 @@ static void do_SP_Task(void)
                     {
 #ifdef DBG
                         if (lookup_breakpoint(0x80000000 + j * 0x10000, 0x10000,
-                                              BPT_FLAG_ENABLED |  BPT_FLAG_READ ) != -1)
+                                              M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) != -1)
                         {
                             readmem[0x8000+j] = read_rdram_break;
                             readmemb[0x8000+j] = read_rdramb_break;
@@ -1208,7 +1208,7 @@ static void do_SP_Task(void)
 #ifdef DBG
                         }
                         if (lookup_breakpoint(0xa0000000 + j * 0x10000, 0x10000,
-                                              BPT_FLAG_ENABLED |  BPT_FLAG_READ ) != -1)
+                                              M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) != -1)
                         {
                             readmem[0xa000+j] = read_rdram_break;
                             readmemb[0xa000+j] = read_rdramb_break;
@@ -1225,7 +1225,7 @@ static void do_SP_Task(void)
 #ifdef DBG
                         }
                         if (lookup_breakpoint(0x80000000 + j * 0x10000, 0x10000,
-                                              BPT_FLAG_ENABLED |  BPT_FLAG_WRITE ) != -1)
+                                              M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) != -1)
                         {
                             writemem[0x8000+j] = write_rdram_break;
                             writememb[0x8000+j] = write_rdramb_break;
@@ -1242,7 +1242,7 @@ static void do_SP_Task(void)
 #ifdef DBG
                         }
                         if (lookup_breakpoint(0xa0000000 + j * 0x10000, 0x10000,
-                                              BPT_FLAG_ENABLED |  BPT_FLAG_WRITE ) != -1)
+                                              M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) != -1)
                         {
                             writemem[0xa000+j] = write_rdram_break;
                             writememb[0xa000+j] = write_rdramb_break;
@@ -1304,7 +1304,7 @@ static void do_SP_Task(void)
                     {
 #ifdef DBG
                         if (lookup_breakpoint(0x80000000 + j * 0x10000, 0x10000,
-                                              BPT_FLAG_ENABLED |  BPT_FLAG_READ ) != -1)
+                                              M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) != -1)
                         {
                             readmem[0x8000+j] = read_rdramFB_break;
                             readmemb[0x8000+j] = read_rdramFBb_break;
@@ -1321,7 +1321,7 @@ static void do_SP_Task(void)
 #ifdef DBG
                         }
                         if (lookup_breakpoint(0xa0000000 + j * 0x10000, 0x10000,
-                                              BPT_FLAG_ENABLED |  BPT_FLAG_READ ) != -1)
+                                              M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) != -1)
                         {
                             readmem[0xa000+j] = read_rdramFB_break;
                             readmemb[0xa000+j] = read_rdramFBb_break;
@@ -1338,7 +1338,7 @@ static void do_SP_Task(void)
 #ifdef DBG
                         }
                         if (lookup_breakpoint(0x80000000 + j * 0x10000, 0x10000,
-                                              BPT_FLAG_ENABLED |  BPT_FLAG_WRITE ) != -1)
+                                              M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) != -1)
                         {
                             writemem[0x8000+j] = write_rdramFB_break;
                             writememb[0x8000+j] = write_rdramFBb_break;
@@ -1355,7 +1355,7 @@ static void do_SP_Task(void)
 #ifdef DBG
                         }
                         if (lookup_breakpoint(0xa0000000 + j * 0x10000, 0x10000,
-                                              BPT_FLAG_ENABLED |  BPT_FLAG_WRITE ) != -1)
+                                              M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) != -1)
                         {
                             writemem[0xa000+j] = write_rdramFB_break;
                             writememb[0xa000+j] = write_rdramFBb_break;


### PR DESCRIPTION
The unused conditional and counter flags have been removed to avoid any
confusion until those features are added.

An `M64P' prefix is also added to the flags. This matches the style of other
API flags.

If the other pull request #29 is merged, there might be some merging issues. I could update this request if that one is pulled.
