### PR TITLE
[NEW DYNAREC ARM] Use ARM mode explicitly - some systems use -mthumb by ...

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -95,6 +95,7 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
     ARCH_DETECTED := 32BITS
     PIC ?= 1
     NEW_DYNAREC := 1
+    CFLAGS += -marm
     ifeq ($(NEON), 1)
         CFLAGS += -mfpu=neon -mfloat-abi=hard -DNEON
     else


### PR DESCRIPTION
...default

Some gnu/linux arm systems (e.g. debian armhf) use --with-mode=thumb instead with --with-mode=arm (gcc runtime -mthumb/-marm options), breaking the new arm dynarec.
This fixes compilation on these systems.

See https://github.com/Gillou68310/mupen64plus-ae/issues/3
