### PR TITLE
Fix load_regs_bt.

### DIFF
--- a/src/r4300/new_dynarec/new_dynarec.c
+++ b/src/r4300/new_dynarec/new_dynarec.c
@@ -4474,8 +4474,13 @@ static void load_regs_bt(signed char i_regmap[],uint64_t i_is32,uint64_t i_dirty
         }
         else if((i_is32>>(regs[t].regmap_entry[hr]&63))&1) {
           int lr=get_reg(regs[t].regmap_entry,regs[t].regmap_entry[hr]-64);
-          assert(lr>=0);
-          emit_sarimm(lr,31,hr);
+          if(lr<0) {
+            emit_loadreg(regs[t].regmap_entry[hr],hr);
+          }
+          else
+          {
+            emit_sarimm(lr,31,hr);
+          }
         }
       }
     }


### PR DESCRIPTION
Super Mario 64 intro was triggering the assert.
I just replicated the behavior found in load_regs_entry.

@Gillou68310 : can you confirm that it this fix makes sense ?
It does work for me, but it is mostly guess work.