### PR TITLE
new_dynarec: Fixed BGTZ/BLEZ

### DIFF
--- a/src/r4300/new_dynarec/assem_arm.c
+++ b/src/r4300/new_dynarec/assem_arm.c
@@ -1748,6 +1748,18 @@ static void emit_jcc(int a)
   u_int offset=genjmp(a);
   output_w32(0x3a000000|offset);
 }
+static void emit_jae(int a)
+{
+  assem_debug("bcs %x",a);
+  u_int offset=genjmp(a);
+  output_w32(0x2a000000|offset);
+}
+static void emit_jb(int a)
+{
+  assem_debug("bcc %x",a);
+  u_int offset=genjmp(a);
+  output_w32(0x3a000000|offset);
+}
 
 static void emit_pushreg(u_int r)
 {

--- a/src/r4300/new_dynarec/assem_x86.c
+++ b/src/r4300/new_dynarec/assem_x86.c
@@ -1671,6 +1671,20 @@ static void emit_jc(int a)
   output_byte(0x82);
   output_w32(a-(int)out-4);
 }
+static void emit_jae(int a)
+{
+  assem_debug("jae %x",a);
+  output_byte(0x0f);
+  output_byte(0x83);
+  output_w32(a-(int)out-4);
+}
+static void emit_jb(int a)
+{
+  assem_debug("jb %x",a);
+  output_byte(0x0f);
+  output_byte(0x82);
+  output_w32(a-(int)out-4);
+}
 
 static void emit_pushimm(int imm)
 {

--- a/src/r4300/new_dynarec/new_dynarec.c
+++ b/src/r4300/new_dynarec/new_dynarec.c
@@ -5356,10 +5356,12 @@ static void cjump_assemble(int i,struct regstat *i_regs)
         emit_cmpimm(s1l,1);
         if(invert){
           nottaken=(int)out;
-          emit_jge(1);
+          if(only32) emit_jge(1);
+          else emit_jae(1);
         }else{
           add_to_linker((int)out,ba[i],internal);
-          emit_jl(0);
+          if(only32) emit_jl(0);
+          else emit_jb(0); 
         }
       }
       if(opcode[i]==7) // BGTZ
@@ -5367,10 +5369,12 @@ static void cjump_assemble(int i,struct regstat *i_regs)
         emit_cmpimm(s1l,1);
         if(invert){
           nottaken=(int)out;
-          emit_jl(1);
+          if(only32) emit_jl(1);
+          else emit_jb(1);
         }else{
           add_to_linker((int)out,ba[i],internal);
-          emit_jge(0);
+          if(only32) emit_jge(0);
+          else emit_jae(0);
         }
       }
       if(invert) {
@@ -5475,13 +5479,15 @@ static void cjump_assemble(int i,struct regstat *i_regs)
       {
         emit_cmpimm(s1l,1);
         nottaken=(int)out;
-        emit_jge(2);
+        if(only32) emit_jge(2);
+        else emit_jae(2);
       }
       if((opcode[i]&0x2f)==7) // BGTZ
       {
         emit_cmpimm(s1l,1);
         nottaken=(int)out;
-        emit_jl(2);
+        if(only32) emit_jl(2);
+        else emit_jb(2);
       }
     } // if(!unconditional)
     int adj;


### PR DESCRIPTION
When testing 64bit mips registers, the low 32bit part should be tested
in unsigned mode.
