### PR TITLE
Allow building the core with the new dynarec on windows

### DIFF
--- a/projects/msvc10/mupen64plus-core.vcxproj
+++ b/projects/msvc10/mupen64plus-core.vcxproj
@@ -1,0 +1,359 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="New_Dynarec_Debug|Win32">
+      <Configuration>New_Dynarec_Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="New_Dynarec_Release|Win32">
+      <Configuration>New_Dynarec_Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{92D3FEB9-2129-41C5-8577-BCD7D961EF41}</ProjectGuid>
+    <RootNamespace>mupen64pluscore</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v100</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v100</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v100</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v100</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(SolutionDir)Debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">Debug\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(SolutionDir)Release\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">Release\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">false</LinkIncremental>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'" />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <TargetName>mupen64plus</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">
+    <TargetName>mupen64plus</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <TargetName>mupen64plus</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">
+    <TargetName>mupen64plus</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\include;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\lib\SDL.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\lib\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\lib\libpng.lib;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\lib\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)mupen64plus.dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\include;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;NEW_DYNAREC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\lib\SDL.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\lib\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\lib\libpng.lib;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\lib\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)mupen64plus.dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\include;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\lib\SDL.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\lib\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\lib\libpng.lib;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\lib\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)mupen64plus.dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\include;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;NEW_DYNAREC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+      <DisableSpecificWarnings>4244</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\lib\SDL.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\lib\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\lib\libpng.lib;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\lib\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)mupen64plus.dll</OutputFile>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\r4300\new_dynarec\new_dynarec.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\assemble.c" />
+    <ClCompile Include="..\..\src\r4300\cached_interp.c" />
+    <ClCompile Include="..\..\src\api\callbacks.c" />
+    <ClCompile Include="..\..\src\main\cheat.c" />
+    <ClCompile Include="..\..\src\api\common.c" />
+    <ClCompile Include="..\..\src\api\config.c" />
+    <ClCompile Include="..\..\src\r4300\cp0.c" />
+    <ClCompile Include="..\..\src\r4300\cp1.c" />
+    <ClCompile Include="..\..\src\debugger\dbg_breakpoints.c" />
+    <ClCompile Include="..\..\src\debugger\dbg_decoder.c" />
+    <ClCompile Include="..\..\src\debugger\dbg_memory.c" />
+    <ClCompile Include="..\..\src\debugger\debugger.c">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
+      <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
+      <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
+      <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
+      <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\debugger.c" />
+    <ClCompile Include="..\..\src\memory\dma.c" />
+    <ClCompile Include="..\..\src\plugin\dummy_audio.c" />
+    <ClCompile Include="..\..\src\plugin\dummy_input.c" />
+    <ClCompile Include="..\..\src\plugin\dummy_rsp.c" />
+    <ClCompile Include="..\..\src\plugin\dummy_video.c" />
+    <ClCompile Include="..\..\src\osal\dynamiclib_win32.c" />
+    <ClCompile Include="..\..\src\main\eventloop.c" />
+    <ClCompile Include="..\..\src\r4300\exception.c" />
+    <ClCompile Include="..\..\src\osal\files_win32.c" />
+    <ClCompile Include="..\..\src\memory\flashram.c" />
+    <ClCompile Include="..\..\src\api\frontend.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gbc.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gcop0.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gcop1.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_d.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_l.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_s.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_w.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gr4300.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gregimm.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gspecial.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gtlb.c" />
+    <ClCompile Include="..\..\src\r4300\instr_counters.c" />
+    <ClCompile Include="..\..\src\r4300\interupt.c" />
+    <ClCompile Include="..\..\src\main\zip\ioapi.c" />
+    <ClCompile Include="..\..\src\main\lirc.c" />
+    <ClCompile Include="..\..\src\main\main.c" />
+    <ClCompile Include="..\..\src\main\md5.c" />
+    <ClCompile Include="..\..\src\memory\memory.c" />
+    <ClCompile Include="..\..\src\memory\n64_cic_nus_6105.c" />
+    <ClCompile Include="..\..\src\osd\OGLFT.cpp" />
+    <ClCompile Include="..\..\src\osd\osd.cpp" />
+    <ClCompile Include="..\..\src\memory\pif.c" />
+    <ClCompile Include="..\..\src\plugin\plugin.c" />
+    <ClCompile Include="..\..\src\main\profile.c" />
+    <ClCompile Include="..\..\src\r4300\pure_interp.c" />
+    <ClCompile Include="..\..\src\r4300\r4300.c" />
+    <ClCompile Include="..\..\src\r4300\recomp.c" />
+    <ClCompile Include="..\..\src\r4300\x86\regcache.c" />
+    <ClCompile Include="..\..\src\r4300\reset.c" />
+    <ClCompile Include="..\..\src\r4300\x86\rjump.c" />
+    <ClCompile Include="..\..\src\main\rom.c" />
+    <ClCompile Include="..\..\src\main\savestates.c" />
+    <ClCompile Include="..\..\src\main\sdl_key_converter.c" />
+    <ClCompile Include="..\..\src\osd\screenshot.cpp" />
+    <ClCompile Include="..\..\src\r4300\tlb.c" />
+    <ClCompile Include="..\..\src\main\zip\unzip.c" />
+    <ClCompile Include="..\..\src\main\util.c" />
+    <ClCompile Include="..\..\src\api\vidext.c" />
+    <ClCompile Include="..\..\src\main\workqueue.c" />
+    <ClCompile Include="..\..\src\main\zip\zip.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\r4300\x86\assemble.h" />
+    <ClInclude Include="..\..\src\r4300\cached_interp.h" />
+    <ClInclude Include="..\..\src\api\callbacks.h" />
+    <ClInclude Include="..\..\src\main\cheat.h" />
+    <ClInclude Include="..\..\src\api\config.h" />
+    <ClInclude Include="..\..\src\r4300\cp0.h" />
+    <ClInclude Include="..\..\src\r4300\cp1.h" />
+    <ClInclude Include="..\..\src\main\zip\crypt.h" />
+    <ClInclude Include="..\..\src\debugger\dbg_breakpoints.h" />
+    <ClInclude Include="..\..\src\debugger\dbg_decoder.h" />
+    <ClInclude Include="..\..\src\debugger\dbg_memory.h" />
+    <ClInclude Include="..\..\src\debugger\dbg_opprintf.h" />
+    <ClInclude Include="..\..\src\debugger\dbg_types.h" />
+    <ClInclude Include="..\..\src\debugger\debugger.h" />
+    <ClInclude Include="..\..\src\api\debugger.h" />
+    <ClInclude Include="..\..\src\memory\dma.h" />
+    <ClInclude Include="..\..\src\plugin\dummy_audio.h" />
+    <ClInclude Include="..\..\src\plugin\dummy_input.h" />
+    <ClInclude Include="..\..\src\plugin\dummy_rsp.h" />
+    <ClInclude Include="..\..\src\plugin\dummy_video.h" />
+    <ClInclude Include="..\..\src\osal\dynamiclib.h" />
+    <ClInclude Include="..\..\src\main\eventloop.h" />
+    <ClInclude Include="..\..\src\r4300\exception.h" />
+    <ClInclude Include="..\..\src\osal\files.h" />
+    <ClInclude Include="..\..\src\memory\flashram.h" />
+    <ClInclude Include="..\..\src\r4300\instr_counters.h" />
+    <ClInclude Include="..\..\src\r4300\x86\interpret.h" />
+    <ClInclude Include="..\..\src\r4300\interupt.h" />
+    <ClInclude Include="..\..\src\main\zip\ioapi.h" />
+    <ClInclude Include="..\..\src\main\lirc.h" />
+    <ClInclude Include="..\..\src\api\m64p_common.h" />
+    <ClInclude Include="..\..\src\api\m64p_config.h" />
+    <ClInclude Include="..\..\src\api\m64p_debugger.h" />
+    <ClInclude Include="..\..\src\api\m64p_frontend.h" />
+    <ClInclude Include="..\..\src\api\m64p_plugin.h" />
+    <ClInclude Include="..\..\src\api\m64p_types.h" />
+    <ClInclude Include="..\..\src\api\m64p_vidext.h" />
+    <ClInclude Include="..\..\src\r4300\macros.h" />
+    <ClInclude Include="..\..\src\main\main.h" />
+    <ClInclude Include="..\..\src\main\md5.h" />
+    <ClInclude Include="..\..\src\memory\memory.h" />
+    <ClInclude Include="..\..\src\memory\n64_cic_nus_6105.h" />
+    <ClInclude Include="..\..\src\osd\OGLFT.h" />
+    <ClInclude Include="..\..\src\r4300\ops.h" />
+    <ClInclude Include="..\..\src\osd\osd.h" />
+    <ClInclude Include="..\..\src\memory\pif.h" />
+    <ClInclude Include="..\..\src\plugin\plugin.h" />
+    <ClInclude Include="..\..\src\osal\preproc.h" />
+    <ClInclude Include="..\..\src\main\profile.h" />
+    <ClInclude Include="..\..\src\r4300\pure_interp.h" />
+    <ClInclude Include="..\..\src\r4300\r4300.h" />
+    <ClInclude Include="..\..\src\r4300\recomp.h" />
+    <ClInclude Include="..\..\src\r4300\recomph.h" />
+    <ClInclude Include="..\..\src\r4300\x86\regcache.h" />
+    <ClInclude Include="..\..\src\r4300\reset.h" />
+    <ClInclude Include="..\..\src\main\rom.h" />
+    <ClInclude Include="..\..\src\main\savestates.h" />
+    <ClInclude Include="..\..\src\main\sdl_key_converter.h" />
+    <ClInclude Include="..\..\src\osd\screenshot.h" />
+    <ClInclude Include="..\..\src\r4300\tlb.h" />
+    <ClInclude Include="..\..\src\main\zip\unzip.h" />
+    <ClInclude Include="..\..\src\main\util.h" />
+    <ClInclude Include="..\..\src\main\version.h" />
+    <ClInclude Include="..\..\src\api\vidext.h" />
+    <ClInclude Include="..\..\src\main\workqueue.h" />
+    <ClInclude Include="..\..\src\main\zip\zip.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\src\r4300\new_dynarec\linkage_x86.asm">
+      <FileType>Document</FileType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath) -dWIN32</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(IntDir)linkage_x86.obj</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath) -dWIN32</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath) -dWIN32</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath) -dWIN32</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)linkage_x86.obj</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)linkage_x86.obj</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)linkage_x86.obj</Outputs>
+    </CustomBuild>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/msvc10/mupen64plus-core.vcxproj
+++ b/projects/msvc10/mupen64plus-core.vcxproj
@@ -190,33 +190,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\r4300\empty_dynarec.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\new_dynarec\assem_x86.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\new_dynarec\new_dynarec.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">CompileAsCpp</CompileAs>
-      <CompileAs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">CompileAsCpp</CompileAs>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\x86\assemble.c">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\cached_interp.c" />
+    <ClCompile Include="..\..\src\ai\ai_controller.c" />
     <ClCompile Include="..\..\src\api\callbacks.c" />
-    <ClCompile Include="..\..\src\main\cheat.c" />
     <ClCompile Include="..\..\src\api\common.c" />
     <ClCompile Include="..\..\src\api\config.c" />
-    <ClCompile Include="..\..\src\r4300\cp0.c" />
-    <ClCompile Include="..\..\src\r4300\cp1.c" />
+    <ClCompile Include="..\..\src\api\debugger.c" />
+    <ClCompile Include="..\..\src\api\frontend.c" />
+    <ClCompile Include="..\..\src\api\vidext.c" />
     <ClCompile Include="..\..\src\debugger\dbg_breakpoints.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -236,31 +216,92 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\debugger\debugger.c">
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
-      <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
-      <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
-      <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
-      <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\api\debugger.c" />
-    <ClCompile Include="..\..\src\memory\dma.c" />
+    <ClCompile Include="..\..\src\main\cheat.c" />
+    <ClCompile Include="..\..\src\main\eep_file.c" />
+    <ClCompile Include="..\..\src\main\eventloop.c" />
+    <ClCompile Include="..\..\src\main\fla_file.c" />
+    <ClCompile Include="..\..\src\main\lirc.c" />
+    <ClCompile Include="..\..\src\main\main.c" />
+    <ClCompile Include="..\..\src\main\md5.c" />
+    <ClCompile Include="..\..\src\main\mpk_file.c" />
+    <ClCompile Include="..\..\src\main\profile.c" />
+    <ClCompile Include="..\..\src\main\rom.c" />
+    <ClCompile Include="..\..\src\main\savestates.c" />
+    <ClCompile Include="..\..\src\main\sdl_key_converter.c" />
+    <ClCompile Include="..\..\src\main\sra_file.c" />
+    <ClCompile Include="..\..\src\main\util.c" />
+    <ClCompile Include="..\..\src\main\workqueue.c" />
+    <ClCompile Include="..\..\src\memory\memory.c" />
+    <ClCompile Include="..\..\src\osal\dynamiclib_unix.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osal\files_unix.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\pi\cart_rom.c" />
+    <ClCompile Include="..\..\src\pi\flashram.c" />
+    <ClCompile Include="..\..\src\pi\pi_controller.c" />
+    <ClCompile Include="..\..\src\pi\sram.c" />
     <ClCompile Include="..\..\src\plugin\dummy_audio.c" />
     <ClCompile Include="..\..\src\plugin\dummy_input.c" />
     <ClCompile Include="..\..\src\plugin\dummy_rsp.c" />
     <ClCompile Include="..\..\src\plugin\dummy_video.c" />
-    <ClCompile Include="..\..\src\osal\dynamiclib_win32.c" />
-    <ClCompile Include="..\..\src\main\eventloop.c" />
+    <ClCompile Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.c" />
+    <ClCompile Include="..\..\src\plugin\get_time_using_C_localtime.c" />
+    <ClCompile Include="..\..\src\plugin\plugin.c" />
+    <ClCompile Include="..\..\src\plugin\rumble_via_input_plugin.c" />
+    <ClCompile Include="..\..\src\r4300\cached_interp.c" />
+    <ClCompile Include="..\..\src\r4300\cp0.c" />
+    <ClCompile Include="..\..\src\r4300\cp1.c" />
+    <ClCompile Include="..\..\src\r4300\empty_dynarec.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\r4300\exception.c" />
+    <ClCompile Include="..\..\src\r4300\instr_counters.c" />
+    <ClCompile Include="..\..\src\r4300\interupt.c" />
+    <ClCompile Include="..\..\src\r4300\mi_controller.c" />
+    <ClCompile Include="..\..\src\r4300\new_dynarec\assem_arm.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\new_dynarec\assem_x86.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\new_dynarec\new_dynarec.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\pure_interp.c" />
+    <ClCompile Include="..\..\src\r4300\r4300.c" />
+    <ClCompile Include="..\..\src\r4300\r4300_core.c" />
+    <ClCompile Include="..\..\src\r4300\recomp.c" />
+    <ClCompile Include="..\..\src\r4300\reset.c" />
+    <ClCompile Include="..\..\src\r4300\tlb.c" />
+    <ClCompile Include="..\..\src\r4300\x86\assemble.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osal\dynamiclib_win32.c" />
     <ClCompile Include="..\..\src\osal\files_win32.c" />
-    <ClCompile Include="..\..\src\memory\flashram.c" />
-    <ClCompile Include="..\..\src\api\frontend.c" />
     <ClCompile Include="..\..\src\r4300\x86\gbc.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
@@ -305,40 +346,19 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\r4300\instr_counters.c" />
-    <ClCompile Include="..\..\src\r4300\interupt.c" />
     <ClCompile Include="..\..\src\main\zip\ioapi.c" />
-    <ClCompile Include="..\..\src\main\lirc.c" />
-    <ClCompile Include="..\..\src\main\main.c" />
-    <ClCompile Include="..\..\src\main\md5.c" />
-    <ClCompile Include="..\..\src\memory\memory.c" />
-    <ClCompile Include="..\..\src\memory\n64_cic_nus_6105.c" />
     <ClCompile Include="..\..\src\osd\OGLFT.cpp" />
     <ClCompile Include="..\..\src\osd\osd.cpp" />
-    <ClCompile Include="..\..\src\memory\pif.c" />
-    <ClCompile Include="..\..\src\plugin\plugin.c" />
-    <ClCompile Include="..\..\src\main\profile.c" />
-    <ClCompile Include="..\..\src\r4300\pure_interp.c" />
-    <ClCompile Include="..\..\src\r4300\r4300.c" />
-    <ClCompile Include="..\..\src\r4300\recomp.c" />
     <ClCompile Include="..\..\src\r4300\x86\regcache.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\r4300\reset.c" />
     <ClCompile Include="..\..\src\r4300\x86\rjump.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\src\main\rom.c" />
-    <ClCompile Include="..\..\src\main\savestates.c" />
-    <ClCompile Include="..\..\src\main\sdl_key_converter.c" />
     <ClCompile Include="..\..\src\osd\screenshot.cpp" />
-    <ClCompile Include="..\..\src\r4300\tlb.c" />
     <ClCompile Include="..\..\src\main\zip\unzip.c" />
-    <ClCompile Include="..\..\src\main\util.c" />
-    <ClCompile Include="..\..\src\api\vidext.c" />
-    <ClCompile Include="..\..\src\main\workqueue.c" />
     <ClCompile Include="..\..\src\main\zip\zip.c" />
     <ClCompile Include="..\..\src\r4300\x86_64\assemble.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -424,84 +444,142 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\rdp\fb.c" />
+    <ClCompile Include="..\..\src\rdp\rdp_core.c" />
+    <ClCompile Include="..\..\src\ri\rdram.c" />
+    <ClCompile Include="..\..\src\ri\ri_controller.c" />
+    <ClCompile Include="..\..\src\rsp\rsp_core.c" />
+    <ClCompile Include="..\..\src\si\af_rtc.c" />
+    <ClCompile Include="..\..\src\si\cic.c" />
+    <ClCompile Include="..\..\src\si\eeprom.c" />
+    <ClCompile Include="..\..\src\si\game_controller.c" />
+    <ClCompile Include="..\..\src\si\mempak.c" />
+    <ClCompile Include="..\..\src\si\n64_cic_nus_6105.c" />
+    <ClCompile Include="..\..\src\si\pif.c" />
+    <ClCompile Include="..\..\src\si\rumblepak.c" />
+    <ClCompile Include="..\..\src\si\si_controller.c" />
+    <ClCompile Include="..\..\src\vi\vi_controller.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src\ai\ai_controller.h" />
+    <ClInclude Include="..\..\src\api\callbacks.h" />
+    <ClInclude Include="..\..\src\api\config.h" />
+    <ClInclude Include="..\..\src\api\debugger.h" />
+    <ClInclude Include="..\..\src\api\m64p_common.h" />
+    <ClInclude Include="..\..\src\api\m64p_config.h" />
+    <ClInclude Include="..\..\src\api\m64p_debugger.h" />
+    <ClInclude Include="..\..\src\api\m64p_frontend.h" />
+    <ClInclude Include="..\..\src\api\m64p_plugin.h" />
+    <ClInclude Include="..\..\src\api\m64p_types.h" />
+    <ClInclude Include="..\..\src\api\m64p_vidext.h" />
+    <ClInclude Include="..\..\src\api\vidext.h" />
     <ClInclude Include="..\..\src\api\vidext_sdl2_compat.h" />
-    <ClInclude Include="..\..\src\debugger\dbg_decoder_local.h">
+    <ClInclude Include="..\..\src\debugger\dbg_breakpoints.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_decoder.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_decoder_local.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_memory.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_types.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\debugger.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\cheat.h" />
+    <ClInclude Include="..\..\src\main\eep_file.h" />
+    <ClInclude Include="..\..\src\main\eventloop.h" />
+    <ClInclude Include="..\..\src\main\fla_file.h" />
+    <ClInclude Include="..\..\src\main\lirc.h" />
     <ClInclude Include="..\..\src\main\list.h" />
+    <ClInclude Include="..\..\src\main\main.h" />
+    <ClInclude Include="..\..\src\main\md5.h" />
+    <ClInclude Include="..\..\src\main\mpk_file.h" />
+    <ClInclude Include="..\..\src\main\profile.h" />
+    <ClInclude Include="..\..\src\main\rom.h" />
+    <ClInclude Include="..\..\src\main\savestates.h" />
+    <ClInclude Include="..\..\src\main\sdl_key_converter.h" />
+    <ClInclude Include="..\..\src\main\sra_file.h" />
+    <ClInclude Include="..\..\src\main\util.h" />
+    <ClInclude Include="..\..\src\main\version.h" />
+    <ClInclude Include="..\..\src\main\workqueue.h" />
+    <ClInclude Include="..\..\src\memory\memory.h" />
+    <ClInclude Include="..\..\src\pi\cart_rom.h" />
+    <ClInclude Include="..\..\src\pi\flashram.h" />
+    <ClInclude Include="..\..\src\pi\pi_controller.h" />
+    <ClInclude Include="..\..\src\pi\sram.h" />
+    <ClInclude Include="..\..\src\plugin\dummy_audio.h" />
+    <ClInclude Include="..\..\src\plugin\dummy_input.h" />
+    <ClInclude Include="..\..\src\plugin\dummy_rsp.h" />
+    <ClInclude Include="..\..\src\plugin\dummy_video.h" />
+    <ClInclude Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.h" />
+    <ClInclude Include="..\..\src\plugin\get_time_using_C_localtime.h" />
+    <ClInclude Include="..\..\src\plugin\plugin.h" />
+    <ClInclude Include="..\..\src\plugin\rumble_via_input_plugin.h" />
+    <ClInclude Include="..\..\src\r4300\cached_interp.h" />
+    <ClInclude Include="..\..\src\r4300\cp0.h" />
+    <ClInclude Include="..\..\src\r4300\cp1.h" />
+    <ClInclude Include="..\..\src\r4300\exception.h" />
     <ClInclude Include="..\..\src\r4300\fpu.h" />
+    <ClInclude Include="..\..\src\r4300\instr_counters.h" />
+    <ClInclude Include="..\..\src\r4300\interupt.h" />
+    <ClInclude Include="..\..\src\r4300\macros.h" />
+    <ClInclude Include="..\..\src\r4300\mi_controller.h" />
+    <ClInclude Include="..\..\src\r4300\new_dynarec\assem_arm.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\..\src\r4300\new_dynarec\assem_x86.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="..\..\src\r4300\new_dynarec\new_dynarec.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="..\..\src\r4300\ops.h" />
+    <ClInclude Include="..\..\src\r4300\pure_interp.h" />
+    <ClInclude Include="..\..\src\r4300\r4300.h" />
+    <ClInclude Include="..\..\src\r4300\r4300_core.h" />
+    <ClInclude Include="..\..\src\r4300\recomp.h" />
+    <ClInclude Include="..\..\src\r4300\recomph.h" />
+    <ClInclude Include="..\..\src\r4300\reset.h" />
+    <ClInclude Include="..\..\src\r4300\tlb.h" />
     <ClInclude Include="..\..\src\r4300\x86\assemble.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClInclude>
-    <ClInclude Include="..\..\src\r4300\cached_interp.h" />
-    <ClInclude Include="..\..\src\api\callbacks.h" />
-    <ClInclude Include="..\..\src\main\cheat.h" />
-    <ClInclude Include="..\..\src\api\config.h" />
-    <ClInclude Include="..\..\src\r4300\cp0.h" />
-    <ClInclude Include="..\..\src\r4300\cp1.h" />
     <ClInclude Include="..\..\src\main\zip\crypt.h" />
-    <ClInclude Include="..\..\src\debugger\dbg_breakpoints.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_decoder.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_memory.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_opprintf.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_types.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\debugger.h">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\debugger.h" />
-    <ClInclude Include="..\..\src\memory\dma.h" />
-    <ClInclude Include="..\..\src\plugin\dummy_audio.h" />
-    <ClInclude Include="..\..\src\plugin\dummy_input.h" />
-    <ClInclude Include="..\..\src\plugin\dummy_rsp.h" />
-    <ClInclude Include="..\..\src\plugin\dummy_video.h" />
     <ClInclude Include="..\..\src\osal\dynamiclib.h" />
-    <ClInclude Include="..\..\src\main\eventloop.h" />
-    <ClInclude Include="..\..\src\r4300\exception.h" />
     <ClInclude Include="..\..\src\osal\files.h" />
-    <ClInclude Include="..\..\src\memory\flashram.h" />
-    <ClInclude Include="..\..\src\r4300\instr_counters.h" />
     <ClInclude Include="..\..\src\r4300\x86\assemble_struct.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
@@ -510,47 +588,16 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClInclude>
-    <ClInclude Include="..\..\src\r4300\interupt.h" />
     <ClInclude Include="..\..\src\main\zip\ioapi.h" />
-    <ClInclude Include="..\..\src\main\lirc.h" />
-    <ClInclude Include="..\..\src\api\m64p_common.h" />
-    <ClInclude Include="..\..\src\api\m64p_config.h" />
-    <ClInclude Include="..\..\src\api\m64p_debugger.h" />
-    <ClInclude Include="..\..\src\api\m64p_frontend.h" />
-    <ClInclude Include="..\..\src\api\m64p_plugin.h" />
-    <ClInclude Include="..\..\src\api\m64p_types.h" />
-    <ClInclude Include="..\..\src\api\m64p_vidext.h" />
-    <ClInclude Include="..\..\src\r4300\macros.h" />
-    <ClInclude Include="..\..\src\main\main.h" />
-    <ClInclude Include="..\..\src\main\md5.h" />
-    <ClInclude Include="..\..\src\memory\memory.h" />
-    <ClInclude Include="..\..\src\memory\n64_cic_nus_6105.h" />
     <ClInclude Include="..\..\src\osd\OGLFT.h" />
-    <ClInclude Include="..\..\src\r4300\ops.h" />
     <ClInclude Include="..\..\src\osd\osd.h" />
-    <ClInclude Include="..\..\src\memory\pif.h" />
-    <ClInclude Include="..\..\src\plugin\plugin.h" />
     <ClInclude Include="..\..\src\osal\preproc.h" />
-    <ClInclude Include="..\..\src\main\profile.h" />
-    <ClInclude Include="..\..\src\r4300\pure_interp.h" />
-    <ClInclude Include="..\..\src\r4300\r4300.h" />
-    <ClInclude Include="..\..\src\r4300\recomp.h" />
-    <ClInclude Include="..\..\src\r4300\recomph.h" />
     <ClInclude Include="..\..\src\r4300\x86\regcache.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClInclude>
-    <ClInclude Include="..\..\src\r4300\reset.h" />
-    <ClInclude Include="..\..\src\main\rom.h" />
-    <ClInclude Include="..\..\src\main\savestates.h" />
-    <ClInclude Include="..\..\src\main\sdl_key_converter.h" />
     <ClInclude Include="..\..\src\osd\screenshot.h" />
-    <ClInclude Include="..\..\src\r4300\tlb.h" />
     <ClInclude Include="..\..\src\main\zip\unzip.h" />
-    <ClInclude Include="..\..\src\main\util.h" />
-    <ClInclude Include="..\..\src\main\version.h" />
-    <ClInclude Include="..\..\src\api\vidext.h" />
-    <ClInclude Include="..\..\src\main\workqueue.h" />
     <ClInclude Include="..\..\src\main\zip\zip.h" />
     <ClInclude Include="..\..\src\r4300\x86_64\assemble.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -576,6 +623,21 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="..\..\src\rdp\fb.h" />
+    <ClInclude Include="..\..\src\rdp\rdp_core.h" />
+    <ClInclude Include="..\..\src\ri\rdram.h" />
+    <ClInclude Include="..\..\src\ri\ri_controller.h" />
+    <ClInclude Include="..\..\src\rsp\rsp_core.h" />
+    <ClInclude Include="..\..\src\si\af_rtc.h" />
+    <ClInclude Include="..\..\src\si\cic.h" />
+    <ClInclude Include="..\..\src\si\eeprom.h" />
+    <ClInclude Include="..\..\src\si\game_controller.h" />
+    <ClInclude Include="..\..\src\si\mempak.h" />
+    <ClInclude Include="..\..\src\si\n64_cic_nus_6105.h" />
+    <ClInclude Include="..\..\src\si\pif.h" />
+    <ClInclude Include="..\..\src\si\rumblepak.h" />
+    <ClInclude Include="..\..\src\si\si_controller.h" />
+    <ClInclude Include="..\..\src\vi\vi_controller.h" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\src\r4300\new_dynarec\linkage_x86.asm">
@@ -600,6 +662,12 @@
     <None Include="..\..\src\r4300\interpreter_regimm.def" />
     <None Include="..\..\src\r4300\interpreter_special.def" />
     <None Include="..\..\src\r4300\interpreter_tlb.def" />
+    <None Include="..\..\src\r4300\new_dynarec\linkage_arm.S">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </None>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/projects/msvc10/mupen64plus-core.vcxproj
+++ b/projects/msvc10/mupen64plus-core.vcxproj
@@ -190,13 +190,26 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\src\r4300\empty_dynarec.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\new_dynarec\assem_x86.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\r4300\new_dynarec\new_dynarec.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">CompileAsCpp</CompileAs>
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">CompileAsCpp</CompileAs>
     </ClCompile>
-    <ClCompile Include="..\..\src\r4300\x86\assemble.c" />
+    <ClCompile Include="..\..\src\r4300\x86\assemble.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\r4300\cached_interp.c" />
     <ClCompile Include="..\..\src\api\callbacks.c" />
     <ClCompile Include="..\..\src\main\cheat.c" />
@@ -248,17 +261,50 @@
     <ClCompile Include="..\..\src\osal\files_win32.c" />
     <ClCompile Include="..\..\src\memory\flashram.c" />
     <ClCompile Include="..\..\src\api\frontend.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gbc.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gcop0.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gcop1.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gcop1_d.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gcop1_l.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gcop1_s.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gcop1_w.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gr4300.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gregimm.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gspecial.c" />
-    <ClCompile Include="..\..\src\r4300\x86\gtlb.c" />
+    <ClCompile Include="..\..\src\r4300\x86\gbc.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop0.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_d.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_l.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_s.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_w.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gr4300.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gregimm.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gspecial.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gtlb.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\r4300\instr_counters.c" />
     <ClCompile Include="..\..\src\r4300\interupt.c" />
     <ClCompile Include="..\..\src\main\zip\ioapi.c" />
@@ -275,9 +321,15 @@
     <ClCompile Include="..\..\src\r4300\pure_interp.c" />
     <ClCompile Include="..\..\src\r4300\r4300.c" />
     <ClCompile Include="..\..\src\r4300\recomp.c" />
-    <ClCompile Include="..\..\src\r4300\x86\regcache.c" />
+    <ClCompile Include="..\..\src\r4300\x86\regcache.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\r4300\reset.c" />
-    <ClCompile Include="..\..\src\r4300\x86\rjump.c" />
+    <ClCompile Include="..\..\src\r4300\x86\rjump.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\main\rom.c" />
     <ClCompile Include="..\..\src\main\savestates.c" />
     <ClCompile Include="..\..\src\main\sdl_key_converter.c" />
@@ -288,9 +340,113 @@
     <ClCompile Include="..\..\src\api\vidext.c" />
     <ClCompile Include="..\..\src\main\workqueue.c" />
     <ClCompile Include="..\..\src\main\zip\zip.c" />
+    <ClCompile Include="..\..\src\r4300\x86_64\assemble.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gbc.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop0.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1_d.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1_l.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1_s.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1_w.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gr4300.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gregimm.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gspecial.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gtlb.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\regcache.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\rjump.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\r4300\x86\assemble.h" />
+    <ClInclude Include="..\..\src\api\vidext_sdl2_compat.h" />
+    <ClInclude Include="..\..\src\debugger\dbg_decoder_local.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\list.h" />
+    <ClInclude Include="..\..\src\r4300\fpu.h" />
+    <ClInclude Include="..\..\src\r4300\new_dynarec\assem_x86.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\new_dynarec\new_dynarec.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86\assemble.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\..\src\r4300\cached_interp.h" />
     <ClInclude Include="..\..\src\api\callbacks.h" />
     <ClInclude Include="..\..\src\main\cheat.h" />
@@ -298,12 +454,42 @@
     <ClInclude Include="..\..\src\r4300\cp0.h" />
     <ClInclude Include="..\..\src\r4300\cp1.h" />
     <ClInclude Include="..\..\src\main\zip\crypt.h" />
-    <ClInclude Include="..\..\src\debugger\dbg_breakpoints.h" />
-    <ClInclude Include="..\..\src\debugger\dbg_decoder.h" />
-    <ClInclude Include="..\..\src\debugger\dbg_memory.h" />
-    <ClInclude Include="..\..\src\debugger\dbg_opprintf.h" />
-    <ClInclude Include="..\..\src\debugger\dbg_types.h" />
-    <ClInclude Include="..\..\src\debugger\debugger.h" />
+    <ClInclude Include="..\..\src\debugger\dbg_breakpoints.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_decoder.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_memory.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_opprintf.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_types.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\debugger.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\..\src\api\debugger.h" />
     <ClInclude Include="..\..\src\memory\dma.h" />
     <ClInclude Include="..\..\src\plugin\dummy_audio.h" />
@@ -316,7 +502,14 @@
     <ClInclude Include="..\..\src\osal\files.h" />
     <ClInclude Include="..\..\src\memory\flashram.h" />
     <ClInclude Include="..\..\src\r4300\instr_counters.h" />
-    <ClInclude Include="..\..\src\r4300\x86\interpret.h" />
+    <ClInclude Include="..\..\src\r4300\x86\assemble_struct.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86\interpret.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\..\src\r4300\interupt.h" />
     <ClInclude Include="..\..\src\main\zip\ioapi.h" />
     <ClInclude Include="..\..\src\main\lirc.h" />
@@ -343,7 +536,10 @@
     <ClInclude Include="..\..\src\r4300\r4300.h" />
     <ClInclude Include="..\..\src\r4300\recomp.h" />
     <ClInclude Include="..\..\src\r4300\recomph.h" />
-    <ClInclude Include="..\..\src\r4300\x86\regcache.h" />
+    <ClInclude Include="..\..\src\r4300\x86\regcache.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\..\src\r4300\reset.h" />
     <ClInclude Include="..\..\src\main\rom.h" />
     <ClInclude Include="..\..\src\main\savestates.h" />
@@ -356,6 +552,30 @@
     <ClInclude Include="..\..\src\api\vidext.h" />
     <ClInclude Include="..\..\src\main\workqueue.h" />
     <ClInclude Include="..\..\src\main\zip\zip.h" />
+    <ClInclude Include="..\..\src\r4300\x86_64\assemble.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86_64\assemble_struct.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86_64\interpret.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86_64\regcache.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\src\r4300\new_dynarec\linkage_x86.asm">
@@ -371,6 +591,15 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)linkage_x86.obj</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)linkage_x86.obj</Outputs>
     </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\src\r4300\interpreter.def" />
+    <None Include="..\..\src\r4300\interpreter_cop0.def" />
+    <None Include="..\..\src\r4300\interpreter_cop1.def" />
+    <None Include="..\..\src\r4300\interpreter_r4300.def" />
+    <None Include="..\..\src\r4300\interpreter_regimm.def" />
+    <None Include="..\..\src\r4300\interpreter_special.def" />
+    <None Include="..\..\src\r4300\interpreter_tlb.def" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/projects/msvc10/mupen64plus-core.vcxproj
+++ b/projects/msvc10/mupen64plus-core.vcxproj
@@ -343,11 +343,11 @@
       <FileType>Document</FileType>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
-      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath) -dWIN32</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath)</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(IntDir)linkage_x86.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath) -dWIN32</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath) -dWIN32</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath) -dWIN32</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.11.06\nasm.exe" -o $(IntDir)linkage_x86.obj -f  win32 %(FullPath)</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)linkage_x86.obj</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)linkage_x86.obj</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)linkage_x86.obj</Outputs>

--- a/projects/msvc10/mupen64plus-core.vcxproj
+++ b/projects/msvc10/mupen64plus-core.vcxproj
@@ -105,7 +105,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\include;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;inline=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -127,7 +127,7 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\include;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;NEW_DYNAREC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;NEW_DYNAREC=1;inline=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -149,7 +149,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\include;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;inline=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -170,7 +170,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\..\src;..\..\..\mupen64plus-win32-deps\SDL-1.2.14\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.3\include;..\..\..\mupen64plus-win32-deps\libpng-1.2.37\include;..\..\..\mupen64plus-win32-deps\freetype-2.3.5-1\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;NEW_DYNAREC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_PARALLEL;NEW_DYNAREC=1;inline=_inline;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -204,9 +204,24 @@
     <ClCompile Include="..\..\src\api\config.c" />
     <ClCompile Include="..\..\src\r4300\cp0.c" />
     <ClCompile Include="..\..\src\r4300\cp1.c" />
-    <ClCompile Include="..\..\src\debugger\dbg_breakpoints.c" />
-    <ClCompile Include="..\..\src\debugger\dbg_decoder.c" />
-    <ClCompile Include="..\..\src\debugger\dbg_memory.c" />
+    <ClCompile Include="..\..\src\debugger\dbg_breakpoints.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\dbg_decoder.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\dbg_memory.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\debugger\debugger.c">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
@@ -216,6 +231,10 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)%(Filename)1.obj</ObjectFileName>
       <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
       <XMLDocumentationFileName Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)%(Filename)1.xdc</XMLDocumentationFileName>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\src\api\debugger.c" />
     <ClCompile Include="..\..\src\memory\dma.c" />

--- a/projects/msvc10/mupen64plus-core.vcxproj.filters
+++ b/projects/msvc10/mupen64plus-core.vcxproj.filters
@@ -1,36 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="..\..\src\api\callbacks.c">
-      <Filter>api</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\api\common.c">
-      <Filter>api</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\api\config.c">
-      <Filter>api</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\api\debugger.c">
-      <Filter>api</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\api\frontend.c">
-      <Filter>api</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\api\vidext.c">
-      <Filter>api</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\debugger\dbg_breakpoints.c">
-      <Filter>debugger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\debugger\dbg_decoder.c">
-      <Filter>debugger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\debugger\dbg_memory.c">
-      <Filter>debugger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\debugger\debugger.c">
-      <Filter>debugger</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\main\zip\ioapi.c">
       <Filter>main\zip</Filter>
     </ClCompile>
@@ -39,54 +9,6 @@
     </ClCompile>
     <ClCompile Include="..\..\src\main\zip\unzip.c">
       <Filter>main\zip</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\cheat.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\eventloop.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\lirc.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\main.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\md5.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\profile.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\rom.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\savestates.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\sdl_key_converter.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\util.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\workqueue.c">
-      <Filter>main</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\memory\dma.c">
-      <Filter>memory</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\memory\flashram.c">
-      <Filter>memory</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\memory\memory.c">
-      <Filter>memory</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\memory\n64_cic_nus_6105.c">
-      <Filter>memory</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\memory\pif.c">
-      <Filter>memory</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\osal\dynamiclib_win32.c">
       <Filter>osal</Filter>
@@ -102,33 +24,6 @@
     </ClCompile>
     <ClCompile Include="..\..\src\osd\screenshot.cpp">
       <Filter>osd</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\plugin\dummy_audio.c">
-      <Filter>plugin</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\plugin\dummy_video.c">
-      <Filter>plugin</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\plugin\dummy_rsp.c">
-      <Filter>plugin</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\plugin\dummy_input.c">
-      <Filter>plugin</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\plugin\plugin.c">
-      <Filter>plugin</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\cached_interp.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\cp0.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\cp1.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\exception.c">
-      <Filter>r4300</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\r4300\new_dynarec\new_dynarec.c">
       <Filter>r4300\new_dynarec</Filter>
@@ -175,30 +70,6 @@
     <ClCompile Include="..\..\src\r4300\x86\rjump.c">
       <Filter>r4300\x86</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\r4300\instr_counters.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\interupt.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\pure_interp.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\r4300.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\recomp.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\reset.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\tlb.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\r4300\empty_dynarec.c">
-      <Filter>r4300</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\r4300\x86_64\assemble.c">
       <Filter>r4300\x86_64</Filter>
     </ClCompile>
@@ -244,56 +115,221 @@
     <ClCompile Include="..\..\src\r4300\new_dynarec\assem_x86.c">
       <Filter>r4300\new_dynarec</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ai\ai_controller.c">
+      <Filter>ai</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\callbacks.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\common.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\config.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\debugger.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\frontend.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\vidext.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\dbg_breakpoints.c">
+      <Filter>debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\dbg_decoder.c">
+      <Filter>debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\dbg_memory.c">
+      <Filter>debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\debugger.c">
+      <Filter>debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\cheat.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\eep_file.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\eventloop.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\fla_file.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\lirc.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\main.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\md5.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\mpk_file.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\profile.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\rom.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\savestates.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\sdl_key_converter.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\sra_file.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\util.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\workqueue.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\memory\memory.c">
+      <Filter>memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osal\dynamiclib_unix.c">
+      <Filter>osal</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osal\files_unix.c">
+      <Filter>osal</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\dummy_audio.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\dummy_input.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\dummy_rsp.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\dummy_video.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\get_time_using_C_localtime.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\plugin.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\rumble_via_input_plugin.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\pi\cart_rom.c">
+      <Filter>pi</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\pi\flashram.c">
+      <Filter>pi</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\pi\pi_controller.c">
+      <Filter>pi</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\pi\sram.c">
+      <Filter>pi</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\rdp\fb.c">
+      <Filter>rdp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\rdp\rdp_core.c">
+      <Filter>rdp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ri\rdram.c">
+      <Filter>ri</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ri\ri_controller.c">
+      <Filter>ri</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\rsp\rsp_core.c">
+      <Filter>rsp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\af_rtc.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\cic.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\eeprom.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\game_controller.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\mempak.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\n64_cic_nus_6105.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\pif.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\rumblepak.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si\si_controller.c">
+      <Filter>si</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\vi\vi_controller.c">
+      <Filter>vi</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\cached_interp.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\cp0.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\cp1.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\empty_dynarec.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\exception.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\instr_counters.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\interupt.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\mi_controller.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\pure_interp.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\r4300.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\r4300_core.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\recomp.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\reset.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\tlb.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\new_dynarec\assem_arm.c">
+      <Filter>r4300\new_dynarec</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\api\callbacks.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\config.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\debugger.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\m64p_common.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\m64p_vidext.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\m64p_config.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\m64p_debugger.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\m64p_frontend.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\m64p_types.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\m64p_plugin.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\vidext.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_types.h">
-      <Filter>debugger</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_breakpoints.h">
-      <Filter>debugger</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_decoder.h">
-      <Filter>debugger</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_memory.h">
-      <Filter>debugger</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\debugger.h">
-      <Filter>debugger</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\main\zip\ioapi.h">
       <Filter>main\zip</Filter>
     </ClInclude>
@@ -302,57 +338,6 @@
     </ClInclude>
     <ClInclude Include="..\..\src\main\zip\unzip.h">
       <Filter>main\zip</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\cheat.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\eventloop.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\lirc.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\main.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\md5.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\profile.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\rom.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\savestates.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\sdl_key_converter.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\util.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\version.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\workqueue.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\memory\dma.h">
-      <Filter>memory</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\memory\flashram.h">
-      <Filter>memory</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\memory\memory.h">
-      <Filter>memory</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\memory\n64_cic_nus_6105.h">
-      <Filter>memory</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\memory\pif.h">
-      <Filter>memory</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\osal\dynamiclib.h">
       <Filter>osal</Filter>
@@ -372,33 +357,6 @@
     <ClInclude Include="..\..\src\osd\screenshot.h">
       <Filter>osd</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\plugin\dummy_video.h">
-      <Filter>plugin</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\plugin\dummy_rsp.h">
-      <Filter>plugin</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\plugin\dummy_input.h">
-      <Filter>plugin</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\plugin\dummy_audio.h">
-      <Filter>plugin</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\plugin\plugin.h">
-      <Filter>plugin</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\cached_interp.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\cp0.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\cp1.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\exception.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\r4300\x86\assemble.h">
       <Filter>r4300\x86</Filter>
     </ClInclude>
@@ -408,53 +366,8 @@
     <ClInclude Include="..\..\src\r4300\x86\regcache.h">
       <Filter>r4300\x86</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\r4300\instr_counters.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\interupt.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\macros.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\ops.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\pure_interp.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\r4300.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\recomp.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\recomph.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\reset.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\tlb.h">
-      <Filter>r4300</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\main\zip\crypt.h">
       <Filter>main\zip</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_opprintf.h">
-      <Filter>debugger</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\api\vidext_sdl2_compat.h">
-      <Filter>api</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\debugger\dbg_decoder_local.h">
-      <Filter>debugger</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\list.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\r4300\fpu.h">
-      <Filter>r4300</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\r4300\x86_64\assemble.h">
       <Filter>r4300\x86_64</Filter>
@@ -475,6 +388,252 @@
       <Filter>r4300\new_dynarec</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\r4300\new_dynarec\new_dynarec.h">
+      <Filter>r4300\new_dynarec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ai\ai_controller.h">
+      <Filter>ai</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\callbacks.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\config.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\debugger.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_common.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_config.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_debugger.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_frontend.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_plugin.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_types.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_vidext.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\vidext.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\vidext_sdl2_compat.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_breakpoints.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_decoder.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_decoder_local.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_memory.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_types.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\debugger.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\cheat.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\eep_file.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\eventloop.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\fla_file.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\lirc.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\list.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\main.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\md5.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\mpk_file.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\profile.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\rom.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\savestates.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\sdl_key_converter.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\sra_file.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\util.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\version.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\workqueue.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\memory\memory.h">
+      <Filter>memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\dummy_audio.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\dummy_input.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\dummy_rsp.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\dummy_video.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\get_time_using_C_localtime.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\plugin.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\rumble_via_input_plugin.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\pi\cart_rom.h">
+      <Filter>pi</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\pi\flashram.h">
+      <Filter>pi</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\pi\pi_controller.h">
+      <Filter>pi</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\pi\sram.h">
+      <Filter>pi</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\rdp\fb.h">
+      <Filter>rdp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\rdp\rdp_core.h">
+      <Filter>rdp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ri\rdram.h">
+      <Filter>ri</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ri\ri_controller.h">
+      <Filter>ri</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\rsp\rsp_core.h">
+      <Filter>rsp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\af_rtc.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\cic.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\eeprom.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\game_controller.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\mempak.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\n64_cic_nus_6105.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\pif.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\rumblepak.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\si\si_controller.h">
+      <Filter>si</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\vi\vi_controller.h">
+      <Filter>vi</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\cached_interp.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\cp0.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\cp1.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\exception.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\fpu.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\instr_counters.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\interupt.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\macros.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\mi_controller.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\ops.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\pure_interp.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\r4300.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\r4300_core.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\recomp.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\recomph.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\reset.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\tlb.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\new_dynarec\assem_arm.h">
       <Filter>r4300\new_dynarec</Filter>
     </ClInclude>
   </ItemGroup>
@@ -515,6 +674,27 @@
     <Filter Include="r4300\x86_64">
       <UniqueIdentifier>{506d581e-1825-4c3d-872b-58db33a6df16}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ai">
+      <UniqueIdentifier>{417674a2-b81c-4027-ba29-a0ee07c731f9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="pi">
+      <UniqueIdentifier>{4da38748-c9d1-457d-8dc6-9e16919bc8c6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rdp">
+      <UniqueIdentifier>{9cdbe4a3-fd38-4ae1-bf43-47eec03cb0e1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ri">
+      <UniqueIdentifier>{8d89fed6-5f08-4b7f-999e-6c3c45f39979}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rsp">
+      <UniqueIdentifier>{6f602ce4-f30d-4aa6-baed-be2706bbf1ea}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="si">
+      <UniqueIdentifier>{1d12a072-9c4a-446c-9e70-62dcd7604b05}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="vi">
+      <UniqueIdentifier>{d4d78b13-1886-4373-8534-24f18c74f0fc}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\src\r4300\new_dynarec\linkage_x86.asm">
@@ -542,6 +722,9 @@
     </None>
     <None Include="..\..\src\r4300\interpreter_tlb.def">
       <Filter>r4300</Filter>
+    </None>
+    <None Include="..\..\src\r4300\new_dynarec\linkage_arm.S">
+      <Filter>r4300\new_dynarec</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/projects/msvc10/mupen64plus-core.vcxproj.filters
+++ b/projects/msvc10/mupen64plus-core.vcxproj.filters
@@ -1,0 +1,547 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\src\api\callbacks.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\common.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\config.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\debugger.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\frontend.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\api\vidext.c">
+      <Filter>api</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\dbg_breakpoints.c">
+      <Filter>debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\dbg_decoder.c">
+      <Filter>debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\dbg_memory.c">
+      <Filter>debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\debugger\debugger.c">
+      <Filter>debugger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\zip\ioapi.c">
+      <Filter>main\zip</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\zip\zip.c">
+      <Filter>main\zip</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\zip\unzip.c">
+      <Filter>main\zip</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\cheat.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\eventloop.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\lirc.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\main.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\md5.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\profile.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\rom.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\savestates.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\sdl_key_converter.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\util.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\workqueue.c">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\memory\dma.c">
+      <Filter>memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\memory\flashram.c">
+      <Filter>memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\memory\memory.c">
+      <Filter>memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\memory\n64_cic_nus_6105.c">
+      <Filter>memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\memory\pif.c">
+      <Filter>memory</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osal\dynamiclib_win32.c">
+      <Filter>osal</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osal\files_win32.c">
+      <Filter>osal</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osd\OGLFT.cpp">
+      <Filter>osd</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osd\osd.cpp">
+      <Filter>osd</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\osd\screenshot.cpp">
+      <Filter>osd</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\dummy_audio.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\dummy_video.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\dummy_rsp.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\dummy_input.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\plugin\plugin.c">
+      <Filter>plugin</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\cached_interp.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\cp0.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\cp1.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\exception.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\new_dynarec\new_dynarec.c">
+      <Filter>r4300\new_dynarec</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\assemble.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gbc.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop0.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_d.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_l.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_s.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gcop1_w.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gr4300.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gregimm.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gspecial.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\gtlb.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\regcache.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86\rjump.c">
+      <Filter>r4300\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\instr_counters.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\interupt.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\pure_interp.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\r4300.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\recomp.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\reset.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\tlb.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\empty_dynarec.c">
+      <Filter>r4300</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\assemble.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gbc.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop0.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1_d.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1_l.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1_s.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gcop1_w.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gr4300.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gregimm.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gspecial.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\gtlb.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\regcache.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\x86_64\rjump.c">
+      <Filter>r4300\x86_64</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\r4300\new_dynarec\assem_x86.c">
+      <Filter>r4300\new_dynarec</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\api\callbacks.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\config.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\debugger.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_common.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_vidext.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_config.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_debugger.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_frontend.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_types.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\m64p_plugin.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\vidext.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_types.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_breakpoints.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_decoder.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_memory.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\debugger.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\zip\ioapi.h">
+      <Filter>main\zip</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\zip\zip.h">
+      <Filter>main\zip</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\zip\unzip.h">
+      <Filter>main\zip</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\cheat.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\eventloop.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\lirc.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\main.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\md5.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\profile.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\rom.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\savestates.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\sdl_key_converter.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\util.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\version.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\workqueue.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\memory\dma.h">
+      <Filter>memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\memory\flashram.h">
+      <Filter>memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\memory\memory.h">
+      <Filter>memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\memory\n64_cic_nus_6105.h">
+      <Filter>memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\memory\pif.h">
+      <Filter>memory</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\osal\dynamiclib.h">
+      <Filter>osal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\osal\files.h">
+      <Filter>osal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\osal\preproc.h">
+      <Filter>osal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\osd\OGLFT.h">
+      <Filter>osd</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\osd\osd.h">
+      <Filter>osd</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\osd\screenshot.h">
+      <Filter>osd</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\dummy_video.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\dummy_rsp.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\dummy_input.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\dummy_audio.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\plugin\plugin.h">
+      <Filter>plugin</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\cached_interp.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\cp0.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\cp1.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\exception.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86\assemble.h">
+      <Filter>r4300\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86\interpret.h">
+      <Filter>r4300\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86\regcache.h">
+      <Filter>r4300\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\instr_counters.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\interupt.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\macros.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\ops.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\pure_interp.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\r4300.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\recomp.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\recomph.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\reset.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\tlb.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\zip\crypt.h">
+      <Filter>main\zip</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_opprintf.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\api\vidext_sdl2_compat.h">
+      <Filter>api</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\debugger\dbg_decoder_local.h">
+      <Filter>debugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\list.h">
+      <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\fpu.h">
+      <Filter>r4300</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86_64\assemble.h">
+      <Filter>r4300\x86_64</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86_64\assemble_struct.h">
+      <Filter>r4300\x86_64</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86_64\interpret.h">
+      <Filter>r4300\x86_64</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86_64\regcache.h">
+      <Filter>r4300\x86_64</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\x86\assemble_struct.h">
+      <Filter>r4300\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\new_dynarec\assem_x86.h">
+      <Filter>r4300\new_dynarec</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\r4300\new_dynarec\new_dynarec.h">
+      <Filter>r4300\new_dynarec</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="api">
+      <UniqueIdentifier>{75918f00-a8e8-4015-ad5c-16c7a4c8f9ef}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="debugger">
+      <UniqueIdentifier>{2c48e256-8a01-48cc-8557-300f9c80bb87}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main">
+      <UniqueIdentifier>{399593a6-c384-44a8-9624-9b475dcf775c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main\zip">
+      <UniqueIdentifier>{1a878d7f-61e3-42f5-acf2-b0ba33609620}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="memory">
+      <UniqueIdentifier>{85cecd57-5582-48e1-89b4-712173bb63e8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="osd">
+      <UniqueIdentifier>{2693a41d-f5b1-4374-b017-2ed0c61e6cbb}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="osal">
+      <UniqueIdentifier>{857c9cab-6b55-41e4-bec3-357d9535f887}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="plugin">
+      <UniqueIdentifier>{3e66acd8-e98d-402c-a684-d06d563bfd9a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="r4300">
+      <UniqueIdentifier>{b24f55e8-62d5-4eee-87dd-4df1b20cb160}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="r4300\new_dynarec">
+      <UniqueIdentifier>{c138e857-6010-4eca-b70c-625ea42d0c62}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="r4300\x86">
+      <UniqueIdentifier>{a9ccadb3-5846-4943-9fcd-234452aacbf3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="r4300\x86_64">
+      <UniqueIdentifier>{506d581e-1825-4c3d-872b-58db33a6df16}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\src\r4300\new_dynarec\linkage_x86.asm">
+      <Filter>r4300\new_dynarec</Filter>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\src\r4300\interpreter.def">
+      <Filter>r4300</Filter>
+    </None>
+    <None Include="..\..\src\r4300\interpreter_cop0.def">
+      <Filter>r4300</Filter>
+    </None>
+    <None Include="..\..\src\r4300\interpreter_cop1.def">
+      <Filter>r4300</Filter>
+    </None>
+    <None Include="..\..\src\r4300\interpreter_r4300.def">
+      <Filter>r4300</Filter>
+    </None>
+    <None Include="..\..\src\r4300\interpreter_regimm.def">
+      <Filter>r4300</Filter>
+    </None>
+    <None Include="..\..\src\r4300\interpreter_special.def">
+      <Filter>r4300</Filter>
+    </None>
+    <None Include="..\..\src\r4300\interpreter_tlb.def">
+      <Filter>r4300</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -161,7 +161,7 @@ ifeq ($(OS), FREEBSD)
   SONAME = libmupen64plus$(POSTFIX).so.2
   LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-dynamic -Wl,-soname,$(SONAME)
   LDLIBS += -L${LOCALBASE}/lib -lc
-  ASFLAGS = -f elf
+  ASFLAGS = -f elf -d ELF_TYPE
 endif
 ifeq ($(OS), LINUX)
   TARGET = libmupen64plus$(POSTFIX).so.2.0.0
@@ -170,7 +170,7 @@ ifeq ($(OS), LINUX)
   LDLIBS += -ldl
   # only export api symbols
   LDFLAGS += -Wl,-version-script,$(SRCDIR)/api/api_export.ver
-  ASFLAGS = -f elf
+  ASFLAGS = -f elf -d ELF_TYPE
 endif
 ifeq ($(OS), OSX)
   #xcode-select has been around since XCode 3.0, i.e. OS X 10.5

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -161,6 +161,7 @@ ifeq ($(OS), FREEBSD)
   SONAME = libmupen64plus$(POSTFIX).so.2
   LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-dynamic -Wl,-soname,$(SONAME)
   LDLIBS += -L${LOCALBASE}/lib -lc
+  ASFLAGS = -f elf
 endif
 ifeq ($(OS), LINUX)
   TARGET = libmupen64plus$(POSTFIX).so.2.0.0
@@ -169,6 +170,7 @@ ifeq ($(OS), LINUX)
   LDLIBS += -ldl
   # only export api symbols
   LDFLAGS += -Wl,-version-script,$(SRCDIR)/api/api_export.ver
+  ASFLAGS = -f elf
 endif
 ifeq ($(OS), OSX)
   #xcode-select has been around since XCode 3.0, i.e. OS X 10.5
@@ -178,6 +180,7 @@ ifeq ($(OS), OSX)
   TARGET = libmupen64plus$(POSTFIX).dylib
   LDFLAGS += -framework CoreFoundation -bundle -read_only_relocs suppress
   LDLIBS += -ldl
+  ASFLAGS = -f macho
   ifeq ($(CPU), X86)
     ifeq ($(ARCH_DETECTED), 64BITS)
       CFLAGS += -pipe -arch x86_64 -mmacosx-version-min=10.5 -isysroot $(OSX_SDK_PATH)
@@ -195,6 +198,7 @@ ifeq ($(OS), MINGW)
   # only export api symbols
   LDFLAGS += -Wl,-version-script,$(SRCDIR)/api/api_export.ver
   LDLIBS += -lpthread
+  ASFLAGS = -f win32
 endif
 
 ifeq ($(CPU_ENDIANNESS), BIG)
@@ -206,6 +210,7 @@ ifneq ($(findstring $(MAKEFLAGS),s),s)
 ifndef V
 	Q_CC  = @echo '    CC  '$@;
 	Q_CXX = @echo '    CXX '$@;
+	Q_AS  = @echo '    AS  '$@;
 	Q_LD  = @echo '    LD  '$@;
 endif
 endif
@@ -321,11 +326,13 @@ endif
 # set base program pointers and flags
 CC        = $(CROSS_COMPILE)gcc
 CXX       = $(CROSS_COMPILE)g++
+AS        = nasm
 RM       ?= rm -f
 INSTALL  ?= install
 MKDIR ?= mkdir -p
 COMPILE.c = $(Q_CC)$(CC) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
 COMPILE.cc = $(Q_CXX)$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
+COMPILE.as = $(Q_AS)$(AS) $(ASFLAGS)
 LINK.o = $(Q_LD)$(CXX) $(CXXFLAGS) $(LDFLAGS) $(TARGET_ARCH)
 
 ifeq ($(OS),OSX)
@@ -505,9 +512,13 @@ ifneq ($(DYNAREC), )
   ifeq ($(NEW_DYNAREC), 1)
     ifeq ($(DYNAREC), x86)
       CFLAGS += -DNEW_DYNAREC=1
+      SOURCE += \
+	    $(SRCDIR)/r4300/new_dynarec/linkage_x86.asm
     else
       ifeq ($(DYNAREC), arm)
         CFLAGS += -DNEW_DYNAREC=3
+        SOURCE += \
+		  $(SRCDIR)/r4300/new_dynarec/linkage_arm.S
       else
         $(error NEW_DYNAREC is only supported on 32 bit x86 and 32 bit armel)
       endif
@@ -515,7 +526,6 @@ ifneq ($(DYNAREC), )
 
     SOURCE += \
       $(SRCDIR)/r4300/empty_dynarec.c \
-      $(SRCDIR)/r4300/new_dynarec/linkage_$(DYNAREC).S \
       $(SRCDIR)/r4300/new_dynarec/new_dynarec.c
   else
     SOURCE += \
@@ -569,6 +579,7 @@ endif
 OBJECTS := $(patsubst $(SRCDIR)/%.c,   $(OBJDIR)/%.o, $(filter %.c,   $(SOURCE)))
 OBJECTS += $(patsubst $(SRCDIR)/%.cpp, $(OBJDIR)/%.o, $(filter %.cpp, $(SOURCE)))
 OBJECTS += $(patsubst $(SRCDIR)/%.S, $(OBJDIR)/%.o, $(filter %.S, $(SOURCE)))
+OBJECTS += $(patsubst $(SRCDIR)/%.asm, $(OBJDIR)/%.o, $(filter %.asm, $(SOURCE)))
 OBJDIRS = $(dir $(OBJECTS))
 $(shell $(MKDIR) $(OBJDIRS))
 
@@ -642,6 +653,9 @@ CFLAGS += -MD -MP
 CXXFLAGS += $(CFLAGS)
 
 # standard build rules
+$(OBJDIR)/%.o: $(SRCDIR)/%.asm
+	$(COMPILE.as) -o $@ $<
+	
 $(OBJDIR)/%.o: $(SRCDIR)/%.S
 	$(COMPILE.c) -o $@ $<
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -868,6 +868,7 @@ m64p_error main_run(void)
     struct fla_file fla;
     struct mpk_file mpk;
     struct sra_file sra;
+    static int channels[] = { 0, 1, 2, 3 };
 
     /* take the r4300 emulator mode from the config file at this point and cache it in a global variable */
     r4300emu = ConfigGetParamInt(g_CoreConfig, "R4300Emulator");
@@ -930,7 +931,6 @@ m64p_error main_run(void)
     g_si.pif.af_rtc.get_time = get_time_using_C_localtime;
 
     /* connect external game controllers */
-    static int channels[] = { 0, 1, 2, 3 };
     for(i = 0; i < GAME_CONTROLLERS_COUNT; ++i)
     {
         g_si.pif.controllers[i].user_data = &channels[i];

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -62,10 +62,10 @@ unsigned int address = 0;
 
 // values that are being written are stored in these variables
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
-unsigned int word;
+unsigned int cpu_word;
 unsigned char cpu_byte;
-unsigned short hword;
-unsigned long long int dword;
+unsigned short cpu_hword;
+unsigned long long int cpu_dword;
 #endif
 
 // addresse where the read value will be stored
@@ -297,7 +297,7 @@ void read_rdramd(void)
 
 void write_rdram(void)
 {
-    writew(write_rdram_dram, &g_ri, address, word);
+    writew(write_rdram_dram, &g_ri, address, cpu_word);
 }
 
 void write_rdramb(void)
@@ -307,12 +307,12 @@ void write_rdramb(void)
 
 void write_rdramh(void)
 {
-    writeh(write_rdram_dram, &g_ri, address, hword);
+    writeh(write_rdram_dram, &g_ri, address, cpu_hword);
 }
 
 void write_rdramd(void)
 {
-    writed(write_rdram_dram, &g_ri, address, dword);
+    writed(write_rdram_dram, &g_ri, address, cpu_dword);
 }
 
 
@@ -338,7 +338,7 @@ void read_rdramFBd(void)
 
 void write_rdramFB(void)
 {
-    writew(write_rdram_fb, &g_dp, address, word);
+    writew(write_rdram_fb, &g_dp, address, cpu_word);
 }
 
 void write_rdramFBb(void)
@@ -348,12 +348,12 @@ void write_rdramFBb(void)
 
 void write_rdramFBh(void)
 {
-    writeh(write_rdram_fb, &g_dp, address, hword);
+    writeh(write_rdram_fb, &g_dp, address, cpu_hword);
 }
 
 void write_rdramFBd(void)
 {
-    writed(write_rdram_fb, &g_dp, address, dword);
+    writed(write_rdram_fb, &g_dp, address, cpu_dword);
 }
 
 
@@ -379,7 +379,7 @@ static void read_rdramregd(void)
 
 static void write_rdramreg(void)
 {
-    writew(write_rdram_regs, &g_ri, address, word);
+    writew(write_rdram_regs, &g_ri, address, cpu_word);
 }
 
 static void write_rdramregb(void)
@@ -389,12 +389,12 @@ static void write_rdramregb(void)
 
 static void write_rdramregh(void)
 {
-    writeh(write_rdram_regs, &g_ri, address, hword);
+    writeh(write_rdram_regs, &g_ri, address, cpu_hword);
 }
 
 static void write_rdramregd(void)
 {
-    writed(write_rdram_regs, &g_ri, address, dword);
+    writed(write_rdram_regs, &g_ri, address, cpu_dword);
 }
 
 
@@ -420,7 +420,7 @@ static void read_rspmemd(void)
 
 static void write_rspmem(void)
 {
-    writew(write_rsp_mem, &g_sp, address, word);
+    writew(write_rsp_mem, &g_sp, address, cpu_word);
 }
 
 static void write_rspmemb(void)
@@ -430,12 +430,12 @@ static void write_rspmemb(void)
 
 static void write_rspmemh(void)
 {
-    writeh(write_rsp_mem, &g_sp, address, hword);
+    writeh(write_rsp_mem, &g_sp, address, cpu_hword);
 }
 
 static void write_rspmemd(void)
 {
-    writed(write_rsp_mem, &g_sp, address, dword);
+    writed(write_rsp_mem, &g_sp, address, cpu_dword);
 }
 
 
@@ -461,7 +461,7 @@ static void read_rspregd(void)
 
 static void write_rspreg(void)
 {
-    writew(write_rsp_regs, &g_sp, address, word);
+    writew(write_rsp_regs, &g_sp, address, cpu_word);
 }
 
 static void write_rspregb(void)
@@ -471,12 +471,12 @@ static void write_rspregb(void)
 
 static void write_rspregh(void)
 {
-    writeh(write_rsp_regs, &g_sp, address, hword);
+    writeh(write_rsp_regs, &g_sp, address, cpu_hword);
 }
 
 static void write_rspregd(void)
 {
-    writed(write_rsp_regs, &g_sp, address, dword);
+    writed(write_rsp_regs, &g_sp, address, cpu_dword);
 }
 
 
@@ -502,7 +502,7 @@ static void read_rspreg2d(void)
 
 static void write_rspreg2(void)
 {
-    writew(write_rsp_regs2, &g_sp, address, word);
+    writew(write_rsp_regs2, &g_sp, address, cpu_word);
 }
 
 static void write_rspreg2b(void)
@@ -512,12 +512,12 @@ static void write_rspreg2b(void)
 
 static void write_rspreg2h(void)
 {
-    writeh(write_rsp_regs2, &g_sp, address, hword);
+    writeh(write_rsp_regs2, &g_sp, address, cpu_hword);
 }
 
 static void write_rspreg2d(void)
 {
-    writed(write_rsp_regs2, &g_sp, address, dword);
+    writed(write_rsp_regs2, &g_sp, address, cpu_dword);
 }
 
 
@@ -543,7 +543,7 @@ static void read_dpd(void)
 
 static void write_dp(void)
 {
-    writew(write_dpc_regs, &g_dp, address, word);
+    writew(write_dpc_regs, &g_dp, address, cpu_word);
 }
 
 static void write_dpb(void)
@@ -553,12 +553,12 @@ static void write_dpb(void)
 
 static void write_dph(void)
 {
-    writeh(write_dpc_regs, &g_dp, address, hword);
+    writeh(write_dpc_regs, &g_dp, address, cpu_hword);
 }
 
 static void write_dpd(void)
 {
-    writed(write_dpc_regs, &g_dp, address, dword);
+    writed(write_dpc_regs, &g_dp, address, cpu_dword);
 }
 
 
@@ -584,7 +584,7 @@ static void read_dpsd(void)
 
 static void write_dps(void)
 {
-    writew(write_dps_regs, &g_dp, address, word);
+    writew(write_dps_regs, &g_dp, address, cpu_word);
 }
 
 static void write_dpsb(void)
@@ -594,12 +594,12 @@ static void write_dpsb(void)
 
 static void write_dpsh(void)
 {
-    writeh(write_dps_regs, &g_dp, address, hword);
+    writeh(write_dps_regs, &g_dp, address, cpu_hword);
 }
 
 static void write_dpsd(void)
 {
-    writed(write_dps_regs, &g_dp, address, dword);
+    writed(write_dps_regs, &g_dp, address, cpu_dword);
 }
 
 
@@ -625,7 +625,7 @@ static void read_mid(void)
 
 static void write_mi(void)
 {
-    writew(write_mi_regs, &g_r4300, address, word);
+    writew(write_mi_regs, &g_r4300, address, cpu_word);
 }
 
 static void write_mib(void)
@@ -635,12 +635,12 @@ static void write_mib(void)
 
 static void write_mih(void)
 {
-    writeh(write_mi_regs, &g_r4300, address, hword);
+    writeh(write_mi_regs, &g_r4300, address, cpu_hword);
 }
 
 static void write_mid(void)
 {
-    writed(write_mi_regs, &g_r4300, address, dword);
+    writed(write_mi_regs, &g_r4300, address, cpu_dword);
 }
 
 
@@ -666,7 +666,7 @@ static void read_vid(void)
 
 static void write_vi(void)
 {
-    writew(write_vi_regs, &g_vi, address, word);
+    writew(write_vi_regs, &g_vi, address, cpu_word);
 }
 
 static void write_vib(void)
@@ -676,12 +676,12 @@ static void write_vib(void)
 
 static void write_vih(void)
 {
-    writeh(write_vi_regs, &g_vi, address, hword);
+    writeh(write_vi_regs, &g_vi, address, cpu_hword);
 }
 
 static void write_vid(void)
 {
-    writed(write_vi_regs, &g_vi, address, dword);
+    writed(write_vi_regs, &g_vi, address, cpu_dword);
 }
 
 
@@ -707,7 +707,7 @@ static void read_aid(void)
 
 static void write_ai(void)
 {
-    writew(write_ai_regs, &g_ai, address, word);
+    writew(write_ai_regs, &g_ai, address, cpu_word);
 }
 
 static void write_aib(void)
@@ -717,12 +717,12 @@ static void write_aib(void)
 
 static void write_aih(void)
 {
-    writeh(write_ai_regs, &g_ai, address, hword);
+    writeh(write_ai_regs, &g_ai, address, cpu_hword);
 }
 
 static void write_aid(void)
 {
-    writed(write_ai_regs, &g_ai, address, dword);
+    writed(write_ai_regs, &g_ai, address, cpu_dword);
 }
 
 
@@ -748,7 +748,7 @@ static void read_pid(void)
 
 static void write_pi(void)
 {
-    writew(write_pi_regs, &g_pi, address, word);
+    writew(write_pi_regs, &g_pi, address, cpu_word);
 }
 
 static void write_pib(void)
@@ -758,12 +758,12 @@ static void write_pib(void)
 
 static void write_pih(void)
 {
-    writeh(write_pi_regs, &g_pi, address, hword);
+    writeh(write_pi_regs, &g_pi, address, cpu_hword);
 }
 
 static void write_pid(void)
 {
-    writed(write_pi_regs, &g_pi, address, dword);
+    writed(write_pi_regs, &g_pi, address, cpu_dword);
 }
 
 
@@ -789,7 +789,7 @@ static void read_rid(void)
 
 static void write_ri(void)
 {
-    writew(write_ri_regs, &g_ri, address, word);
+    writew(write_ri_regs, &g_ri, address, cpu_word);
 }
 
 static void write_rib(void)
@@ -799,12 +799,12 @@ static void write_rib(void)
 
 static void write_rih(void)
 {
-    writeh(write_ri_regs, &g_ri, address, hword);
+    writeh(write_ri_regs, &g_ri, address, cpu_hword);
 }
 
 static void write_rid(void)
 {
-    writed(write_ri_regs, &g_ri, address, dword);
+    writed(write_ri_regs, &g_ri, address, cpu_dword);
 }
 
 
@@ -830,7 +830,7 @@ static void read_sid(void)
 
 static void write_si(void)
 {
-    writew(write_si_regs, &g_si, address, word);
+    writew(write_si_regs, &g_si, address, cpu_word);
 }
 
 static void write_sib(void)
@@ -840,12 +840,12 @@ static void write_sib(void)
 
 static void write_sih(void)
 {
-    writeh(write_si_regs, &g_si, address, hword);
+    writeh(write_si_regs, &g_si, address, cpu_hword);
 }
 
 static void write_sid(void)
 {
-    writed(write_si_regs, &g_si, address, dword);
+    writed(write_si_regs, &g_si, address, cpu_dword);
 }
 
 static void read_pi_flashram_status(void)
@@ -870,7 +870,7 @@ static void read_pi_flashram_statusd(void)
 
 static void write_pi_flashram_command(void)
 {
-    writew(write_flashram_command, &g_pi, address, word);
+    writew(write_flashram_command, &g_pi, address, cpu_word);
 }
 
 static void write_pi_flashram_commandb(void)
@@ -880,12 +880,12 @@ static void write_pi_flashram_commandb(void)
 
 static void write_pi_flashram_commandh(void)
 {
-    writeh(write_flashram_command, &g_pi, address, hword);
+    writeh(write_flashram_command, &g_pi, address, cpu_hword);
 }
 
 static void write_pi_flashram_commandd(void)
 {
-    writed(write_flashram_command, &g_pi, address, dword);
+    writed(write_flashram_command, &g_pi, address, cpu_dword);
 }
 
 
@@ -911,7 +911,7 @@ static void read_romd(void)
 
 static void write_rom(void)
 {
-    writew(write_cart_rom, &g_pi, address, word);
+    writew(write_cart_rom, &g_pi, address, cpu_word);
 }
 
 
@@ -937,7 +937,7 @@ static void read_pifd(void)
 
 static void write_pif(void)
 {
-    writew(write_pif_ram, &g_si, address, word);
+    writew(write_pif_ram, &g_si, address, cpu_word);
 }
 
 static void write_pifb(void)
@@ -947,12 +947,12 @@ static void write_pifb(void)
 
 static void write_pifh(void)
 {
-    writeh(write_pif_ram, &g_si, address, hword);
+    writeh(write_pif_ram, &g_si, address, cpu_hword);
 }
 
 static void write_pifd(void)
 {
-    writed(write_pif_ram, &g_si, address, dword);
+    writed(write_pif_ram, &g_si, address, cpu_dword);
 }
 
 /* HACK: just to get F-Zero to boot
@@ -994,7 +994,7 @@ static void read_ddd(void)
 
 static void write_dd(void)
 {
-    writew(write_dd_regs, NULL, address, word);
+    writew(write_dd_regs, NULL, address, cpu_word);
 }
 
 static void write_ddb(void)
@@ -1004,12 +1004,12 @@ static void write_ddb(void)
 
 static void write_ddh(void)
 {
-    writeh(write_dd_regs, NULL, address, hword);
+    writeh(write_dd_regs, NULL, address, cpu_hword);
 }
 
 static void write_ddd(void)
 {
-    writed(write_dd_regs, NULL, address, dword);
+    writed(write_dd_regs, NULL, address, cpu_dword);
 }
 
 #ifdef DBG

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -33,10 +33,10 @@
 #define write_hword_in_memory() writememh[address >>16]()
 #define write_dword_in_memory() writememd[address >>16]()
 
-extern unsigned int address, word;
+extern unsigned int address, cpu_word;
 extern unsigned char cpu_byte;
-extern unsigned short hword;
-extern unsigned long long dword, *rdword;
+extern unsigned short cpu_hword;
+extern unsigned long long cpu_dword, *rdword;
 
 extern void (*readmem[0x10000])(void);
 extern void (*readmemb[0x10000])(void);

--- a/src/r4300/interpreter_r4300.def
+++ b/src/r4300/interpreter_r4300.def
@@ -390,7 +390,7 @@ DECLARE_INSTRUCTION(SH)
    long long int *lsrtp = PC->f.i.rt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
-   hword = (unsigned short)(*lsrtp & 0xFFFF);
+   cpu_hword = (unsigned short)(*lsrtp & 0xFFFF);
    write_hword_in_memory();
    CHECK_MEMORY();
 }
@@ -405,7 +405,7 @@ DECLARE_INSTRUCTION(SWL)
      {
       case 0:
     address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
-    word = (unsigned int)*lsrtp;
+    cpu_word = (unsigned int)*lsrtp;
     write_word_in_memory();
     CHECK_MEMORY();
     break;
@@ -415,7 +415,7 @@ DECLARE_INSTRUCTION(SWL)
     read_word_in_memory();
     if(address)
       {
-         word = ((unsigned int)*lsrtp >> 8) | ((unsigned int) old_word & 0xFF000000);
+         cpu_word = ((unsigned int)*lsrtp >> 8) | ((unsigned int) old_word & 0xFF000000);
          write_word_in_memory();
          CHECK_MEMORY();
       }
@@ -426,7 +426,7 @@ DECLARE_INSTRUCTION(SWL)
     read_word_in_memory();
     if(address)
       {
-         word = ((unsigned int)*lsrtp >> 16) | ((unsigned int) old_word & 0xFFFF0000);
+         cpu_word = ((unsigned int)*lsrtp >> 16) | ((unsigned int) old_word & 0xFFFF0000);
          write_word_in_memory();
          CHECK_MEMORY();
       }
@@ -446,7 +446,7 @@ DECLARE_INSTRUCTION(SW)
    long long int *lsrtp = PC->f.i.rt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
-   word = (unsigned int)(*lsrtp & 0xFFFFFFFF);
+   cpu_word = (unsigned int)(*lsrtp & 0xFFFFFFFF);
    write_word_in_memory();
    CHECK_MEMORY();
 }
@@ -461,7 +461,7 @@ DECLARE_INSTRUCTION(SDL)
      {
       case 0:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
-    dword = *lsrtp;
+    cpu_dword = *lsrtp;
     write_dword_in_memory();
     CHECK_MEMORY();
     break;
@@ -471,7 +471,7 @@ DECLARE_INSTRUCTION(SDL)
     read_dword_in_memory();
     if(address)
       {
-         dword = ((unsigned long long)*lsrtp >> 8)|(old_word & 0xFF00000000000000LL);
+         cpu_dword = ((unsigned long long)*lsrtp >> 8)|(old_word & 0xFF00000000000000LL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -482,7 +482,7 @@ DECLARE_INSTRUCTION(SDL)
     read_dword_in_memory();
     if(address)
       {
-         dword = ((unsigned long long)*lsrtp >> 16)|(old_word & 0xFFFF000000000000LL);
+         cpu_dword = ((unsigned long long)*lsrtp >> 16)|(old_word & 0xFFFF000000000000LL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -493,7 +493,7 @@ DECLARE_INSTRUCTION(SDL)
     read_dword_in_memory();
     if(address)
       {
-         dword = ((unsigned long long)*lsrtp >> 24)|(old_word & 0xFFFFFF0000000000LL);
+         cpu_dword = ((unsigned long long)*lsrtp >> 24)|(old_word & 0xFFFFFF0000000000LL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -504,7 +504,7 @@ DECLARE_INSTRUCTION(SDL)
     read_dword_in_memory();
     if(address)
       {
-         dword = ((unsigned long long)*lsrtp >> 32)|(old_word & 0xFFFFFFFF00000000LL);
+         cpu_dword = ((unsigned long long)*lsrtp >> 32)|(old_word & 0xFFFFFFFF00000000LL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -515,7 +515,7 @@ DECLARE_INSTRUCTION(SDL)
     read_dword_in_memory();
     if(address)
       {
-         dword = ((unsigned long long)*lsrtp >> 40)|(old_word & 0xFFFFFFFFFF000000LL);
+         cpu_dword = ((unsigned long long)*lsrtp >> 40)|(old_word & 0xFFFFFFFFFF000000LL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -526,7 +526,7 @@ DECLARE_INSTRUCTION(SDL)
     read_dword_in_memory();
     if(address)
       {
-         dword = ((unsigned long long)*lsrtp >> 48)|(old_word & 0xFFFFFFFFFFFF0000LL);
+         cpu_dword = ((unsigned long long)*lsrtp >> 48)|(old_word & 0xFFFFFFFFFFFF0000LL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -537,7 +537,7 @@ DECLARE_INSTRUCTION(SDL)
     read_dword_in_memory();
     if(address)
       {
-         dword = ((unsigned long long)*lsrtp >> 56)|(old_word & 0xFFFFFFFFFFFFFF00LL);
+         cpu_dword = ((unsigned long long)*lsrtp >> 56)|(old_word & 0xFFFFFFFFFFFFFF00LL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -559,7 +559,7 @@ DECLARE_INSTRUCTION(SDR)
     read_dword_in_memory();
     if(address)
       {
-         dword = (*lsrtp << 56) | (old_word & 0x00FFFFFFFFFFFFFFLL);
+         cpu_dword = (*lsrtp << 56) | (old_word & 0x00FFFFFFFFFFFFFFLL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -570,7 +570,7 @@ DECLARE_INSTRUCTION(SDR)
     read_dword_in_memory();
     if(address)
       {
-         dword = (*lsrtp << 48) | (old_word & 0x0000FFFFFFFFFFFFLL);
+         cpu_dword = (*lsrtp << 48) | (old_word & 0x0000FFFFFFFFFFFFLL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -581,7 +581,7 @@ DECLARE_INSTRUCTION(SDR)
     read_dword_in_memory();
     if(address)
       {
-         dword = (*lsrtp << 40) | (old_word & 0x000000FFFFFFFFFFLL);
+         cpu_dword = (*lsrtp << 40) | (old_word & 0x000000FFFFFFFFFFLL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -592,7 +592,7 @@ DECLARE_INSTRUCTION(SDR)
     read_dword_in_memory();
     if(address)
       {
-         dword = (*lsrtp << 32) | (old_word & 0x00000000FFFFFFFFLL);
+         cpu_dword = (*lsrtp << 32) | (old_word & 0x00000000FFFFFFFFLL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -603,7 +603,7 @@ DECLARE_INSTRUCTION(SDR)
     read_dword_in_memory();
     if(address)
       {
-         dword = (*lsrtp << 24) | (old_word & 0x0000000000FFFFFFLL);
+         cpu_dword = (*lsrtp << 24) | (old_word & 0x0000000000FFFFFFLL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -614,7 +614,7 @@ DECLARE_INSTRUCTION(SDR)
     read_dword_in_memory();
     if(address)
       {
-         dword = (*lsrtp << 16) | (old_word & 0x000000000000FFFFLL);
+         cpu_dword = (*lsrtp << 16) | (old_word & 0x000000000000FFFFLL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -625,14 +625,14 @@ DECLARE_INSTRUCTION(SDR)
     read_dword_in_memory();
     if(address)
       {
-         dword = (*lsrtp << 8) | (old_word & 0x00000000000000FFLL);
+         cpu_dword = (*lsrtp << 8) | (old_word & 0x00000000000000FFLL);
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 7:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
-    dword = *lsrtp;
+    cpu_dword = *lsrtp;
     write_dword_in_memory();
     CHECK_MEMORY();
     break;
@@ -653,7 +653,7 @@ DECLARE_INSTRUCTION(SWR)
     read_word_in_memory();
     if(address)
       {
-         word = ((unsigned int)*lsrtp << 24) | ((unsigned int) old_word & 0x00FFFFFF);
+         cpu_word = ((unsigned int)*lsrtp << 24) | ((unsigned int) old_word & 0x00FFFFFF);
          write_word_in_memory();
          CHECK_MEMORY();
       }
@@ -664,7 +664,7 @@ DECLARE_INSTRUCTION(SWR)
     read_word_in_memory();
     if(address)
       {
-         word = ((unsigned int)*lsrtp << 16) | ((unsigned int) old_word & 0x0000FFFF);
+         cpu_word = ((unsigned int)*lsrtp << 16) | ((unsigned int) old_word & 0x0000FFFF);
          write_word_in_memory();
          CHECK_MEMORY();
       }
@@ -675,14 +675,14 @@ DECLARE_INSTRUCTION(SWR)
     read_word_in_memory();
     if(address)
       {
-         word = ((unsigned int)*lsrtp << 8) | ((unsigned int) old_word & 0x000000FF);
+         cpu_word = ((unsigned int)*lsrtp << 8) | ((unsigned int) old_word & 0x000000FF);
          write_word_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 3:
     address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
-    word = (unsigned int)*lsrtp;
+    cpu_word = (unsigned int)*lsrtp;
     write_word_in_memory();
     CHECK_MEMORY();
     break;
@@ -752,7 +752,7 @@ DECLARE_INSTRUCTION(SC)
    if(llbit)
    {
       address = (unsigned int) lsaddr;
-      word = (unsigned int)(*lsrtp & 0xFFFFFFFF);
+      cpu_word = (unsigned int)(*lsrtp & 0xFFFFFFFF);
       write_word_in_memory();
       CHECK_MEMORY();
       llbit = 0;
@@ -771,7 +771,7 @@ DECLARE_INSTRUCTION(SWC1)
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
    address = (unsigned int) lslfaddr;
-   word = *((int*)reg_cop1_simple[lslfft]);
+   cpu_word = *((int*)reg_cop1_simple[lslfft]);
    write_word_in_memory();
    CHECK_MEMORY();
 }
@@ -783,7 +783,7 @@ DECLARE_INSTRUCTION(SDC1)
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
    address = (unsigned int) lslfaddr;
-   dword = *((unsigned long long*)reg_cop1_double[lslfft]);
+   cpu_dword = *((unsigned long long*)reg_cop1_double[lslfft]);
    write_dword_in_memory();
    CHECK_MEMORY();
 }
@@ -794,7 +794,7 @@ DECLARE_INSTRUCTION(SD)
    long long int *lsrtp = PC->f.i.rt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
-   dword = *lsrtp;
+   cpu_dword = *lsrtp;
    write_dword_in_memory();
    CHECK_MEMORY();
 }

--- a/src/r4300/new_dynarec/assem_arm.c
+++ b/src/r4300/new_dynarec/assem_arm.c
@@ -2807,12 +2807,12 @@ static void do_writestub(int n)
   if(type==STOREB_STUB)
     emit_writebyte(rt,(int)&cpu_byte);
   if(type==STOREH_STUB)
-    emit_writehword(rt,(int)&hword);
+    emit_writehword(rt,(int)&cpu_hword);
   if(type==STOREW_STUB)
-    emit_writeword(rt,(int)&word);
+    emit_writeword(rt,(int)&cpu_word);
   if(type==STORED_STUB) {
-    emit_writeword(rt,(int)&dword);
-    emit_writeword(r?rth:rt,(int)&dword+4);
+    emit_writeword(rt,(int)&cpu_dword);
+    emit_writeword(r?rth:rt,(int)&cpu_dword+4);
   }
   //emit_pusha();
   save_regs(reglist);
@@ -2874,12 +2874,12 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
   if(type==STOREB_STUB)
     emit_writebyte(rt,(int)&cpu_byte);
   if(type==STOREH_STUB)
-    emit_writehword(rt,(int)&hword);
+    emit_writehword(rt,(int)&cpu_hword);
   if(type==STOREW_STUB)
-    emit_writeword(rt,(int)&word);
+    emit_writeword(rt,(int)&cpu_word);
   if(type==STORED_STUB) {
-    emit_writeword(rt,(int)&dword);
-    emit_writeword(target?rth:rt,(int)&dword+4);
+    emit_writeword(rt,(int)&cpu_dword);
+    emit_writeword(target?rth:rt,(int)&cpu_dword+4);
   }
   //emit_pusha();
   save_regs(reglist);

--- a/src/r4300/new_dynarec/assem_x86.c
+++ b/src/r4300/new_dynarec/assem_x86.c
@@ -28,9 +28,12 @@ int branch_target;
 uint64_t readmem_dword;
 static precomp_instr fake_pc;
 u_int memory_map[1048576];
-static u_int mini_ht[32][2]  __attribute__((aligned(8)));
-u_char restore_candidate[512]  __attribute__((aligned(4)));
+ALIGN(8, static u_int mini_ht[32][2]);
+ALIGN(4, u_char restore_candidate[512]);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void do_interrupt();
 void jump_vaddr_eax();
 void jump_vaddr_ecx();
@@ -38,6 +41,9 @@ void jump_vaddr_edx();
 void jump_vaddr_ebx();
 void jump_vaddr_ebp();
 void jump_vaddr_edi();
+#ifdef __cplusplus
+}
+#endif
 
 static const u_int jump_vaddr_reg[8] = {
   (int)jump_vaddr_eax,
@@ -49,6 +55,9 @@ static const u_int jump_vaddr_reg[8] = {
   0,
   (int)jump_vaddr_edi };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 void invalidate_block_eax();
 void invalidate_block_ecx();
 void invalidate_block_edx();
@@ -56,6 +65,9 @@ void invalidate_block_ebx();
 void invalidate_block_ebp();
 void invalidate_block_esi();
 void invalidate_block_edi();
+#ifdef __cplusplus
+}
+#endif
 
 static const u_int invalidate_block_reg[8] = {
   (int)invalidate_block_eax,
@@ -104,13 +116,13 @@ static void set_jump_target(int addr,int target)
 
 static void *kill_pointer(void *stub)
 {
-  int *i_ptr=*((int **)(stub+6));
+  int *i_ptr=*((int **)((int)stub+6));
   *i_ptr=(int)stub-(int)i_ptr-4;
   return i_ptr;
 }
 static int get_pointer(void *stub)
 {
-  int *i_ptr=*((int **)(stub+6));
+  int *i_ptr=*((int **)((int)stub+6));
   return *i_ptr+(int)i_ptr+4;
 }
 
@@ -741,7 +753,7 @@ static void multdiv_alloc_x86(struct regstat *current,int i)
 
 /* Assembler */
 
-static const char const regname[8][4] = {
+static const char regname[8][4] = {
  "eax",
  "ecx",
  "edx",
@@ -2698,7 +2710,7 @@ static void do_readstub(int n)
   // but not doing so causes random crashes...
   emit_readword((int)&g_cp0_regs[CP0_COUNT_REG],HOST_CCREG);
   emit_readword((int)&next_interupt,ECX);
-  emit_addimm(HOST_CCREG,-CLOCK_DIVIDER*(stubs[n][6]+1),HOST_CCREG);
+  emit_addimm(HOST_CCREG,-(int)CLOCK_DIVIDER*(stubs[n][6]+1),HOST_CCREG);
   emit_sub(HOST_CCREG,ECX,HOST_CCREG);
   emit_writeword(ECX,(int)&last_count);
   emit_storereg(CCREG,HOST_CCREG);
@@ -2793,7 +2805,7 @@ static void inline_readstub(int type, int i, u_int addr, signed char regmap[], i
   // but not doing so causes random crashes...
   emit_readword((int)&g_cp0_regs[CP0_COUNT_REG],HOST_CCREG);
   emit_readword((int)&next_interupt,ECX);
-  emit_addimm(HOST_CCREG,-CLOCK_DIVIDER*(adj+1),HOST_CCREG);
+  emit_addimm(HOST_CCREG,-(int)CLOCK_DIVIDER*(adj+1),HOST_CCREG);
   emit_sub(HOST_CCREG,ECX,HOST_CCREG);
   emit_writeword(ECX,(int)&last_count);
   emit_storereg(CCREG,HOST_CCREG);
@@ -2899,7 +2911,7 @@ static void do_writestub(int n)
   emit_callreg(addr);
   emit_readword((int)&g_cp0_regs[CP0_COUNT_REG],HOST_CCREG);
   emit_readword((int)&next_interupt,ECX);
-  emit_addimm(HOST_CCREG,-CLOCK_DIVIDER*(stubs[n][6]+1),HOST_CCREG);
+  emit_addimm(HOST_CCREG,-(int)CLOCK_DIVIDER*(stubs[n][6]+1),HOST_CCREG);
   emit_sub(HOST_CCREG,ECX,HOST_CCREG);
   emit_writeword(ECX,(int)&last_count);
   emit_storereg(CCREG,HOST_CCREG);
@@ -2982,7 +2994,7 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
   emit_call(((u_int *)ftable)[addr>>16]);
   emit_readword((int)&g_cp0_regs[CP0_COUNT_REG],HOST_CCREG);
   emit_readword((int)&next_interupt,ECX);
-  emit_addimm(HOST_CCREG,-CLOCK_DIVIDER*(adj+1),HOST_CCREG);
+  emit_addimm(HOST_CCREG,-(int)CLOCK_DIVIDER*(adj+1),HOST_CCREG);
   emit_sub(HOST_CCREG,ECX,HOST_CCREG);
   emit_writeword(ECX,(int)&last_count);
   emit_storereg(CCREG,HOST_CCREG);
@@ -3506,7 +3518,7 @@ static void cop0_assemble(int i,struct regstat *i_regs)
     if(copr==9||copr==11||copr==12) {
       emit_readword((int)&g_cp0_regs[CP0_COUNT_REG],HOST_CCREG);
       emit_readword((int)&next_interupt,ECX);
-      emit_addimm(HOST_CCREG,-CLOCK_DIVIDER*ccadj[i],HOST_CCREG);
+      emit_addimm(HOST_CCREG,-(int)CLOCK_DIVIDER*ccadj[i],HOST_CCREG);
       emit_sub(HOST_CCREG,ECX,HOST_CCREG);
       emit_writeword(ECX,(int)&last_count);
       emit_storereg(CCREG,HOST_CCREG);

--- a/src/r4300/new_dynarec/assem_x86.c
+++ b/src/r4300/new_dynarec/assem_x86.c
@@ -2857,12 +2857,12 @@ static void do_writestub(int n)
   if(type==STOREB_STUB)
     emit_writebyte(rt,(int)&cpu_byte);
   if(type==STOREH_STUB)
-    emit_writehword(rt,(int)&hword);
+    emit_writehword(rt,(int)&cpu_hword);
   if(type==STOREW_STUB)
-    emit_writeword(rt,(int)&word);
+    emit_writeword(rt,(int)&cpu_word);
   if(type==STORED_STUB) {
-    emit_writeword(rt,(int)&dword);
-    emit_writeword(r?rth:rt,(int)&dword+4);
+    emit_writeword(rt,(int)&cpu_dword);
+    emit_writeword(r?rth:rt,(int)&cpu_dword+4);
   }
   emit_pusha();
   ds=i_regs!=&regs[i];
@@ -2931,12 +2931,12 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
   if(type==STOREB_STUB)
     emit_writebyte(rt,(int)&cpu_byte);
   if(type==STOREH_STUB)
-    emit_writehword(rt,(int)&hword);
+    emit_writehword(rt,(int)&cpu_hword);
   if(type==STOREW_STUB)
-    emit_writeword(rt,(int)&word);
+    emit_writeword(rt,(int)&cpu_word);
   if(type==STORED_STUB) {
-    emit_writeword(rt,(int)&dword);
-    emit_writeword(target?rth:rt,(int)&dword+4);
+    emit_writeword(rt,(int)&cpu_dword);
+    emit_writeword(target?rth:rt,(int)&cpu_dword+4);
   }
   emit_pusha();
   if((signed int)addr>=(signed int)0xC0000000) {

--- a/src/r4300/new_dynarec/assem_x86.h
+++ b/src/r4300/new_dynarec/assem_x86.h
@@ -14,7 +14,14 @@
 
 #define USE_MINI_HT 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void *base_addr; // Code generator target address
+#ifdef __cplusplus
+}
+#endif
+
 #define TARGET_SIZE_2 25 // 2^25 = 32 megabytes
 #define JUMP_TABLE_SIZE 0 // Not needed for 32-bit x86
 

--- a/src/r4300/new_dynarec/linkage_arm.S
+++ b/src/r4300/new_dynarec/linkage_arm.S
@@ -83,12 +83,12 @@
 	.hidden address
 	.global	readmem_dword
 	.hidden readmem_dword
-	.global	dword
-	.hidden dword
-	.global	word
-	.hidden word
-	.global	hword
-	.hidden hword
+	.global	cpu_dword
+	.hidden cpu_dword
+	.global	cpu_word
+	.hidden cpu_word
+	.global	cpu_hword
+	.hidden cpu_hword
 	.global	cpu_byte
 	.hidden cpu_byte
 	.global	branch_target
@@ -141,19 +141,19 @@ address = invc_ptr + 4
 readmem_dword = address + 4
 	.type	readmem_dword, %object
 	.size	readmem_dword, 8
-dword = readmem_dword + 8
-	.type	dword, %object
-	.size	dword, 8
-word = dword + 8
-	.type	word, %object
-	.size	word, 4
-hword = word + 4
-	.type	hword, %object
-	.size	hword, 2
-cpu_byte = hword + 2
+cpu_dword = readmem_dword + 8
+	.type	cpu_dword, %object
+	.size	cpu_dword, 8
+cpu_word = cpu_dword + 8
+	.type	cpu_word, %object
+	.size	cpu_word, 4
+cpu_hword = cpu_word + 4
+	.type	cpu_hword, %object
+	.size	cpu_hword, 2
+cpu_byte = cpu_hword + 2
 	.type	cpu_byte, %object
 	.size	cpu_byte, 1 /* 1 byte free */
-FCR0 = hword + 4
+FCR0 = cpu_hword + 4
 	.type	FCR0, %object
 	.size	FCR0, 4
 FCR31 = FCR0 + 4
@@ -933,7 +933,7 @@ invalidate_addr_call:
 write_rdram_new:
 	ldr	r3, [fp, #ram_offset-dynarec_local]
 	ldr	r2, [fp, #address-dynarec_local]
-	ldr	r0, [fp, #word-dynarec_local]
+	ldr	r0, [fp, #cpu_word-dynarec_local]
 	str	r0, [r2, r3, lsl #2]
 	b	.E12
 	.size	write_rdram_new, .-write_rdram_new
@@ -956,7 +956,7 @@ write_rdramb_new:
 write_rdramh_new:
 	ldr	r3, [fp, #ram_offset-dynarec_local]
 	ldr	r2, [fp, #address-dynarec_local]
-	ldrh	r0, [fp, #hword-dynarec_local]
+	ldrh	r0, [fp, #cpu_hword-dynarec_local]
 	eor	r2, r2, #2
 	lsl	r3, r3, #2
 	strh	r0, [r2, r3]
@@ -969,9 +969,9 @@ write_rdramh_new:
 write_rdramd_new:
 	ldr	r3, [fp, #ram_offset-dynarec_local]
 	ldr	r2, [fp, #address-dynarec_local]
-/*	ldrd	r0, [fp, #dword-dynarec_local]*/
-	ldr	r0, [fp, #dword-dynarec_local]
-	ldr	r1, [fp, #dword+4-dynarec_local]
+/*	ldrd	r0, [fp, #cpu_dword-dynarec_local]*/
+	ldr	r0, [fp, #cpu_dword-dynarec_local]
+	ldr	r1, [fp, #cpu_dword+4-dynarec_local]
 	add	r3, r2, r3, lsl #2
 	str	r0, [r3, #4]
 	str	r1, [r3]
@@ -1078,7 +1078,7 @@ write_nomem_new:
 	mov	r1, #0xc
 	tst	r12, #0x40000000
 	bne	tlb_exception
-	ldr	r0, [fp, #word-dynarec_local]
+	ldr	r0, [fp, #cpu_word-dynarec_local]
 	str	r0, [r2, r12, lsl #2]
 	mov	pc, lr
 	.size	write_nomem_new, .-write_nomem_new
@@ -1122,7 +1122,7 @@ write_nomemh_new:
 	lsls	r12, #2
 	bcs	tlb_exception
 	eor	r2, r2, #2
-	ldrh	r0, [fp, #hword-dynarec_local]
+	ldrh	r0, [fp, #cpu_hword-dynarec_local]
 	strh	r0, [r2, r12]
 	mov	pc, lr
 	.size	write_nomemh_new, .-write_nomemh_new
@@ -1144,8 +1144,8 @@ write_nomemd_new:
 	lsls	r12, #2
 	bcs	tlb_exception
 	add	r3, r2, #4
-	ldr	r0, [fp, #dword+4-dynarec_local]
-	ldr	r1, [fp, #dword-dynarec_local]
+	ldr	r0, [fp, #cpu_dword+4-dynarec_local]
+	ldr	r1, [fp, #cpu_dword-dynarec_local]
 /*	strd	r0, [r2, r12]*/
 	str	r0, [r2, r12]
 	str	r1, [r3, r12]

--- a/src/r4300/new_dynarec/linkage_x86.S
+++ b/src/r4300/new_dynarec/linkage_x86.S
@@ -675,7 +675,7 @@ invalidate_block_call:
 	.type	write_rdram_new, @function
 write_rdram_new:
 	mov	address, %edi
-	mov	word, %ecx
+	mov	cpu_word, %ecx
 	mov	%ecx, g_rdram-0x80000000(%edi)
 	jmp	.E12
 	.size	write_rdram_new, .-write_rdram_new
@@ -697,7 +697,7 @@ write_rdramb_new:
 write_rdramh_new:
 	mov	address, %edi
 	xor	$2, %edi
-	movw	hword, %cx
+	movw	cpu_hword, %cx
 	movw	%cx, g_rdram-0x80000000(%edi)
 	jmp	.E12
 	.size	write_rdramh_new, .-write_rdramh_new
@@ -707,8 +707,8 @@ write_rdramh_new:
 	.type	write_rdramd_new, @function
 write_rdramd_new:
 	mov	address, %edi
-	mov	dword+4, %ecx
-	mov	dword, %edx
+	mov	cpu_dword+4, %ecx
+	mov	cpu_dword, %edx
 	mov	%ecx, g_rdram-0x80000000(%edi)
 	mov	%edx, g_rdram-0x80000000+4(%edi)
 	jmp	.E12
@@ -803,7 +803,7 @@ read_nomemd_new:
 write_nomem_new:
 	call	do_invalidate
 	mov	memory_map(,%edi,4),%edi
-	mov	word, %ecx
+	mov	cpu_word, %ecx
 	mov	$0xc, %eax
 	shl	$2, %edi
 	jc	tlb_exception
@@ -832,7 +832,7 @@ write_nomemb_new:
 write_nomemh_new:
 	call	do_invalidate
 	mov	memory_map(,%edi,4),%edi
-	movw	hword, %cx
+	movw	cpu_hword, %cx
 	mov	$0xc, %eax
 	shl	$2, %edi
 	jc	tlb_exception
@@ -847,8 +847,8 @@ write_nomemh_new:
 write_nomemd_new:
 	call	do_invalidate
 	mov	memory_map(,%edi,4),%edi
-	mov	dword+4, %edx
-	mov	dword, %ecx
+	mov	cpu_dword+4, %edx
+	mov	cpu_dword, %ecx
 	mov	$0xc, %eax
 	shl	$2, %edi
 	jc	tlb_exception

--- a/src/r4300/new_dynarec/linkage_x86.asm
+++ b/src/r4300/new_dynarec/linkage_x86.asm
@@ -1,0 +1,873 @@
+;Mupen64plus - linkage_x86.asm                                           
+;Copyright (C) 2009-2011 Ari64                                         
+;                                                                      
+;This program is free software; you can redistribute it and/or modify  
+;it under the terms of the GNU General Public License as published by  
+;the Free Software Foundation; either version 2 of the License, or     
+;(at your option) any later version.                                   
+;                                                                      
+;This program is distributed in the hope that it will be useful,       
+;but WITHOUT ANY WARRANTY; without even the implied warranty of        
+;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         
+;GNU General Public License for more details.                          
+;                                                                      
+;You should have received a copy of the GNU General Public License     
+;along with this program; if not, write to the                         
+;Free Software Foundation, Inc.,                                       
+;51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          
+
+%ifdef WIN32
+    %macro  cglobal 1
+      global  _%1
+      %define %1 _%1
+    %endmacro
+
+    %macro  cextern 1
+      extern  _%1
+      %define %1 _%1
+    %endmacro
+%else
+    %macro  cglobal 1
+      global  %1
+    %endmacro
+    
+    %macro  cextern 1
+      extern  %1
+    %endmacro
+%endif
+
+cglobal dyna_linker
+cglobal dyna_linker_ds
+cglobal jump_vaddr_eax
+cglobal jump_vaddr_ecx
+cglobal jump_vaddr_edx
+cglobal jump_vaddr_ebx
+cglobal jump_vaddr_ebp
+cglobal jump_vaddr_edi
+cglobal verify_code_ds
+cglobal verify_code_vm
+cglobal verify_code
+cglobal cc_interrupt
+cglobal do_interrupt
+cglobal fp_exception
+cglobal fp_exception_ds
+cglobal jump_syscall
+cglobal jump_eret
+cglobal new_dyna_start
+cglobal invalidate_block_eax
+cglobal invalidate_block_ecx
+cglobal invalidate_block_edx
+cglobal invalidate_block_ebx
+cglobal invalidate_block_ebp
+cglobal invalidate_block_esi
+cglobal invalidate_block_edi
+cglobal write_rdram_new
+cglobal write_rdramb_new
+cglobal write_rdramh_new
+cglobal write_rdramd_new
+cglobal read_nomem_new
+cglobal read_nomemb_new
+cglobal read_nomemh_new
+cglobal read_nomemd_new
+cglobal write_nomem_new
+cglobal write_nomemb_new
+cglobal write_nomemh_new
+cglobal write_nomemd_new
+cglobal breakpoint
+
+cextern base_addr
+cextern tlb_LUT_r
+cextern jump_in
+cextern add_link
+cextern hash_table
+cextern jump_dirty
+cextern new_recompile_block
+cextern g_cp0_regs
+cextern get_addr_ht
+cextern cycle_count
+cextern get_addr
+cextern branch_target
+cextern memory_map
+cextern pending_exception
+cextern restore_candidate
+cextern gen_interupt
+cextern next_interupt
+cextern stop
+cextern last_count
+cextern pcaddr
+cextern clean_blocks
+cextern reg
+cextern hi
+cextern lo
+cextern invalidate_block
+cextern address
+cextern rdram
+cextern cpu_byte
+cextern cpu_hword
+cextern cpu_word
+cextern cpu_dword
+cextern invalid_code
+cextern readmem_dword
+cextern check_interupt
+cextern get_addr_32
+
+section .bss
+align 4
+
+section .rodata
+section .text
+
+dyna_linker:
+    ;eax = virtual target address
+    ;ebx = instruction to patch
+    mov     edi,    eax
+    mov     ecx,    eax
+    shr     edi,    12
+    cmp     eax,    0C0000000h
+    cmovge  ecx,    [tlb_LUT_r+edi*4]
+    test    ecx,    ecx
+    cmovz   ecx,    eax
+    xor     ecx,    080000000h
+    mov     edx,    2047
+    shr     ecx,    12
+    and     edx,    ecx
+    or      edx,    2048
+    cmp     ecx,    edx
+    cmova   ecx,    edx
+    ;jump_in lookup
+    mov     edx,    [jump_in+ecx*4]
+_A1:
+    test    edx,    edx
+    je      _A3
+    mov     edi,    [edx]
+    xor     edi,    eax
+    or      edi,    [4+edx]
+    je      _A2
+    mov     edx,    DWORD [12+edx]
+    jmp     _A1
+_A2:
+    mov     edi,    [ebx]
+    mov     ebp,    esi
+    lea     esi,    [4+ebx+edi*1]
+    mov     edi,    eax
+    pusha
+    call    add_link
+    popa
+    mov     edi,    [8+edx]
+    mov     esi,    ebp
+    lea     edx,    [-4+edi]
+    sub     edx,    ebx
+    mov     DWORD [ebx],    edx
+    jmp     edi
+_A3:
+    ;hash_table lookup
+    mov     edi,    eax
+    mov     edx,    eax
+    shr     edi,    16
+    shr     edx,    12
+    xor     edi,    eax
+    and     edx,    2047
+    movzx   edi,    di
+    shl     edi,    4
+    cmp     ecx,    2048
+    cmovc   ecx,    edx
+    cmp     eax,    [hash_table+edi]
+    jne     _A5
+_A4:
+    mov     edx,    [hash_table+4+edi]
+    jmp     edx
+_A5:
+    cmp     eax,    [hash_table+8+edi]
+    lea     edi,    [8+edi]
+    je      _A4
+    ;jump_dirty lookup
+    mov     edx,    [jump_dirty+ecx*4]
+_A6:
+    test    edx,    edx
+    je      _A8
+    mov     ecx,    [edx]
+    xor     ecx,    eax
+    or      ecx,    [4+edx]
+    je      _A7
+    mov     edx,    DWORD [12+edx]
+    jmp     _A6
+_A7:
+    mov     edx,    [8+edx]
+    ;hash_table insert
+    mov     ebx,    [hash_table-8+edi]
+    mov     ecx,    [hash_table-4+edi]
+    mov     [hash_table-8+edi],    eax
+    mov     [hash_table-4+edi],    edx
+    mov     [hash_table+edi],      ebx
+    mov     [hash_table+4+edi],    ecx
+    jmp     edx
+_A8:
+    mov     edi,    eax
+    pusha
+    call    new_recompile_block
+    test    eax,    eax
+    popa
+    je      dyna_linker
+    ;pagefault
+    mov     ebx,    eax
+    mov     ecx,    008h
+
+exec_pagefault:
+    ;eax = instruction pointer
+    ;ebx = fault address
+    ;ecx = cause
+    mov     edx,    [g_cp0_regs+48]
+    add     esp,    -12
+    mov     edi,    [g_cp0_regs+16]
+    or      edx,    2
+    mov     [g_cp0_regs+32],    ebx        ;BadVAddr
+    and     edi,    0FF80000Fh
+    mov     [g_cp0_regs+48],    edx        ;Status
+    mov     [g_cp0_regs+52],    ecx        ;Cause
+    mov     [g_cp0_regs+56],    eax        ;EPC
+    mov     ecx,    ebx
+    shr     ebx,    9
+    and     ecx,    0FFFFE000h
+    and     ebx,    0007FFFF0h
+    mov     [g_cp0_regs+40],    ecx        ;EntryHI
+    or      edi,    ebx
+    mov     [g_cp0_regs+16],    edi        ;Context
+    push     080000000h
+    call    get_addr_ht
+    add     esp,    16
+    jmp     eax
+
+;Special dynamic linker for the case where a page fault
+;may occur in a branch delay slot
+dyna_linker_ds:
+    mov     edi,    eax
+    mov     ecx,    eax
+    shr     edi,    12
+    cmp     eax,    0C0000000h
+    cmovge  ecx,    [tlb_LUT_r+edi*4]
+    test    ecx,    ecx
+    cmovz   ecx,    eax
+    xor     ecx,    080000000h
+    mov     edx,    2047
+    shr     ecx,    12
+    and     edx,    ecx
+    or      edx,    2048
+    cmp     ecx,    edx
+    cmova   ecx,    edx
+    ;jump_in lookup
+    mov     edx,    [jump_in+ecx*4]
+_B1:
+    test    edx,    edx
+    je      _B3
+    mov     edi,    [edx]
+    xor     edi,    eax
+    or      edi,    [4+edx]
+    je      _B2
+    mov     edx,    DWORD [12+edx]
+    jmp     _B1
+_B2:
+    mov     edi,    [ebx]
+    mov     ecx,    esi
+    lea     esi,    [4+ebx+edi*1]
+    mov     edi,    eax
+    pusha
+    call    add_link
+    popa
+    mov     edi,    [8+edx]
+    mov     esi,    ecx
+    lea     edx,    [-4+edi]
+    sub     edx,    ebx
+    mov     DWORD [ebx],    edx
+    jmp     edi
+_B3:
+    ;hash_table lookup
+    mov     edi,    eax
+    mov     edx,    eax
+    shr     edi,    16
+    shr     edx,    12
+    xor     edi,    eax
+    and     edx,    2047
+    movzx   edi,    di
+    shl     edi,    4
+    cmp     ecx,    2048
+    cmovc   ecx,    edx
+    cmp     eax,    [hash_table+edi]
+    jne     _B5
+_B4:
+    mov     edx,    [hash_table+4+edi]
+    jmp     edx
+_B5:
+    cmp     eax,    [hash_table+8+edi]
+    lea     edi,    [8+edi]
+    je      _B4
+    ;jump_dirty lookup
+    mov     edx,    [jump_dirty+ecx*4]
+_B6:
+    test    edx,    edx
+    je      _B8
+    mov     ecx,    [edx]
+    xor     ecx,    eax
+    or      ecx,    [4+edx]
+    je      _B7
+    mov     edx,    DWORD [12+edx]
+    jmp     _B6
+_B7:
+    mov     edx,    [8+edx]
+    ;hash_table insert
+    mov     ebx,    [hash_table-8+edi]
+    mov     ecx,    [hash_table-4+edi]
+    mov     [hash_table-8+edi],    eax
+    mov     [hash_table-4+edi],    edx
+    mov     [hash_table+edi],      ebx
+    mov     [hash_table+4+edi],    ecx
+    jmp     edx
+_B8:
+    mov     edi,    eax
+    and     edi,    0FFFFFFF8h
+    inc     edi
+    pusha
+    call    new_recompile_block
+    test    eax,    eax
+    popa
+    je      dyna_linker_ds
+    ;pagefault
+    and     eax,    0FFFFFFF8h
+    mov     ecx,    080000008h    ;High bit set indicates pagefault in delay slot 
+    mov     ebx,    eax
+    sub     eax,    4
+    jmp     exec_pagefault
+
+jump_vaddr_eax:
+    mov     edi,    eax
+    jmp     jump_vaddr_edi
+
+jump_vaddr_ecx:
+    mov     edi,    ecx
+    jmp     jump_vaddr_edi
+
+jump_vaddr_edx:
+    mov     edi,    edx
+    jmp     jump_vaddr_edi
+
+jump_vaddr_ebx:
+    mov     edi,    ebx
+    jmp     jump_vaddr_edi
+
+jump_vaddr_ebp:
+    mov     edi,    ebp
+
+jump_vaddr_edi:
+    mov     eax,    edi
+
+jump_vaddr:
+    ;Check hash table
+    shr     eax,    16
+    xor     eax,    edi
+    movzx   eax,    ax
+    shl     eax,    4
+    cmp     edi,    [hash_table+eax]
+    jne     _C2
+_C1:
+    mov     edi,    [hash_table+4+eax]
+    jmp     edi
+_C2:
+    cmp     edi,    [hash_table+8+eax]
+    lea     eax,    [8+eax]
+    je      _C1
+    ;No hit on hash table, call compiler
+    add     esp,    -12
+    push    edi
+    mov     [cycle_count],    esi    ;CCREG
+    call    get_addr
+    mov     esi,    [cycle_count]
+    add     esp,    16
+    jmp     eax
+
+verify_code_ds:
+    mov     [branch_target],    ebp
+
+verify_code_vm:
+    ;eax = source (virtual address)
+    ;ebx = target
+    ;ecx = length
+    cmp     eax,    0C0000000h
+    jl      verify_code
+    mov     edx,    eax
+    lea     ebp,    [-1+eax+ecx*1]
+    shr     edx,    12
+    shr     ebp,    12
+    mov     edi,    [memory_map+edx*4]
+    test    edi,    edi
+    js      _D5
+    lea     eax,    [eax+edi*4]
+_D1:
+    xor     edi,    [memory_map+edx*4]
+    shl     edi,    2
+    jne     _D5
+    mov     edi,    [memory_map+edx*4]
+    inc     edx
+    cmp     edx,    ebp
+    jbe     _D1
+
+verify_code:
+    ;eax = source
+    ;ebx = target
+    ;ecx = length
+    mov     edi,    [-4+eax+ecx*1]
+    xor     edi,    [-4+ebx+ecx*1]
+    jne     _D5
+    mov     edx,    ecx
+    add     ecx,    -4
+    je      _D3
+    test    edx,    4
+    cmove   ecx,    edx
+    mov     [cycle_count],    esi
+_D2:
+    mov     edx,    [-4+eax+ecx*1]
+    mov     ebp,    [-4+ebx+ecx*1]
+    mov     esi,    [-8+eax+ecx*1]
+    xor     ebp,    edx
+    mov     edi,    [-8+ebx+ecx*1]
+    jne     _D4
+    xor     edi,    esi
+    jne     _D4
+    add     ecx,    -8
+    jne     _D2
+    mov     esi,    [cycle_count]
+    mov     ebp,    [branch_target]
+_D3:
+    ret
+_D4:
+    mov     esi,    [cycle_count]
+_D5:
+    mov     ebp,    [branch_target]
+    push    esi           ;for stack alignment, unused
+    push    DWORD [8+esp]
+    call    get_addr
+    add     esp,    16    ;pop stack
+    jmp     eax
+
+cc_interrupt:
+    add     esi,    [last_count]
+    add     esp,    -28                 ;Align stack
+    mov     [g_cp0_regs+36],    esi    ;Count
+    shr     esi,    19
+    mov     DWORD [pending_exception],    0
+    and     esi,    07fh
+    cmp     DWORD [restore_candidate+esi*4],    0
+    jne     _E4
+_E1:
+    call    gen_interupt
+    mov     esi,    [g_cp0_regs+36]
+    mov     eax,    [next_interupt]
+    mov     ebx,    [pending_exception]
+    mov     ecx,    [stop]
+    add     esp,    28
+    mov     [last_count],    eax
+    sub     esi,    eax
+    test    ecx,    ecx
+    jne     _E3
+    test    ebx,    ebx
+    jne     _E2
+    ret
+_E2:
+    add     esp,    -8
+    mov     edi,    [pcaddr]
+    mov     [cycle_count],    esi    ;CCREG
+    push    edi
+    call    get_addr_ht
+    mov     esi,    [cycle_count]
+    add     esp,    16
+    jmp     eax
+_E3:
+    add     esp,    16     ;pop stack
+    pop     edi            ;restore edi
+    pop     esi            ;restore esi
+    pop     ebx            ;restore ebx
+    pop     ebp            ;restore ebp
+    ret                    ;exit dynarec
+_E4:
+    ;Move 'dirty' blocks to the 'clean' list
+    mov     ebx,    [restore_candidate+esi*4]
+    mov     ebp,    esi
+    mov     DWORD [restore_candidate+esi*4],    0
+    shl     ebp,    5
+_E5:
+    shr     ebx,    1
+    jnc     _E6
+    mov     [esp],    ebp
+    call    clean_blocks
+_E6:
+    inc     ebp
+    test    ebp,    31
+    jne     _E5
+    jmp     _E1
+
+do_interrupt:
+    mov     edi,    [pcaddr]
+    add     esp,    -12
+    push    edi
+    call    get_addr_ht
+    add     esp,    16
+    mov     esi,    [g_cp0_regs+36]
+    mov     ebx,    [next_interupt]
+    mov     [last_count],    ebx
+    sub     esi,    ebx
+    add     esi,    2
+    jmp     eax
+
+fp_exception:
+    mov     edx,    01000002ch
+_E7:
+    mov     ebx,    [g_cp0_regs+48]
+    add     esp,    -12
+    or      ebx,    2
+    mov     [g_cp0_regs+48],    ebx     ;Status
+    mov     [g_cp0_regs+52],    edx     ;Cause
+    mov     [g_cp0_regs+56],    eax     ;EPC
+    push    080000180h
+    call    get_addr_ht
+    add     esp,    16
+    jmp     eax
+
+fp_exception_ds:
+    mov     edx,    09000002ch    ;Set high bit if delay slot
+    jmp     _E7
+
+jump_syscall:
+    mov     edx,    020h
+    mov     ebx,    [g_cp0_regs+48]
+    add     esp,    -12
+    or      ebx,    2
+    mov     [g_cp0_regs+48],    ebx     ;Status
+    mov     [g_cp0_regs+52],    edx     ;Cause
+    mov     [g_cp0_regs+56],    eax     ;EPC
+    push    080000180h
+    call    get_addr_ht
+    add     esp,    16
+    jmp     eax
+
+jump_eret:
+    mov     ebx,    [g_cp0_regs+48]        ;Status
+    add     esi,    [last_count]
+    and     ebx,    0FFFFFFFDh
+    mov     [g_cp0_regs+36],    esi        ;Count
+    mov     [g_cp0_regs+48],    ebx        ;Status
+    call    check_interupt
+    mov     eax,    [next_interupt]
+    mov     esi,    [g_cp0_regs+36]
+    mov     [last_count],    eax
+    sub     esi,    eax
+    mov     eax,    [g_cp0_regs+56]        ;EPC
+    jns     _E11
+_E8:
+    mov     ebx,    248
+    xor     edi,    edi
+_E9:
+    mov     ecx,    [reg+ebx]
+    mov     edx,    [reg+4+ebx]
+    sar     ecx,    31
+    xor     edx,    ecx
+    neg     edx
+    adc     edi,    edi
+    sub     ebx,    8
+    jne     _E9
+    mov     ecx,    [hi+ebx]
+    mov     edx,    [hi+4+ebx]
+    sar     ecx,    31
+    xor     edx,    ecx
+    jne     _E10
+    mov     ecx,    [lo+ebx]
+    mov     edx,    [lo+4+ebx]
+    sar     ecx,    31
+    xor     edx,    ecx
+_E10:
+    neg     edx
+    adc     edi,    edi
+    add     esp,    -8
+    push    edi
+    push    eax
+    mov     [cycle_count],    esi
+    call    get_addr_32
+    mov     esi,    [cycle_count]
+    add     esp,    16
+    jmp     eax
+_E11:
+    mov     [pcaddr],    eax
+    call    cc_interrupt
+    mov     eax,    [pcaddr]
+    jmp     _E8
+
+new_dyna_start:
+    push    ebp
+    push    ebx
+    push    esi
+    push    edi
+    add     esp,    -8    ;align stack
+    push    0a4000040h
+    call    new_recompile_block
+    mov     edi,    DWORD [next_interupt]
+    mov     esi,    DWORD [g_cp0_regs+36]
+    mov     DWORD [last_count],    edi
+    sub     esi,    edi
+    jmp     DWORD [base_addr]
+
+invalidate_block_eax:
+    push    eax
+    push    ecx
+    push    edx
+    push    eax
+    jmp     invalidate_block_call
+
+invalidate_block_ecx:
+    push    eax
+    push    ecx
+    push    edx
+    push    ecx
+    jmp     invalidate_block_call
+
+invalidate_block_edx:
+    push    eax
+    push    ecx
+    push    edx
+    push    edx
+    jmp     invalidate_block_call
+
+invalidate_block_ebx:
+    push    eax
+    push    ecx
+    push    edx
+    push    ebx
+    jmp     invalidate_block_call
+
+invalidate_block_ebp:
+    push    eax
+    push    ecx
+    push    edx
+    push    ebp
+    jmp     invalidate_block_call
+
+invalidate_block_esi:
+    push    eax
+    push    ecx
+    push    edx
+    push    esi
+    jmp     invalidate_block_call
+
+invalidate_block_edi:
+    push    eax
+    push    ecx
+    push    edx
+    push    edi
+
+invalidate_block_call:
+    call    invalidate_block
+    pop     eax ;Throw away
+    pop     edx
+    pop     ecx
+    pop     eax
+    ret
+
+write_rdram_new:
+    mov     edi,    [address]
+    mov     ecx,    [cpu_word]
+    mov     [rdram-0x80000000+edi],    ecx
+    jmp     _E12
+
+write_rdramb_new:
+    mov     edi,    [address]
+    xor     edi,    3
+    mov     cl,     BYTE [cpu_byte]
+    mov     BYTE [rdram-0x80000000+edi],    cl
+    jmp     _E12
+
+write_rdramh_new:
+    mov     edi,    [address]
+    xor     edi,    2
+    mov     cx,     WORD [cpu_hword]
+    mov     WORD [rdram-0x80000000+edi],    cx
+    jmp     _E12
+
+write_rdramd_new:
+    mov     edi,    [address]
+    mov     ecx,    [cpu_dword+4]
+    mov     edx,    [cpu_dword+0]
+    mov     [rdram-0x80000000+edi],      ecx
+    mov     [rdram-0x80000000+4+edi],    edx
+    jmp     _E12
+
+
+do_invalidate:
+    mov     edi,    [address]
+    mov     ebx,    edi    ;Return ebx to caller
+_E12:
+    shr     edi,    12
+    cmp     BYTE [invalid_code+edi],    1
+    je      _E13
+    push    edi
+    call    invalidate_block
+    pop     edi
+_E13:
+ret
+
+read_nomem_new:
+    mov     edi,    [address]
+    mov     ebx,    edi
+    shr     edi,    12
+    mov     edi,    [memory_map+edi*4]
+    mov     eax,    08h
+    test    edi,    edi
+    js      tlb_exception
+    mov     ecx,    [ebx+edi*4]
+    mov     [readmem_dword],    ecx
+    ret
+
+read_nomemb_new:
+    mov     edi,    [address]
+    mov     ebx,    edi
+    shr     edi,    12
+    mov     edi,    [memory_map+edi*4]
+    mov     eax,    08h
+    test    edi,    edi
+    js      tlb_exception
+    xor     ebx,    3
+    movzx   ecx,    BYTE [ebx+edi*4]
+    mov     [readmem_dword],    ecx
+    ret
+
+read_nomemh_new:
+    mov     edi,    [address]
+    mov     ebx,    edi
+    shr     edi,    12
+    mov     edi,    [memory_map+edi*4]
+    mov     eax,    08h
+    test    edi,    edi
+    js      tlb_exception
+    xor     ebx,    2
+    movzx   ecx,    WORD [ebx+edi*4]
+    mov     [readmem_dword],    ecx
+    ret
+
+read_nomemd_new:
+    mov     edi,    [address]
+    mov     ebx,    edi
+    shr     edi,    12
+    mov     edi,    [memory_map+edi*4]
+    mov     eax,    08h
+    test    edi,    edi
+    js      tlb_exception
+    mov     ecx,    [4+ebx+edi*4]
+    mov     edx,    [ebx+edi*4]
+    mov     [readmem_dword],      ecx
+    mov     [readmem_dword+4],    edx
+    ret
+
+write_nomem_new:
+    call    do_invalidate
+    mov     edi,    [memory_map+edi*4]
+    mov     ecx,    [cpu_word]
+    mov     eax,    0ch
+    shl     edi,    2
+    jc      tlb_exception
+    mov     [ebx+edi],    ecx
+    ret
+
+write_nomemb_new:
+    call    do_invalidate
+    mov     edi,    [memory_map+edi*4]
+    mov     cl,     BYTE [cpu_byte]
+    mov     eax,    0ch
+    shl     edi,    2
+    jc      tlb_exception
+    xor     ebx,    3
+    mov     BYTE [ebx+edi],    cl
+    ret
+
+write_nomemh_new:
+    call    do_invalidate
+    mov     edi,    [memory_map+edi*4]
+    mov     cx,     WORD [cpu_hword]
+    mov     eax,    0ch
+    shl     edi,    2
+    jc      tlb_exception
+    xor     ebx,    2
+    mov     WORD [ebx+edi],    cx
+    ret
+
+write_nomemd_new:
+    call    do_invalidate
+    mov     edi,    [memory_map+edi*4]
+    mov     edx,    [cpu_dword+4]
+    mov     ecx,    [cpu_dword+0]
+    mov     eax,    0ch
+    shl     edi,    2
+    jc      tlb_exception
+    mov     [ebx+edi],    edx
+    mov     [4+ebx+edi],    ecx
+    ret
+
+
+tlb_exception:
+    ;eax = cause
+    ;ebx = address
+    ;ebp = instr addr + flags
+    mov     ebp,    [024h+esp]
+;Debug: 
+    ;push    ebp
+    ;push    ebx
+    ;push    eax
+    ;call    tlb_debug
+    ;pop     eax
+    ;pop     ebx
+    ;pop     ebp
+;end debug
+    mov     esi,    [g_cp0_regs+48]
+    mov     ecx,    ebp
+    mov     edx,    ebp
+    mov     edi,    ebp
+    shl     ebp,    31
+    shr     ecx,    12
+    or      eax,    ebp
+    sar     ebp,    29
+    and     edx,    0FFFFFFFCh
+    mov     ecx,    [memory_map+ecx*4]
+    or      esi,    2
+    mov     ecx,    [edx+ecx*4]
+    add     edx,    ebp
+    mov     [g_cp0_regs+48],    esi    ;Status
+    mov     [g_cp0_regs+52],    eax    ;Cause
+    mov     [g_cp0_regs+56],    edx    ;EPC
+    add     esp,    024h
+    mov     edx,    06000022h
+    mov     ebp,    ecx
+    movsx   eax,    cx
+    shr     ecx,    26
+    shr     ebp,    21
+    sub     ebx,    eax
+    and     ebp,    01fh
+    ror     edx,    cl
+    mov     esi,    [g_cp0_regs+16]
+    cmovc   ebx,    [reg+ebp*8]
+    and     esi,    0FF80000Fh
+    mov     [reg+ebp*8],    ebx
+    add     eax,    ebx
+    sar     ebx,    31
+    mov     [g_cp0_regs+32],    eax    ;BadVAddr
+    shr     eax,    9
+    test    edi,    2
+    cmove   ebx,    [reg+4+ebp*8]
+    add     esp,    -12
+    and     eax,    0007FFFF0h
+    mov     [reg+4+ebp*8],    ebx
+    push    080000180h
+    or      esi,    eax
+    mov     [g_cp0_regs+16],    esi    ;Context
+    call    get_addr_ht
+    add     esp,    16
+    mov     edi,    DWORD [next_interupt]
+    mov     esi,    DWORD [g_cp0_regs+36]    ;Count
+    mov     DWORD [last_count],    edi
+    sub     esi,    edi
+    jmp     eax
+
+breakpoint:

--- a/src/r4300/new_dynarec/linkage_x86.asm
+++ b/src/r4300/new_dynarec/linkage_x86.asm
@@ -101,7 +101,7 @@ cextern hi
 cextern lo
 cextern invalidate_block
 cextern address
-cextern rdram
+cextern g_rdram
 cextern cpu_byte
 cextern cpu_hword
 cextern cpu_word
@@ -671,29 +671,29 @@ invalidate_block_call:
 write_rdram_new:
     mov     edi,    [address]
     mov     ecx,    [cpu_word]
-    mov     [rdram-0x80000000+edi],    ecx
+    mov     [g_rdram-0x80000000+edi],    ecx
     jmp     _E12
 
 write_rdramb_new:
     mov     edi,    [address]
     xor     edi,    3
     mov     cl,     BYTE [cpu_byte]
-    mov     BYTE [rdram-0x80000000+edi],    cl
+    mov     BYTE [g_rdram-0x80000000+edi],    cl
     jmp     _E12
 
 write_rdramh_new:
     mov     edi,    [address]
     xor     edi,    2
     mov     cx,     WORD [cpu_hword]
-    mov     WORD [rdram-0x80000000+edi],    cx
+    mov     WORD [g_rdram-0x80000000+edi],    cx
     jmp     _E12
 
 write_rdramd_new:
     mov     edi,    [address]
     mov     ecx,    [cpu_dword+4]
     mov     edx,    [cpu_dword+0]
-    mov     [rdram-0x80000000+edi],      ecx
-    mov     [rdram-0x80000000+4+edi],    edx
+    mov     [g_rdram-0x80000000+edi],      ecx
+    mov     [g_rdram-0x80000000+4+edi],    edx
     jmp     _E12
 
 

--- a/src/r4300/new_dynarec/linkage_x86.asm
+++ b/src/r4300/new_dynarec/linkage_x86.asm
@@ -16,7 +16,15 @@
 ;Free Software Foundation, Inc.,                                       
 ;51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          
 
-%ifdef WIN32
+%ifdef ELF_TYPE
+    %macro  cglobal 1
+      global  %1
+    %endmacro
+    
+    %macro  cextern 1
+      extern  %1
+    %endmacro
+%else
     %macro  cglobal 1
       global  _%1
       %define %1 _%1
@@ -25,14 +33,6 @@
     %macro  cextern 1
       extern  _%1
       %define %1 _%1
-    %endmacro
-%else
-    %macro  cglobal 1
-      global  %1
-    %endmacro
-    
-    %macro  cextern 1
-      extern  %1
     %endmacro
 %endif
 

--- a/src/r4300/new_dynarec/new_dynarec.h
+++ b/src/r4300/new_dynarec/new_dynarec.h
@@ -26,8 +26,14 @@
 #define NEW_DYNAREC_AMD64 2
 #define NEW_DYNAREC_ARM 3
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern int pcaddr;
 extern int pending_exception;
+#ifdef __cplusplus
+}
+#endif
 
 void invalidate_all_pages(void);
 void invalidate_block(unsigned int block);

--- a/src/r4300/x86/gr4300.c
+++ b/src/r4300/x86/gr4300.c
@@ -1612,7 +1612,7 @@ void gensh(void)
    
    mov_m32_imm32((unsigned int *)(&PC), (unsigned int)(dst+1)); // 10
    mov_m32_reg32((unsigned int *)(&address), EBX); // 6
-   mov_m16_reg16((unsigned short *)(&hword), CX); // 7
+   mov_m16_reg16((unsigned short *)(&cpu_hword), CX); // 7
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)writememh); // 7
    call_reg32(EBX); // 2
@@ -1674,7 +1674,7 @@ void gensw(void)
    
    mov_m32_imm32((unsigned int *)(&PC), (unsigned int)(dst+1)); // 10
    mov_m32_reg32((unsigned int *)(&address), EBX); // 6
-   mov_m32_reg32((unsigned int *)(&word), ECX); // 6
+   mov_m32_reg32((unsigned int *)(&cpu_word), ECX); // 6
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)writemem); // 7
    call_reg32(EBX); // 2
@@ -1885,7 +1885,7 @@ void genswc1(void)
    
    mov_m32_imm32((unsigned int *)(&PC), (unsigned int)(dst+1)); // 10
    mov_m32_reg32((unsigned int *)(&address), EBX); // 6
-   mov_m32_reg32((unsigned int *)(&word), ECX); // 6
+   mov_m32_reg32((unsigned int *)(&cpu_word), ECX); // 6
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)writemem); // 7
    call_reg32(EBX); // 2
@@ -1943,8 +1943,8 @@ void gensdc1(void)
    
    mov_m32_imm32((unsigned int *)(&PC), (unsigned int)(dst+1)); // 10
    mov_m32_reg32((unsigned int *)(&address), EBX); // 6
-   mov_m32_reg32((unsigned int *)(&dword), ECX); // 6
-   mov_m32_reg32((unsigned int *)(&dword)+1, EDX); // 6
+   mov_m32_reg32((unsigned int *)(&cpu_dword), ECX); // 6
+   mov_m32_reg32((unsigned int *)(&cpu_dword)+1, EDX); // 6
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)writememd); // 7
    call_reg32(EBX); // 2
@@ -2003,8 +2003,8 @@ void gensd(void)
    
    mov_m32_imm32((unsigned int *)(&PC), (unsigned int)(dst+1)); // 10
    mov_m32_reg32((unsigned int *)(&address), EBX); // 6
-   mov_m32_reg32((unsigned int *)(&dword), ECX); // 6
-   mov_m32_reg32((unsigned int *)(&dword)+1, EDX); // 6
+   mov_m32_reg32((unsigned int *)(&cpu_dword), ECX); // 6
+   mov_m32_reg32((unsigned int *)(&cpu_dword)+1, EDX); // 6
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)writememd); // 7
    call_reg32(EBX); // 2

--- a/src/r4300/x86_64/gr4300.c
+++ b/src/r4300/x86_64/gr4300.c
@@ -1737,7 +1737,7 @@ void gensh(void)
    mov_reg64_imm64(RAX, (unsigned long long) (dst+1)); // 10
    mov_m64rel_xreg64((unsigned long long *)(&PC), RAX); // 7
    mov_m32rel_xreg32((unsigned int *)(&address), EBX); // 7
-   mov_m16rel_xreg16((unsigned short *)(&hword), CX); // 8
+   mov_m16rel_xreg16((unsigned short *)(&cpu_hword), CX); // 8
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
    call_reg64(RBX); // 2
@@ -1812,7 +1812,7 @@ void gensw(void)
    mov_reg64_imm64(RAX, (unsigned long long) (dst+1)); // 10
    mov_m64rel_xreg64((unsigned long long *)(&PC), RAX); // 7
    mov_m32rel_xreg32((unsigned int *)(&address), EBX); // 7
-   mov_m32rel_xreg32((unsigned int *)(&word), ECX); // 7
+   mov_m32rel_xreg32((unsigned int *)(&cpu_word), ECX); // 7
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
    call_reg64(RBX); // 2
@@ -2065,7 +2065,7 @@ void genswc1(void)
    mov_reg64_imm64(RAX, (unsigned long long) (dst+1)); // 10
    mov_m64rel_xreg64((unsigned long long *)(&PC), RAX); // 7
    mov_m32rel_xreg32((unsigned int *)(&address), EBX); // 7
-   mov_m32rel_xreg32((unsigned int *)(&word), ECX); // 7
+   mov_m32rel_xreg32((unsigned int *)(&cpu_word), ECX); // 7
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
    call_reg64(RBX); // 2
@@ -2133,8 +2133,8 @@ void gensdc1(void)
    mov_reg64_imm64(RAX, (unsigned long long) (dst+1)); // 10
    mov_m64rel_xreg64((unsigned long long *)(&PC), RAX); // 7
    mov_m32rel_xreg32((unsigned int *)(&address), EBX); // 7
-   mov_m32rel_xreg32((unsigned int *)(&dword), ECX); // 7
-   mov_m32rel_xreg32((unsigned int *)(&dword)+1, EDX); // 7
+   mov_m32rel_xreg32((unsigned int *)(&cpu_dword), ECX); // 7
+   mov_m32rel_xreg32((unsigned int *)(&cpu_dword)+1, EDX); // 7
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
    call_reg64(RBX); // 2
@@ -2202,8 +2202,8 @@ void gensd(void)
    mov_reg64_imm64(RAX, (unsigned long long) (dst+1)); // 10
    mov_m64rel_xreg64((unsigned long long *)(&PC), RAX); // 7
    mov_m32rel_xreg32((unsigned int *)(&address), EBX); // 7
-   mov_m32rel_xreg32((unsigned int *)(&dword), ECX); // 7
-   mov_m32rel_xreg32((unsigned int *)(&dword)+1, EDX); // 7
+   mov_m32rel_xreg32((unsigned int *)(&cpu_dword), ECX); // 7
+   mov_m32rel_xreg32((unsigned int *)(&cpu_dword)+1, EDX); // 7
    shr_reg32_imm8(EBX, 16); // 3
    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
    call_reg64(RBX); // 2


### PR DESCRIPTION
Here's some instructions In order to build with the new_dynarec on windows:

MSVC2010:
-Open mupen64plus-ui-console solution property page
-Select "Configuration Properties"
-Change mupen64plus-core project configuration to New_Dynarec_Debug or New_Dynarec_Release depending if you're building in Debug or Release mode.

MINGW:
Use "make" with NEW_DYNAREC=1 