### PR TITLE
Add a m64p_dbg_runstate enum for DebugSetRunState.

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus_v2.0_Core_Debugger.txt
+++ b/doc/emuwiki-api-doc/Mupen64Plus_v2.0_Core_Debugger.txt
@@ -38,10 +38,10 @@ Most libmupen64plus functions return an <tt>m64p_error</tt> return code, which i
 <br />
 {| border="1"
 |Prototype
-|'''<tt>m64p_error DebugSetRunState(int runstate)</tt>'''
+|'''<tt>m64p_error DebugSetRunState(m64p_dbg_runstate runstate)</tt>'''
 |-
 |Input Parameters
-|'''<tt>runstate</tt>''' 0 == pause, 1 == single instruction step, 2 == run
+|'''<tt>runstate</tt>''' An <tt>m64p_dbg_runstate</tt> enumerated type specifying the debugging state of the emulator. <tt>M64P_DBG_RUNSTATE_RUNNING</tt> continues execution until a breakpoint is hit or a different state is chosen. <tt>M64P_DBG_RUNSTATE_STEPPING</tt> enters a single step running mode that sends callbacks as each step is performed. <tt>M64P_DBG_RUNSTATE_PAUSED</tt> pauses execution to allow manual stepping.
 |-
 |Requirements
 |The Mupen64Plus library must be built with debugger support and must be initialized before calling this function.

--- a/doc/emuwiki-api-doc/Mupen64Plus_v2.0_headers.txt
+++ b/doc/emuwiki-api-doc/Mupen64Plus_v2.0_headers.txt
@@ -194,6 +194,12 @@
  } m64p_dbg_state;
  
  typedef enum {
+   M64P_DBG_RUNSTATE_PAUSED = 0,
+   M64P_DBG_RUNSTATE_STEPPING,
+   M64P_DBG_RUNSTATE_RUNNING
+ } m64p_dbg_runstate;
+ 
+ typedef enum {
    M64P_DBG_MEM_TYPE = 1,
    M64P_DBG_MEM_FLAGS,
    M64P_DBG_MEM_HAS_RECOMPILED,

--- a/src/api/debugger.c
+++ b/src/api/debugger.c
@@ -106,10 +106,10 @@ EXPORT m64p_error CALL DebugSetCallbacks(void (*dbg_frontend_init)(void), void (
 #endif
 }
 
-EXPORT m64p_error CALL DebugSetRunState(int runstate)
+EXPORT m64p_error CALL DebugSetRunState(m64p_dbg_runstate runstate)
 {
 #ifdef DBG
-    run = runstate; /* in debugger/debugger.c */
+    g_dbg_runstate = runstate; /* in debugger/debugger.c */
     return M64ERR_SUCCESS;
 #else
     return M64ERR_UNSUPPORTED;
@@ -122,7 +122,7 @@ EXPORT int CALL DebugGetState(m64p_dbg_state statenum)
     switch (statenum)
     {
         case M64P_DBG_RUN_STATE:
-            return run;
+            return g_dbg_runstate;
         case M64P_DBG_PREVIOUS_PC:
             return previousPC;
         case M64P_DBG_NUM_BREAKPOINTS:

--- a/src/api/m64p_debugger.h
+++ b/src/api/m64p_debugger.h
@@ -58,9 +58,9 @@ EXPORT m64p_error CALL DebugSetCoreCompare(void (*)(unsigned int), void (*)(int,
  *
  * This function sets the run state of the R4300 CPU emulator.
  */
-typedef m64p_error (*ptr_DebugSetRunState)(int);
+typedef m64p_error (*ptr_DebugSetRunState)(m64p_dbg_runstate);
 #if defined(M64P_CORE_PROTOTYPES)
-EXPORT m64p_error CALL DebugSetRunState(int);
+EXPORT m64p_error CALL DebugSetRunState(m64p_dbg_runstate);
 #endif
 
 /* DebugGetState()

--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -216,6 +216,12 @@ typedef enum {
 } m64p_dbg_state;
 
 typedef enum {
+  M64P_DBG_RUNSTATE_PAUSED = 0,
+  M64P_DBG_RUNSTATE_STEPPING,
+  M64P_DBG_RUNSTATE_RUNNING
+} m64p_dbg_runstate;
+
+typedef enum {
   M64P_DBG_MEM_TYPE = 1,
   M64P_DBG_MEM_FLAGS,
   M64P_DBG_MEM_HAS_RECOMPILED,

--- a/src/debugger/dbg_breakpoints.c
+++ b/src/debugger/dbg_breakpoints.c
@@ -184,17 +184,15 @@ int check_breakpoints_on_mem_access( uint32 pc, uint32 address, uint32 size, uin
     //It automatically stops and updates the debugger on hit, so the memory access
     //functions only need to call it and can discard the result.
     int bpt;
-    if(run == 2)
-    {
-        bpt=lookup_breakpoint( address, size, flags );
-        if(bpt != -1)
-        {
+    if (g_dbg_runstate == M64P_DBG_RUNSTATE_RUNNING) {
+        bpt = lookup_breakpoint(address, size, flags);
+        if (bpt != -1) {
             if (BPT_CHECK_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_LOG))
                 log_breakpoint(pc, flags, address);
-            
-            run = 0;
+
+            g_dbg_runstate = M64P_DBG_RUNSTATE_PAUSED;
             update_debugger(pc);
-        
+
             return bpt;
         }
     }

--- a/src/debugger/debugger.h
+++ b/src/debugger/debugger.h
@@ -23,11 +23,11 @@
 #ifndef __DEBUGGER_H__
 #define __DEBUGGER_H__
 
+#include "api/m64p_types.h"
+
 extern int g_DebuggerActive;  /* True if the debugger is running */
 
-/* State of the Emulation Thread:
-   0 -> pause, 1 -> step, 2 -> run. */
-extern int run;
+extern m64p_dbg_runstate g_dbg_runstate;
 
 extern uint32 previousPC;
 


### PR DESCRIPTION
This should help API users properly pass run state values, and improves readability of the run state code.