### PR TITLE
Add a MIPS support stanza for the Unix Makefile

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -104,6 +104,13 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
     $(warning Architecture "$(HOST_CPU)" not officially supported.')
   endif
 endif
+ifneq ("$(filter mips,$(HOST_CPU))","")
+  CPU := MIPS
+  ARCH_DETECTED := 32BITS
+  PIC ?= 1
+  NO_ASM := 1
+  $(warning Architecture "$(HOST_CPU)" not officially supported.')
+endif
 ifeq ("$(CPU)","NONE")
   $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
 endif


### PR DESCRIPTION
I attach a commit that adds preliminary unofficial support for compiling the Pure Interpreter and Cached Interpreter for little-endian MIPS as a build target.

I do not have access to a big-endian MIPS host to check its `uname -m` output. It is possible that my proposed stanza compiles for big-endian MIPS as if it were little-endian, if the output includes `mips` (for example `mipseb`). Given the low-level nature of the Core, such an incorrect compilation would give Undefined Behavior on the emulated N64 from the execution of its very first opcode due to its entire address space having the wrong endianness.