### PR TITLE
Fix initialization of l_ExternalVideoFuncTable.

### DIFF
--- a/src/api/vidext.c
+++ b/src/api/vidext.c
@@ -39,7 +39,7 @@
 #endif
 
 /* local variables */
-static m64p_video_extension_functions l_ExternalVideoFuncTable = {10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
+static m64p_video_extension_functions l_ExternalVideoFuncTable = {11, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 static int l_VideoExtensionActive = 0;
 static int l_VideoOutputActive = 0;
 static int l_Fullscreen = 0;


### PR DESCRIPTION
The m64p_extension_functions structure has been modified with commit a557d21
without updating the initialization value.
