### PR TITLE
Si refactorings

### DIFF
--- a/projects/msvc11/mupen64plus-core.vcxproj
+++ b/projects/msvc11/mupen64plus-core.vcxproj
@@ -136,6 +136,7 @@
     <ClCompile Include="..\..\src\r4300\exception.c" />
     <ClCompile Include="..\..\src\rdp\fb.c" />
     <ClCompile Include="..\..\src\osal\files_win32.c" />
+    <ClCompile Include="..\..\src\main\fla_file.c" />
     <ClCompile Include="..\..\src\pi\flashram.c" />
     <ClCompile Include="..\..\src\api\frontend.c" />
     <ClCompile Include="..\..\src\si\game_controller.c" />
@@ -228,6 +229,7 @@
     <ClInclude Include="..\..\src\r4300\exception.h" />
     <ClInclude Include="..\..\src\rdp\fb.h" />
     <ClInclude Include="..\..\src\osal\files.h" />
+    <ClInclude Include="..\..\src\main\fla_file.h" />
     <ClInclude Include="..\..\src\pi\flashram.h" />
     <ClInclude Include="..\..\src\si\game_controller.h" />
     <ClInclude Include="..\..\src\plugin\get_time_using_C_localtime.h" />

--- a/projects/msvc11/mupen64plus-core.vcxproj
+++ b/projects/msvc11/mupen64plus-core.vcxproj
@@ -144,6 +144,7 @@
     <ClCompile Include="..\..\src\r4300\x86\gcop1_l.c" />
     <ClCompile Include="..\..\src\r4300\x86\gcop1_s.c" />
     <ClCompile Include="..\..\src\r4300\x86\gcop1_w.c" />
+    <ClCompile Include="..\..\src\plugin\get_time_using_C_localtime.c" />
     <ClCompile Include="..\..\src\r4300\x86\gr4300.c" />
     <ClCompile Include="..\..\src\r4300\x86\gregimm.c" />
     <ClCompile Include="..\..\src\r4300\x86\gspecial.c" />
@@ -221,6 +222,7 @@
     <ClInclude Include="..\..\src\osal\files.h" />
     <ClInclude Include="..\..\src\pi\flashram.h" />
     <ClInclude Include="..\..\src\si\game_controller.h" />
+    <ClInclude Include="..\..\src\plugin\get_time_using_C_localtime.h" />
     <ClInclude Include="..\..\src\r4300\instr_counters.h" />
     <ClInclude Include="..\..\src\r4300\x86\interpret.h" />
     <ClInclude Include="..\..\src\r4300\interupt.h" />

--- a/projects/msvc11/mupen64plus-core.vcxproj
+++ b/projects/msvc11/mupen64plus-core.vcxproj
@@ -130,6 +130,7 @@
     <ClCompile Include="..\..\src\plugin\dummy_video.c" />
     <ClCompile Include="..\..\src\osal\dynamiclib_win32.c" />
     <ClCompile Include="..\..\src\si\eeprom.c" />
+    <ClCompile Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.c" />
     <ClCompile Include="..\..\src\main\eventloop.c" />
     <ClCompile Include="..\..\src\r4300\exception.c" />
     <ClCompile Include="..\..\src\rdp\fb.c" />
@@ -178,6 +179,8 @@
     <ClCompile Include="..\..\src\r4300\x86\rjump.c" />
     <ClCompile Include="..\..\src\main\rom.c" />
     <ClCompile Include="..\..\src\rsp\rsp_core.c" />
+    <ClCompile Include="..\..\src\plugin\rumble_via_input_plugin.c" />
+    <ClCompile Include="..\..\src\si\rumblepak.c" />
     <ClCompile Include="..\..\src\main\savestates.c" />
     <ClCompile Include="..\..\src\main\sdl_key_converter.c" />
     <ClCompile Include="..\..\src\osd\screenshot.cpp" />
@@ -217,6 +220,7 @@
     <ClInclude Include="..\..\src\plugin\dummy_video.h" />
     <ClInclude Include="..\..\src\osal\dynamiclib.h" />
     <ClInclude Include="..\..\src\si\eeprom.h" />
+    <ClInclude Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.h" />
     <ClInclude Include="..\..\src\main\eventloop.h" />
     <ClInclude Include="..\..\src\r4300\exception.h" />
     <ClInclude Include="..\..\src\rdp\fb.h" />
@@ -264,6 +268,8 @@
     <ClInclude Include="..\..\src\ri\ri_controller.h" />
     <ClInclude Include="..\..\src\main\rom.h" />
     <ClInclude Include="..\..\src\rsp\rsp_core.h" />
+    <ClInclude Include="..\..\src\plugin\rumble_via_input_plugin.h" />
+    <ClInclude Include="..\..\src\si\rumblepak.h" />
     <ClInclude Include="..\..\src\main\savestates.h" />
     <ClInclude Include="..\..\src\main\sdl_key_converter.h" />
     <ClInclude Include="..\..\src\osd\screenshot.h" />

--- a/projects/msvc11/mupen64plus-core.vcxproj
+++ b/projects/msvc11/mupen64plus-core.vcxproj
@@ -186,6 +186,7 @@
     <ClCompile Include="..\..\src\main\sdl_key_converter.c" />
     <ClCompile Include="..\..\src\osd\screenshot.cpp" />
     <ClCompile Include="..\..\src\si\si_controller.c" />
+    <ClCompile Include="..\..\src\main\sra_file.c" />
     <ClCompile Include="..\..\src\pi\sram.c" />
     <ClCompile Include="..\..\src\r4300\tlb.c" />
     <ClCompile Include="..\..\src\main\zip\unzip.c" />
@@ -276,6 +277,7 @@
     <ClInclude Include="..\..\src\main\sdl_key_converter.h" />
     <ClInclude Include="..\..\src\osd\screenshot.h" />
     <ClInclude Include="..\..\src\si\si_controller.h" />
+    <ClInclude Include="..\..\src\main\sra_file.h" />
     <ClInclude Include="..\..\src\pi\sram.h" />
     <ClInclude Include="..\..\src\r4300\tlb.h" />
     <ClInclude Include="..\..\src\main\zip\unzip.h" />

--- a/projects/msvc11/mupen64plus-core.vcxproj
+++ b/projects/msvc11/mupen64plus-core.vcxproj
@@ -158,6 +158,7 @@
     <ClCompile Include="..\..\src\memory\memory.c" />
     <ClCompile Include="..\..\src\si\mempak.c" />
     <ClCompile Include="..\..\src\r4300\mi_controller.c" />
+    <ClCompile Include="..\..\src\main\mpk_file.c" />
     <ClCompile Include="..\..\src\si\n64_cic_nus_6105.c" />
     <ClCompile Include="..\..\src\osd\OGLFT.cpp" />
     <ClCompile Include="..\..\src\osd\osd.cpp" />
@@ -241,6 +242,7 @@
     <ClInclude Include="..\..\src\memory\memory.h" />
     <ClInclude Include="..\..\src\si\mempak.h" />
     <ClInclude Include="..\..\src\r4300\mi_controller.h" />
+    <ClInclude Include="..\..\src\main\mpk_file.h" />
     <ClInclude Include="..\..\src\si\n64_cic_nus_6105.h" />
     <ClInclude Include="..\..\src\osd\OGLFT.h" />
     <ClInclude Include="..\..\src\r4300\ops.h" />

--- a/projects/msvc11/mupen64plus-core.vcxproj
+++ b/projects/msvc11/mupen64plus-core.vcxproj
@@ -129,6 +129,7 @@
     <ClCompile Include="..\..\src\plugin\dummy_rsp.c" />
     <ClCompile Include="..\..\src\plugin\dummy_video.c" />
     <ClCompile Include="..\..\src\osal\dynamiclib_win32.c" />
+    <ClCompile Include="..\..\src\main\eep_file.c" />
     <ClCompile Include="..\..\src\si\eeprom.c" />
     <ClCompile Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.c" />
     <ClCompile Include="..\..\src\main\eventloop.c" />
@@ -219,6 +220,7 @@
     <ClInclude Include="..\..\src\plugin\dummy_rsp.h" />
     <ClInclude Include="..\..\src\plugin\dummy_video.h" />
     <ClInclude Include="..\..\src\osal\dynamiclib.h" />
+    <ClInclude Include="..\..\src\main\eep_file.h" />
     <ClInclude Include="..\..\src\si\eeprom.h" />
     <ClInclude Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.h" />
     <ClInclude Include="..\..\src\main\eventloop.h" />

--- a/projects/msvc8/mupen64plus-core.vcproj
+++ b/projects/msvc8/mupen64plus-core.vcproj
@@ -289,6 +289,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\main\eep_file.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\si\eeprom.c"
 				>
 			</File>
@@ -644,6 +648,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\osal\dynamiclib.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\main\eep_file.h"
 				>
 			</File>
 			<File

--- a/projects/msvc8/mupen64plus-core.vcproj
+++ b/projects/msvc8/mupen64plus-core.vcproj
@@ -405,6 +405,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\main\mpk_file.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\si\n64_cic_nus_6105.c"
 				>
 			</File>
@@ -732,6 +736,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\r4300\mi_controller.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\main\mpk_file.h"
 				>
 			</File>
 			<File

--- a/projects/msvc8/mupen64plus-core.vcproj
+++ b/projects/msvc8/mupen64plus-core.vcproj
@@ -293,6 +293,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\plugin\emulate_game_controller_via_input_plugin.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\main\eventloop.c"
 				>
 			</File>
@@ -485,6 +489,14 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\plugin\rumble_via_input_plugin.c"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\si\rumblepak.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\main\savestates.c"
 				>
 			</File>
@@ -636,6 +648,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\si\eeprom.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\plugin\emulate_game_controller_via_input_plugin.h"
 				>
 			</File>
 			<File
@@ -824,6 +840,14 @@
 			</File>
 			<File
 				RelativePath="..\..\src\rsp\rsp_core.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\plugin\rumble_via_input_plugin.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\si\rumblepak.h"
 				>
 			</File>
 			<File

--- a/projects/msvc8/mupen64plus-core.vcproj
+++ b/projects/msvc8/mupen64plus-core.vcproj
@@ -517,6 +517,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\main\sra_file.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\pi\sram.c"
 				>
 			</File>
@@ -872,6 +876,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\si\si_controller.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\main\sram_file.h"
 				>
 			</File>
 			<File

--- a/projects/msvc8/mupen64plus-core.vcproj
+++ b/projects/msvc8/mupen64plus-core.vcproj
@@ -349,6 +349,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\plugin\get_time_using_C_localtime.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\r4300\x86\gr4300.c"
 				>
 			</File>
@@ -652,6 +656,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\si\game_controller.h"
+				>
+			</File>
+			<File
+                RelativePath="..\..\src\plugin\get_time_using_C_localtime.h"
 				>
 			</File>
 			<File

--- a/projects/msvc8/mupen64plus-core.vcproj
+++ b/projects/msvc8/mupen64plus-core.vcproj
@@ -317,6 +317,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\main\fla_file.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\pi\flashram.c"
 				>
 			</File>
@@ -680,6 +684,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\osal\files.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\main\fla_file.h"
 				>
 			</File>
 			<File

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -419,6 +419,7 @@ SOURCE = \
 	$(SRCDIR)/pi/flashram.c \
 	$(SRCDIR)/pi/pi_controller.c \
 	$(SRCDIR)/pi/sram.c \
+	$(SRCDIR)/plugin/get_time_using_C_localtime.c \
 	$(SRCDIR)/plugin/plugin.c \
 	$(SRCDIR)/plugin/dummy_video.c \
 	$(SRCDIR)/plugin/dummy_audio.c \

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -409,6 +409,7 @@ SOURCE = \
 	$(SRCDIR)/main/cheat.c \
 	$(SRCDIR)/main/eventloop.c \
 	$(SRCDIR)/main/md5.c \
+	$(SRCDIR)/main/mpk_file.c \
 	$(SRCDIR)/main/profile.c \
 	$(SRCDIR)/main/rom.c \
 	$(SRCDIR)/main/savestates.c \

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -407,6 +407,7 @@ SOURCE = \
 	$(SRCDIR)/main/main.c \
 	$(SRCDIR)/main/util.c \
 	$(SRCDIR)/main/cheat.c \
+	$(SRCDIR)/main/eep_file.c \
 	$(SRCDIR)/main/eventloop.c \
 	$(SRCDIR)/main/md5.c \
 	$(SRCDIR)/main/mpk_file.c \

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -409,6 +409,7 @@ SOURCE = \
 	$(SRCDIR)/main/cheat.c \
 	$(SRCDIR)/main/eep_file.c \
 	$(SRCDIR)/main/eventloop.c \
+	$(SRCDIR)/main/fla_file.c \
 	$(SRCDIR)/main/md5.c \
 	$(SRCDIR)/main/mpk_file.c \
 	$(SRCDIR)/main/profile.c \

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -420,7 +420,9 @@ SOURCE = \
 	$(SRCDIR)/pi/flashram.c \
 	$(SRCDIR)/pi/pi_controller.c \
 	$(SRCDIR)/pi/sram.c \
+	$(SRCDIR)/plugin/emulate_game_controller_via_input_plugin.c \
 	$(SRCDIR)/plugin/get_time_using_C_localtime.c \
+	$(SRCDIR)/plugin/rumble_via_input_plugin.c \
 	$(SRCDIR)/plugin/plugin.c \
 	$(SRCDIR)/plugin/dummy_video.c \
 	$(SRCDIR)/plugin/dummy_audio.c \
@@ -451,6 +453,7 @@ SOURCE = \
 	$(SRCDIR)/si/mempak.c \
 	$(SRCDIR)/si/n64_cic_nus_6105.c \
 	$(SRCDIR)/si/pif.c \
+	$(SRCDIR)/si/rumblepak.c \
 	$(SRCDIR)/si/si_controller.c \
 	$(SRCDIR)/vi/vi_controller.c \
 	$(SRCDIR)/osd/screenshot.cpp

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -415,6 +415,7 @@ SOURCE = \
 	$(SRCDIR)/main/rom.c \
 	$(SRCDIR)/main/savestates.c \
 	$(SRCDIR)/main/sdl_key_converter.c \
+	$(SRCDIR)/main/sra_file.c \
 	$(SRCDIR)/main/workqueue.c \
 	$(SRCDIR)/memory/memory.c \
 	$(SRCDIR)/pi/cart_rom.c \

--- a/src/main/eep_file.c
+++ b/src/main/eep_file.c
@@ -1,0 +1,85 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - eep_file.c                                              *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "eep_file.h"
+
+#include "api/m64p_types.h"
+#include "api/callbacks.h"
+#include "main/util.h"
+#include "si/eeprom.h"
+
+#include <stdlib.h>
+
+void open_eep_file(struct eep_file* eep, const char* filename)
+{
+    /* ! Take ownership of filename ! */
+    eep->filename = filename;
+
+    /* try to load eep file content */
+    switch(read_from_file(eep->filename, eep->eeprom, EEPROM_MAX_SIZE))
+    {
+    case file_open_error:
+        /* if no prior file exists, provide default mempaks content */
+        DebugMessage(M64MSG_VERBOSE, "couldn't open eeprom file '%s' for reading", eep->filename);
+        format_eeprom(eep->eeprom);
+        break;
+    case file_read_error:
+        DebugMessage(M64MSG_WARNING, "failed to read eeprom file '%s'", eep->filename);
+        break;
+    default:
+        break;
+    }
+
+    eep->touched = 0;
+}
+
+void close_eep_file(struct eep_file* eep)
+{
+    /* write back eep file content (if touched) */
+    if (eep->touched != 0)
+    {
+        switch(write_to_file(eep->filename, eep->eeprom, EEPROM_MAX_SIZE))
+        {
+        case file_open_error:
+            DebugMessage(M64MSG_WARNING, "couldn't open eeprom file '%s' for writing", eep->filename);
+            break;
+        case file_write_error:
+            DebugMessage(M64MSG_WARNING, "failed to write eeprom file '%s'", eep->filename);
+            break;
+        default:
+            break;
+        }
+    }
+
+    free((void*)eep->filename);
+}
+
+uint8_t* eep_file_ptr(struct eep_file* eep)
+{
+    return eep->eeprom;
+}
+
+void touch_eep_file(void* opaque)
+{
+    struct eep_file* eep = (struct eep_file*)opaque;
+    eep->touched = 1;
+}
+

--- a/src/main/eep_file.c
+++ b/src/main/eep_file.c
@@ -59,7 +59,7 @@ uint8_t* eep_file_ptr(struct eep_file* eep)
     return eep->eeprom;
 }
 
-void touch_eep_file(void* opaque)
+void save_eep_file(void* opaque)
 {
     /* flush eeprom to disk */
     struct eep_file* eep = (struct eep_file*)opaque;

--- a/src/main/eep_file.c
+++ b/src/main/eep_file.c
@@ -39,7 +39,7 @@ void open_eep_file(struct eep_file* eep, const char* filename)
     case file_open_error:
         /* if no prior file exists, provide default mempaks content */
         DebugMessage(M64MSG_VERBOSE, "couldn't open eeprom file '%s' for reading", eep->filename);
-        format_eeprom(eep->eeprom);
+        format_eeprom(eep->eeprom, EEPROM_MAX_SIZE);
         break;
     case file_read_error:
         DebugMessage(M64MSG_WARNING, "failed to read eeprom file '%s'", eep->filename);

--- a/src/main/eep_file.h
+++ b/src/main/eep_file.h
@@ -34,7 +34,6 @@ struct eep_file
 {
     uint8_t eeprom[EEPROM_MAX_SIZE];
     const char* filename;
-    int touched;
 };
 
 void open_eep_file(struct eep_file* eep, const char* filename);

--- a/src/main/eep_file.h
+++ b/src/main/eep_file.h
@@ -1,7 +1,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - pif.h                                                   *
+ *   Mupen64plus - eep_file.h                                              *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
- *   Copyright (C) 2002 Hacktarux                                          *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,60 +19,25 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_SI_PIF_H
-#define M64P_SI_PIF_H
+#ifndef M64P_MAIN_EEP_FILE_H
+#define M64P_MAIN_EEP_FILE_H
 
 #include <stdint.h>
 
-#include "af_rtc.h"
-#include "cic.h"
-#include "eeprom.h"
-#include "game_controller.h"
+#include "si/eeprom.h"
 
-enum { GAME_CONTROLLERS_COUNT = 4 };
-
-struct si_controller;
-
-enum { PIF_RAM_SIZE = 0x40 };
-
-enum pif_commands
+struct eep_file
 {
-    PIF_CMD_STATUS = 0x00,
-    PIF_CMD_CONTROLLER_READ = 0x01,
-    PIF_CMD_PAK_READ = 0x02,
-    PIF_CMD_PAK_WRITE = 0x03,
-    PIF_CMD_EEPROM_READ = 0x04,
-    PIF_CMD_EEPROM_WRITE = 0x05,
-    PIF_CMD_AF_RTC_STATUS = 0x06,
-    PIF_CMD_AF_RTC_READ = 0x07,
-    PIF_CMD_AF_RTC_WRITE = 0x08,
-    PIF_CMD_RESET = 0xff,
+    uint8_t eeprom[EEPROM_MAX_SIZE];
+    const char* filename;
+    int touched;
 };
 
-struct pif
-{
-    uint8_t ram[PIF_RAM_SIZE];
+void open_eep_file(struct eep_file* eep, const char* filename);
+void close_eep_file(struct eep_file* eep);
 
-    struct game_controller controllers[GAME_CONTROLLERS_COUNT];
-    struct eeprom eeprom;
-    struct af_rtc af_rtc;
+uint8_t* eep_file_ptr(struct eep_file* eep);
 
-    struct cic cic;
-};
-
-static inline uint32_t pif_ram_address(uint32_t address)
-{
-    return ((address & 0xfffc) - 0x7c0);
-}
-
-
-void init_pif(struct pif* pif);
-
-int read_pif_ram(void* opaque, uint32_t address, uint32_t* value);
-int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
-
-void update_pif_write(struct si_controller* si);
-void update_pif_read(struct si_controller* si);
+void touch_eep_file(void* opaque);
 
 #endif
-

--- a/src/main/eep_file.h
+++ b/src/main/eep_file.h
@@ -24,7 +24,11 @@
 
 #include <stdint.h>
 
-#include "si/eeprom.h"
+/* Note: EEP files are all EEPROM_MAX_SIZE bytes long,
+ * whatever the real EEPROM size is.
+ */
+
+enum { EEPROM_MAX_SIZE = 0x800 };
 
 struct eep_file
 {

--- a/src/main/eep_file.h
+++ b/src/main/eep_file.h
@@ -41,6 +41,6 @@ void close_eep_file(struct eep_file* eep);
 
 uint8_t* eep_file_ptr(struct eep_file* eep);
 
-void touch_eep_file(void* opaque);
+void save_eep_file(void* opaque);
 
 #endif

--- a/src/main/fla_file.c
+++ b/src/main/fla_file.c
@@ -1,0 +1,85 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - fla_file.c                                              *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "fla_file.h"
+
+#include "api/m64p_types.h"
+#include "api/callbacks.h"
+#include "main/util.h"
+#include "pi/flashram.h"
+
+#include <stdlib.h>
+
+void open_fla_file(struct fla_file* fla, const char* filename)
+{
+    /* ! Take ownership of filename ! */
+    fla->filename = filename;
+
+    /* try to load fla file content */
+    switch(read_from_file(fla->filename, fla->flashram, FLASHRAM_SIZE))
+    {
+    case file_open_error:
+        /* if no prior file exists, provide default flashram content */
+        DebugMessage(M64MSG_VERBOSE, "couldn't open sram file '%s' for reading", fla->filename);
+        format_flashram(fla->flashram);
+        break;
+    case file_read_error:
+        DebugMessage(M64MSG_WARNING, "failed to read flashram file '%s'", fla->filename);
+        break;
+    default:
+        break;
+    }
+
+    fla->touched = 0;
+}
+
+void close_fla_file(struct fla_file* fla)
+{
+    /* write back fla file content (if touched) */
+    if (fla->touched != 0)
+    {
+        switch(write_to_file(fla->filename, fla->flashram, FLASHRAM_SIZE))
+        {
+        case file_open_error:
+            DebugMessage(M64MSG_WARNING, "couldn't open flashram file '%s' for writing", fla->filename);
+            break;
+        case file_write_error:
+            DebugMessage(M64MSG_WARNING, "failed to write flashram file '%s'", fla->filename);
+            break;
+        default:
+            break;
+        }
+    }
+
+    free((void*)fla->filename);
+}
+
+uint8_t* fla_file_ptr(struct fla_file* fla)
+{
+    return fla->flashram;
+}
+
+void touch_fla_file(void* opaque)
+{
+    struct fla_file* fla = (struct fla_file*)opaque;
+    fla->touched = 1;
+}
+

--- a/src/main/fla_file.c
+++ b/src/main/fla_file.c
@@ -59,7 +59,7 @@ uint8_t* fla_file_ptr(struct fla_file* fla)
     return fla->flashram;
 }
 
-void touch_fla_file(void* opaque)
+void save_fla_file(void* opaque)
 {
     /* flush flashram to disk */
     struct fla_file* fla = (struct fla_file*)opaque;

--- a/src/main/fla_file.h
+++ b/src/main/fla_file.h
@@ -37,6 +37,6 @@ void close_fla_file(struct fla_file* fla);
 
 uint8_t* fla_file_ptr(struct fla_file* fla);
 
-void touch_fla_file(void* opaque);
+void save_fla_file(void* opaque);
 
 #endif

--- a/src/main/fla_file.h
+++ b/src/main/fla_file.h
@@ -1,8 +1,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - flashram.h                                              *
+ *   Mupen64plus - fla_file.h                                              *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
  *   Copyright (C) 2014 Bobby Smiles                                       *
- *   Copyright (C) 2002 Hacktarux                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -20,47 +19,25 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_PI_FLASHRAM_H
-#define M64P_PI_FLASHRAM_H
+#ifndef M64P_MAIN_FLA_FILE_H
+#define M64P_MAIN_FLA_FILE_H
 
 #include <stdint.h>
 
-struct pi_controller;
+#include "pi/flashram.h"
 
-enum { FLASHRAM_SIZE = 0x20000 };
-
-enum flashram_mode
+struct fla_file
 {
-    FLASHRAM_MODE_NOPES = 0,
-    FLASHRAM_MODE_ERASE,
-    FLASHRAM_MODE_WRITE,
-    FLASHRAM_MODE_READ,
-    FLASHRAM_MODE_STATUS
+    uint8_t flashram[FLASHRAM_SIZE];
+    const char* filename;
+    int touched;
 };
 
-struct flashram
-{
-    /* external sram storage */
-    void* user_data;
-    void (*touch)(void*);
-    uint8_t* data;
+void open_fla_file(struct fla_file* fla, const char* filename);
+void close_fla_file(struct fla_file* fla);
 
-    enum flashram_mode mode;
-    uint64_t status;
-    unsigned int erase_offset;
-    unsigned int write_pointer;
-};
+uint8_t* fla_file_ptr(struct fla_file* fla);
 
-void init_flashram(struct flashram* flashram);
-
-void flashram_touch(struct flashram* flashram);
-
-void format_flashram(uint8_t* flash);
-
-int read_flashram_status(void* opaque, uint32_t address, uint32_t* value);
-int write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
-
-void dma_read_flashram(struct pi_controller* pi);
-void dma_write_flashram(struct pi_controller* pi);
+void touch_fla_file(void* opaque);
 
 #endif

--- a/src/main/fla_file.h
+++ b/src/main/fla_file.h
@@ -30,7 +30,6 @@ struct fla_file
 {
     uint8_t flashram[FLASHRAM_SIZE];
     const char* filename;
-    int touched;
 };
 
 void open_fla_file(struct fla_file* fla, const char* filename);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -905,6 +905,18 @@ m64p_error main_run(void)
     g_si.pif.eeprom.user_data = &eep;
     g_si.pif.eeprom.touch = touch_eep_file;
     g_si.pif.eeprom.data = eep_file_ptr(&eep);
+    if (ROM_SETTINGS.savetype != EEPROM_16KB)
+    {
+        /* 4kbits EEPROM */
+        g_si.pif.eeprom.size = 0x200;
+        g_si.pif.eeprom.id = 0x8000;
+    }
+    else
+    {
+        /* 16kbits EEPROM */
+        g_si.pif.eeprom.size = 0x800;
+        g_si.pif.eeprom.id = 0xc000;
+    }
 
     /* open fla file (if any) and connect it to flashram */
     open_fla_file(&fla, get_flashram_path());

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -896,14 +896,14 @@ m64p_error main_run(void)
     for(i = 0; i < GAME_CONTROLLERS_COUNT; ++i)
     {
         g_si.pif.controllers[i].mempak.user_data = &mpk;
-        g_si.pif.controllers[i].mempak.touch = touch_mpk_file;
+        g_si.pif.controllers[i].mempak.save = save_mpk_file;
         g_si.pif.controllers[i].mempak.data = mpk_file_ptr(&mpk, i);
     }
 
     /* open eep file (if any) and connect it to eeprom */
     open_eep_file(&eep, get_eeprom_path());
     g_si.pif.eeprom.user_data = &eep;
-    g_si.pif.eeprom.touch = touch_eep_file;
+    g_si.pif.eeprom.save = save_eep_file;
     g_si.pif.eeprom.data = eep_file_ptr(&eep);
     if (ROM_SETTINGS.savetype != EEPROM_16KB)
     {
@@ -921,13 +921,13 @@ m64p_error main_run(void)
     /* open fla file (if any) and connect it to flashram */
     open_fla_file(&fla, get_flashram_path());
     g_pi.flashram.user_data = &fla;
-    g_pi.flashram.touch = touch_fla_file;
+    g_pi.flashram.save = save_fla_file;
     g_pi.flashram.data = fla_file_ptr(&fla);
 
     /* open sra file (if any) and connect it to SRAM */
     open_sra_file(&sra, get_sram_path());
     g_pi.sram.user_data = &sra;
-    g_pi.sram.touch = touch_sra_file;
+    g_pi.sram.save = save_sra_file;
     g_pi.sram.data = sra_file_ptr(&sra);
 
 #ifdef WITH_LIRC

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -45,6 +45,7 @@
 #include "cheat.h"
 #include "eep_file.h"
 #include "eventloop.h"
+#include "fla_file.h"
 #include "mpk_file.h"
 #include "profile.h"
 #include "rom.h"
@@ -151,6 +152,11 @@ static char *get_eeprom_path(void)
 static char *get_sram_path(void)
 {
     return formatstr("%s%s.sra", get_savesrampath(), ROM_SETTINGS.goodname);
+}
+
+static char *get_flashram_path(void)
+{
+    return formatstr("%s%s.fla", get_savesrampath(), ROM_SETTINGS.goodname);
 }
 
 
@@ -805,6 +811,7 @@ m64p_error main_run(void)
 {
     size_t i;
     struct eep_file eep;
+    struct fla_file fla;
     struct mpk_file mpk;
     struct sra_file sra;
 
@@ -899,6 +906,12 @@ m64p_error main_run(void)
     g_si.pif.eeprom.touch = touch_eep_file;
     g_si.pif.eeprom.data = eep_file_ptr(&eep);
 
+    /* open fla file (if any) and connect it to flashram */
+    open_fla_file(&fla, get_flashram_path());
+    g_pi.flashram.user_data = &fla;
+    g_pi.flashram.touch = touch_fla_file;
+    g_pi.flashram.data = fla_file_ptr(&fla);
+
     /* open sra file (if any) and connect it to SRAM */
     open_sra_file(&sra, get_sram_path());
     g_pi.sram.user_data = &sra;
@@ -936,6 +949,7 @@ m64p_error main_run(void)
 #endif
 
     close_sra_file(&sra);
+    close_fla_file(&fla);
     close_eep_file(&eep);
     close_mpk_file(&mpk);
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -57,6 +57,7 @@
 #include "osd/screenshot.h"
 #include "pi/pi_controller.h"
 #include "plugin/plugin.h"
+#include "plugin/get_time_using_C_localtime.h"
 #include "r4300/r4300.h"
 #include "r4300/r4300_core.h"
 #include "r4300/interupt.h"
@@ -843,6 +844,10 @@ m64p_error main_run(void)
 
     // setup rendering callback from video plugin to the core, for screenshots and On-Screen-Display
     gfx.setRenderingCallback(video_plugin_render_callback);
+
+    /* connect external time source to AF_RTC component */
+    g_si.pif.af_rtc.user_data = NULL;
+    g_si.pif.af_rtc.get_time = get_time_using_C_localtime;
 
 #ifdef WITH_LIRC
     lircStart();

--- a/src/main/mpk_file.c
+++ b/src/main/mpk_file.c
@@ -1,0 +1,88 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - mpk_file.c                                              *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "mpk_file.h"
+
+#include "api/m64p_types.h"
+#include "api/callbacks.h"
+
+#include "main/util.h"
+
+#include <stdlib.h>
+
+
+void open_mpk_file(struct mpk_file* mpk, const char* filename)
+{
+    size_t i;
+
+    /* ! Take ownership of filename ! */
+    mpk->filename = filename;
+
+    /* try to load mpk file content */
+    switch(read_from_file(mpk->filename, mpk->mempaks, MEMPAK_COUNT*MEMPAK_SIZE))
+    {
+    case file_open_error:
+        /* if no prior file exists, provide default mempaks content */
+        DebugMessage(M64MSG_VERBOSE, "couldn't open mem pak file '%s' for reading", mpk->filename);
+        for(i = 0; i < MEMPAK_COUNT; ++i)
+            format_mempak(mpk->mempaks[i]);
+        break;
+    case file_read_error:
+        DebugMessage(M64MSG_WARNING, "failed to read mem pak file '%s'", mpk->filename);
+        break;
+    default:
+        break;
+    }
+
+    mpk->touched = 0;
+}
+
+void close_mpk_file(struct mpk_file* mpk)
+{
+    /* write back mpk file content (if touched) */
+    if (mpk->touched != 0)
+    {
+        switch(write_to_file(mpk->filename, mpk->mempaks, MEMPAK_COUNT*MEMPAK_SIZE))
+        {
+        case file_open_error:
+            DebugMessage(M64MSG_WARNING, "couldn't open mem pak file '%s' for writing", mpk->filename);
+            break;
+        case file_write_error:
+            DebugMessage(M64MSG_WARNING, "failed to write mem pak file '%s'", mpk->filename);
+            break;
+        default:
+            break;
+        }
+    }
+
+    free((void*)mpk->filename);
+}
+
+uint8_t* mpk_file_ptr(struct mpk_file* mpk, size_t controller_idx)
+{
+    return &mpk->mempaks[controller_idx][0];
+}
+
+void touch_mpk_file(void* opaque)
+{
+    struct mpk_file* mpk = (struct mpk_file*)opaque;
+    mpk->touched = 1;
+}

--- a/src/main/mpk_file.c
+++ b/src/main/mpk_file.c
@@ -28,7 +28,6 @@
 
 #include <stdlib.h>
 
-
 void open_mpk_file(struct mpk_file* mpk, const char* filename)
 {
     size_t i;
@@ -51,28 +50,10 @@ void open_mpk_file(struct mpk_file* mpk, const char* filename)
     default:
         break;
     }
-
-    mpk->touched = 0;
 }
 
 void close_mpk_file(struct mpk_file* mpk)
 {
-    /* write back mpk file content (if touched) */
-    if (mpk->touched != 0)
-    {
-        switch(write_to_file(mpk->filename, mpk->mempaks, GAME_CONTROLLERS_COUNT*MEMPAK_SIZE))
-        {
-        case file_open_error:
-            DebugMessage(M64MSG_WARNING, "couldn't open mem pak file '%s' for writing", mpk->filename);
-            break;
-        case file_write_error:
-            DebugMessage(M64MSG_WARNING, "failed to write mem pak file '%s'", mpk->filename);
-            break;
-        default:
-            break;
-        }
-    }
-
     free((void*)mpk->filename);
 }
 
@@ -83,6 +64,18 @@ uint8_t* mpk_file_ptr(struct mpk_file* mpk, size_t controller_idx)
 
 void touch_mpk_file(void* opaque)
 {
+    /* flush mempak to disk */
     struct mpk_file* mpk = (struct mpk_file*)opaque;
-    mpk->touched = 1;
+
+    switch(write_to_file(mpk->filename, mpk->mempaks, GAME_CONTROLLERS_COUNT*MEMPAK_SIZE))
+    {
+    case file_open_error:
+        DebugMessage(M64MSG_WARNING, "couldn't open mem pak file '%s' for writing", mpk->filename);
+        break;
+    case file_write_error:
+        DebugMessage(M64MSG_WARNING, "failed to write mem pak file '%s'", mpk->filename);
+        break;
+    default:
+        break;
+    }
 }

--- a/src/main/mpk_file.c
+++ b/src/main/mpk_file.c
@@ -20,11 +20,11 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "mpk_file.h"
+#include "util.h"
 
 #include "api/m64p_types.h"
 #include "api/callbacks.h"
-
-#include "main/util.h"
+#include "si/pif.h"
 
 #include <stdlib.h>
 
@@ -37,12 +37,12 @@ void open_mpk_file(struct mpk_file* mpk, const char* filename)
     mpk->filename = filename;
 
     /* try to load mpk file content */
-    switch(read_from_file(mpk->filename, mpk->mempaks, MEMPAK_COUNT*MEMPAK_SIZE))
+    switch(read_from_file(mpk->filename, mpk->mempaks, GAME_CONTROLLERS_COUNT*MEMPAK_SIZE))
     {
     case file_open_error:
         /* if no prior file exists, provide default mempaks content */
         DebugMessage(M64MSG_VERBOSE, "couldn't open mem pak file '%s' for reading", mpk->filename);
-        for(i = 0; i < MEMPAK_COUNT; ++i)
+        for(i = 0; i < GAME_CONTROLLERS_COUNT; ++i)
             format_mempak(mpk->mempaks[i]);
         break;
     case file_read_error:
@@ -60,7 +60,7 @@ void close_mpk_file(struct mpk_file* mpk)
     /* write back mpk file content (if touched) */
     if (mpk->touched != 0)
     {
-        switch(write_to_file(mpk->filename, mpk->mempaks, MEMPAK_COUNT*MEMPAK_SIZE))
+        switch(write_to_file(mpk->filename, mpk->mempaks, GAME_CONTROLLERS_COUNT*MEMPAK_SIZE))
         {
         case file_open_error:
             DebugMessage(M64MSG_WARNING, "couldn't open mem pak file '%s' for writing", mpk->filename);

--- a/src/main/mpk_file.c
+++ b/src/main/mpk_file.c
@@ -62,7 +62,7 @@ uint8_t* mpk_file_ptr(struct mpk_file* mpk, size_t controller_idx)
     return &mpk->mempaks[controller_idx][0];
 }
 
-void touch_mpk_file(void* opaque)
+void save_mpk_file(void* opaque)
 {
     /* flush mempak to disk */
     struct mpk_file* mpk = (struct mpk_file*)opaque;

--- a/src/main/mpk_file.h
+++ b/src/main/mpk_file.h
@@ -39,6 +39,6 @@ void close_mpk_file(struct mpk_file* mpk);
 
 uint8_t* mpk_file_ptr(struct mpk_file* mpk, size_t controller_idx);
 
-void touch_mpk_file(void* opaque);
+void save_mpk_file(void* opaque);
 
 #endif

--- a/src/main/mpk_file.h
+++ b/src/main/mpk_file.h
@@ -1,5 +1,5 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - mempak.h                                                *
+ *   Mupen64plus - mpk_file.h                                              *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
  *   Copyright (C) 2014 Bobby Smiles                                       *
  *                                                                         *
@@ -19,27 +19,26 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_SI_MEMPAK_H
-#define M64P_SI_MEMPAK_H
+#ifndef M64P_MAIN_MPK_FILE_H
+#define M64P_MAIN_MPK_FILE_H
 
+#include "si/mempak.h"
+
+#include <stddef.h>
 #include <stdint.h>
 
-struct mempak
+struct mpk_file
 {
-    /* external mpk storage */
-    void* user_data;
-    void (*touch)(void*);
-    uint8_t* data;
+    uint8_t mempaks[MEMPAK_COUNT][MEMPAK_SIZE];
+    const char* filename;
+    int touched;
 };
 
-enum { MEMPAK_COUNT = 4 };
-enum { MEMPAK_SIZE = 0x8000 };
+void open_mpk_file(struct mpk_file* mpk, const char* filename);
+void close_mpk_file(struct mpk_file* mpk);
 
-void mempak_touch(struct mempak* mpk);
+uint8_t* mpk_file_ptr(struct mpk_file* mpk, size_t controller_idx);
 
-void format_mempak(uint8_t* mempak);
-
-void mempak_read_command(struct mempak* mpk, uint8_t* cmd);
-void mempak_write_command(struct mempak* mpk, uint8_t* cmd);
+void touch_mpk_file(void* opaque);
 
 #endif

--- a/src/main/mpk_file.h
+++ b/src/main/mpk_file.h
@@ -32,7 +32,6 @@ struct mpk_file
 {
     uint8_t mempaks[GAME_CONTROLLERS_COUNT][MEMPAK_SIZE];
     const char* filename;
-    int touched;
 };
 
 void open_mpk_file(struct mpk_file* mpk, const char* filename);

--- a/src/main/sra_file.c
+++ b/src/main/sra_file.c
@@ -59,7 +59,7 @@ uint8_t* sra_file_ptr(struct sra_file* sra)
     return sra->sram;
 }
 
-void touch_sra_file(void* opaque)
+void save_sra_file(void* opaque)
 {
     /* flush sram to disk */
     struct sra_file* sra = (struct sra_file*)opaque;

--- a/src/main/sra_file.c
+++ b/src/main/sra_file.c
@@ -1,0 +1,85 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - sra_file.c                                              *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "sra_file.h"
+
+#include "api/m64p_types.h"
+#include "api/callbacks.h"
+#include "main/util.h"
+#include "pi/sram.h"
+
+#include <stdlib.h>
+
+void open_sra_file(struct sra_file* sra, const char* filename)
+{
+    /* ! Take ownership of filename ! */
+    sra->filename = filename;
+
+    /* try to load sra file content */
+    switch(read_from_file(sra->filename, sra->sram, SRAM_SIZE))
+    {
+    case file_open_error:
+        /* if no prior file exists, provide default sram content */
+        DebugMessage(M64MSG_VERBOSE, "couldn't open sram file '%s' for reading", sra->filename);
+        format_sram(sra->sram);
+        break;
+    case file_read_error:
+        DebugMessage(M64MSG_WARNING, "failed to read sram file '%s'", sra->filename);
+        break;
+    default:
+        break;
+    }
+
+    sra->touched = 0;
+}
+
+void close_sra_file(struct sra_file* sra)
+{
+    /* write back sra file content (if touched) */
+    if (sra->touched != 0)
+    {
+        switch(write_to_file(sra->filename, sra->sram, SRAM_SIZE))
+        {
+        case file_open_error:
+            DebugMessage(M64MSG_WARNING, "couldn't open sram file '%s' for writing", sra->filename);
+            break;
+        case file_write_error:
+            DebugMessage(M64MSG_WARNING, "failed to write sram file '%s'", sra->filename);
+            break;
+        default:
+            break;
+        }
+    }
+
+    free((void*)sra->filename);
+}
+
+uint8_t* sra_file_ptr(struct sra_file* sra)
+{
+    return sra->sram;
+}
+
+void touch_sra_file(void* opaque)
+{
+    struct sra_file* sra = (struct sra_file*)opaque;
+    sra->touched = 1;
+}
+

--- a/src/main/sra_file.h
+++ b/src/main/sra_file.h
@@ -1,5 +1,5 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - sram.h                                                  *
+ *   Mupen64plus - sra_file.h                                              *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
  *   Copyright (C) 2014 Bobby Smiles                                       *
  *                                                                         *
@@ -19,28 +19,25 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_PI_SRAM_H
-#define M64P_PI_SRAM_H
+#ifndef M64P_MAIN_SRA_FILE_H
+#define M64P_MAIN_SRA_FILE_H
 
 #include <stdint.h>
 
-struct pi_controller;
+#include "pi/sram.h"
 
-enum { SRAM_SIZE = 0x8000 };
-
-struct sram
+struct sra_file
 {
-    /* external sram storage */
-    void* user_data;
-    void (*touch)(void*);
-    uint8_t* data;
+    uint8_t sram[SRAM_SIZE];
+    const char* filename;
+    int touched;
 };
 
-void sram_touch(struct sram* sram);
+void open_sra_file(struct sra_file* sra, const char* filename);
+void close_sra_file(struct sra_file* sra);
 
-void format_sram(uint8_t* sram);
+uint8_t* sra_file_ptr(struct sra_file* sra);
 
-void dma_write_sram(struct pi_controller* pi);
-void dma_read_sram(struct pi_controller* pi);
+void touch_sra_file(void* opaque);
 
 #endif

--- a/src/main/sra_file.h
+++ b/src/main/sra_file.h
@@ -30,7 +30,6 @@ struct sra_file
 {
     uint8_t sram[SRAM_SIZE];
     const char* filename;
-    int touched;
 };
 
 void open_sra_file(struct sra_file* sra, const char* filename);

--- a/src/main/sra_file.h
+++ b/src/main/sra_file.h
@@ -37,6 +37,6 @@ void close_sra_file(struct sra_file* sra);
 
 uint8_t* sra_file_ptr(struct sra_file* sra);
 
-void touch_sra_file(void* opaque);
+void save_sra_file(void* opaque);
 
 #endif

--- a/src/pi/flashram.c
+++ b/src/pi/flashram.c
@@ -64,14 +64,14 @@ static void flashram_command(struct pi_controller* pi, uint32_t command)
         {
             for (i=flashram->erase_offset; i<(flashram->erase_offset+128); ++i)
                 flashram->data[i^S8] = 0xff;
-            flashram_touch(flashram);
+            flashram_save(flashram);
         }
         break;
         case FLASHRAM_MODE_WRITE:
         {
             for(i = 0; i < 128; ++i)
                 flashram->data[(flashram->erase_offset+i)^S8]= dram[(flashram->write_pointer+i)^S8];
-            flashram_touch(flashram);
+            flashram_save(flashram);
         }
         break;
         case FLASHRAM_MODE_STATUS:
@@ -106,9 +106,9 @@ void init_flashram(struct flashram* flashram)
     flashram->write_pointer = 0;
 }
 
-void flashram_touch(struct flashram* flashram)
+void flashram_save(struct flashram* flashram)
 {
-    flashram->touch(flashram->user_data);
+    flashram->save(flashram->user_data);
 }
 
 void format_flashram(uint8_t* flash)

--- a/src/pi/flashram.h
+++ b/src/pi/flashram.h
@@ -42,7 +42,7 @@ struct flashram
 {
     /* external sram storage */
     void* user_data;
-    void (*touch)(void*);
+    void (*save)(void*);
     uint8_t* data;
 
     enum flashram_mode mode;
@@ -53,7 +53,7 @@ struct flashram
 
 void init_flashram(struct flashram* flashram);
 
-void flashram_touch(struct flashram* flashram);
+void flashram_save(struct flashram* flashram);
 
 void format_flashram(uint8_t* flash);
 

--- a/src/pi/pi_controller.h
+++ b/src/pi/pi_controller.h
@@ -56,7 +56,7 @@ struct pi_controller
 
     struct cart_rom cart_rom;
     struct flashram flashram;
-    uint8_t sram[SRAM_SIZE];
+    struct sram sram;
 
     int use_flashram;
 

--- a/src/pi/sram.c
+++ b/src/pi/sram.c
@@ -22,13 +22,6 @@
 #include "sram.h"
 #include "pi_controller.h"
 
-#include "api/m64p_types.h"
-#include "api/callbacks.h"
-
-#include "main/main.h"
-#include "main/rom.h"
-#include "main/util.h"
-
 #include "memory/memory.h"
 
 #include "ri/ri_controller.h"
@@ -36,56 +29,16 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include <stdlib.h>
 
 
-static char *get_sram_path(void)
+void sram_touch(struct sram* sram)
 {
-    return formatstr("%s%s.sra", get_savesrampath(), ROM_SETTINGS.goodname);
+    sram->touch(sram->user_data);
 }
 
-static void sram_format(uint8_t* sram)
+void format_sram(uint8_t* sram)
 {
     memset(sram, 0, SRAM_SIZE);
-}
-
-static void sram_read_file(uint8_t* sram)
-{
-    char *filename = get_sram_path();
-
-    sram_format(sram);
-    switch (read_from_file(filename, sram, SRAM_SIZE))
-    {
-        case file_open_error:
-            DebugMessage(M64MSG_VERBOSE, "couldn't open sram file '%s' for reading", filename);
-            sram_format(sram);
-            break;
-        case file_read_error:
-            DebugMessage(M64MSG_WARNING, "fread() failed on 32kb read from sram file '%s'", filename);
-            sram_format(sram);
-            break;
-        default: break;
-    }
-
-    free(filename);
-}
-
-static void sram_write_file(uint8_t* sram)
-{
-    char *filename = get_sram_path();
-
-    switch (write_to_file(filename, sram, SRAM_SIZE))
-    {
-        case file_open_error:
-            DebugMessage(M64MSG_WARNING, "couldn't open sram file '%s' for writing.", filename);
-            break;
-        case file_write_error:
-            DebugMessage(M64MSG_WARNING, "fwrite() failed on 32kb write to sram file '%s'", filename);
-            break;
-        default: break;
-    }
-
-    free(filename);
 }
 
 
@@ -94,17 +47,15 @@ void dma_write_sram(struct pi_controller* pi)
     size_t i;
     size_t length = (pi->regs[PI_RD_LEN_REG] & 0xffffff) + 1;
 
-    uint8_t* sram = pi->sram;
+    uint8_t* sram = pi->sram.data;
     uint8_t* dram = (uint8_t*)pi->ri->rdram.dram;
     uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] - 0x08000000;
     uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG];
 
-    sram_read_file(sram);
-
     for(i = 0; i < length; ++i)
         sram[(cart_addr+i)^S8] = dram[(dram_addr+i)^S8];
 
-    sram_write_file(sram);
+    sram_touch(&pi->sram);
 }
 
 void dma_read_sram(struct pi_controller* pi)
@@ -112,12 +63,10 @@ void dma_read_sram(struct pi_controller* pi)
     size_t i;
     size_t length = (pi->regs[PI_WR_LEN_REG] & 0xffffff) + 1;
 
-    uint8_t* sram = pi->sram;
+    uint8_t* sram = pi->sram.data;
     uint8_t* dram = (uint8_t*)pi->ri->rdram.dram;
     uint32_t cart_addr = (pi->regs[PI_CART_ADDR_REG] - 0x08000000) & 0xffff;
     uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG];
-
-    sram_read_file(sram);
 
     for(i = 0; i < length; ++i)
         dram[(dram_addr+i)^S8] = sram[(cart_addr+i)^S8];

--- a/src/pi/sram.c
+++ b/src/pi/sram.c
@@ -31,9 +31,9 @@
 #include <string.h>
 
 
-void sram_touch(struct sram* sram)
+void sram_save(struct sram* sram)
 {
-    sram->touch(sram->user_data);
+    sram->save(sram->user_data);
 }
 
 void format_sram(uint8_t* sram)
@@ -55,7 +55,7 @@ void dma_write_sram(struct pi_controller* pi)
     for(i = 0; i < length; ++i)
         sram[(cart_addr+i)^S8] = dram[(dram_addr+i)^S8];
 
-    sram_touch(&pi->sram);
+    sram_save(&pi->sram);
 }
 
 void dma_read_sram(struct pi_controller* pi)

--- a/src/pi/sram.h
+++ b/src/pi/sram.h
@@ -32,11 +32,11 @@ struct sram
 {
     /* external sram storage */
     void* user_data;
-    void (*touch)(void*);
+    void (*save)(void*);
     uint8_t* data;
 };
 
-void sram_touch(struct sram* sram);
+void sram_save(struct sram* sram);
 
 void format_sram(uint8_t* sram);
 

--- a/src/plugin/emulate_game_controller_via_input_plugin.h
+++ b/src/plugin/emulate_game_controller_via_input_plugin.h
@@ -1,5 +1,5 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - mpk_file.h                                              *
+ *   Mupen64plus - emulate_game_controller_via_input_plugin.h              *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
  *   Copyright (C) 2014 Bobby Smiles                                       *
  *                                                                         *
@@ -19,27 +19,15 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_MAIN_MPK_FILE_H
-#define M64P_MAIN_MPK_FILE_H
+#ifndef M64P_PLUGIN_EMULATE_GAME_CONTROLLER_VIA_INPUT_PLUGIN_H
+#define M64P_PLUGIN_EMULATE_GAME_CONTROLLER_VIA_INPUT_PLUGIN_H
 
-#include "si/mempak.h"
-#include "si/pif.h"
-
-#include <stddef.h>
 #include <stdint.h>
 
-struct mpk_file
-{
-    uint8_t mempaks[GAME_CONTROLLERS_COUNT][MEMPAK_SIZE];
-    const char* filename;
-    int touched;
-};
+enum pak_type;
 
-void open_mpk_file(struct mpk_file* mpk, const char* filename);
-void close_mpk_file(struct mpk_file* mpk);
+int egcvip_is_connected(void* opaque, enum pak_type* pak);
 
-uint8_t* mpk_file_ptr(struct mpk_file* mpk, size_t controller_idx);
-
-void touch_mpk_file(void* opaque);
+uint32_t egcvip_get_input(void* opaque);
 
 #endif

--- a/src/plugin/get_time_using_C_localtime.c
+++ b/src/plugin/get_time_using_C_localtime.c
@@ -1,7 +1,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - pif.h                                                   *
+ *   Mupen64plus - get_time_using_C_localtime.c                            *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
- *   Copyright (C) 2002 Hacktarux                                          *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,60 +19,16 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_SI_PIF_H
-#define M64P_SI_PIF_H
+#include "get_time_using_C_localtime.h"
 
-#include <stdint.h>
+#include <time.h>
 
-#include "af_rtc.h"
-#include "cic.h"
-#include "eeprom.h"
-#include "game_controller.h"
 
-struct si_controller;
-
-enum { PIF_RAM_SIZE = 0x40 };
-
-enum pif_commands
+const struct tm* get_time_using_C_localtime(void* user_data)
 {
-    PIF_CMD_STATUS = 0x00,
-    PIF_CMD_CONTROLLER_READ = 0x01,
-    PIF_CMD_PAK_READ = 0x02,
-    PIF_CMD_PAK_WRITE = 0x03,
-    PIF_CMD_EEPROM_READ = 0x04,
-    PIF_CMD_EEPROM_WRITE = 0x05,
-    PIF_CMD_AF_RTC_STATUS = 0x06,
-    PIF_CMD_AF_RTC_READ = 0x07,
-    PIF_CMD_AF_RTC_WRITE = 0x08,
-    PIF_CMD_RESET = 0xff,
-};
+    time_t current_time;
 
-struct pif
-{
-    uint8_t ram[PIF_RAM_SIZE];
-
-    uint8_t eeprom[EEPROM_MAX_SIZE];
-
-    struct game_controllers controllers;
-
-    struct af_rtc af_rtc;
-
-    struct cic cic;
-};
-
-static inline uint32_t pif_ram_address(uint32_t address)
-{
-    return ((address & 0xfffc) - 0x7c0);
+    time(&current_time);
+    return localtime(&current_time);
 }
-
-
-void init_pif(struct pif* pif);
-
-int read_pif_ram(void* opaque, uint32_t address, uint32_t* value);
-int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
-
-void update_pif_write(struct si_controller* si);
-void update_pif_read(struct si_controller* si);
-
-#endif
 

--- a/src/plugin/get_time_using_C_localtime.h
+++ b/src/plugin/get_time_using_C_localtime.h
@@ -1,7 +1,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - pif.h                                                   *
+ *   Mupen64plus - get_time_using_C_localtime.h                            *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
- *   Copyright (C) 2002 Hacktarux                                          *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,60 +19,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_SI_PIF_H
-#define M64P_SI_PIF_H
+#ifndef M64P_PLUGIN_GET_TIME_USING_C_LOCALTIME_H
+#define M64P_PLUGIN_GET_TIME_USING_C_LOCALTIME_H
 
-#include <stdint.h>
+struct tm;
 
-#include "af_rtc.h"
-#include "cic.h"
-#include "eeprom.h"
-#include "game_controller.h"
-
-struct si_controller;
-
-enum { PIF_RAM_SIZE = 0x40 };
-
-enum pif_commands
-{
-    PIF_CMD_STATUS = 0x00,
-    PIF_CMD_CONTROLLER_READ = 0x01,
-    PIF_CMD_PAK_READ = 0x02,
-    PIF_CMD_PAK_WRITE = 0x03,
-    PIF_CMD_EEPROM_READ = 0x04,
-    PIF_CMD_EEPROM_WRITE = 0x05,
-    PIF_CMD_AF_RTC_STATUS = 0x06,
-    PIF_CMD_AF_RTC_READ = 0x07,
-    PIF_CMD_AF_RTC_WRITE = 0x08,
-    PIF_CMD_RESET = 0xff,
-};
-
-struct pif
-{
-    uint8_t ram[PIF_RAM_SIZE];
-
-    uint8_t eeprom[EEPROM_MAX_SIZE];
-
-    struct game_controllers controllers;
-
-    struct af_rtc af_rtc;
-
-    struct cic cic;
-};
-
-static inline uint32_t pif_ram_address(uint32_t address)
-{
-    return ((address & 0xfffc) - 0x7c0);
-}
-
-
-void init_pif(struct pif* pif);
-
-int read_pif_ram(void* opaque, uint32_t address, uint32_t* value);
-int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
-
-void update_pif_write(struct si_controller* si);
-void update_pif_read(struct si_controller* si);
+const struct tm* get_time_using_C_localtime(void* user_data);
 
 #endif
-

--- a/src/plugin/rumble_via_input_plugin.h
+++ b/src/plugin/rumble_via_input_plugin.h
@@ -1,5 +1,5 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - mpk_file.h                                              *
+ *   Mupen64plus - rumble_via_input_plugin.h                               *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
  *   Copyright (C) 2014 Bobby Smiles                                       *
  *                                                                         *
@@ -19,27 +19,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_MAIN_MPK_FILE_H
-#define M64P_MAIN_MPK_FILE_H
+#ifndef M64P_PLUGIN_RUMBLE_VIA_INPUT_PLUGIN_H
+#define M64P_PLUGIN_RUMBLE_VIA_INPUT_PLUGIN_H
 
-#include "si/mempak.h"
-#include "si/pif.h"
+enum rumble_action;
 
-#include <stddef.h>
-#include <stdint.h>
-
-struct mpk_file
-{
-    uint8_t mempaks[GAME_CONTROLLERS_COUNT][MEMPAK_SIZE];
-    const char* filename;
-    int touched;
-};
-
-void open_mpk_file(struct mpk_file* mpk, const char* filename);
-void close_mpk_file(struct mpk_file* mpk);
-
-uint8_t* mpk_file_ptr(struct mpk_file* mpk, size_t controller_idx);
-
-void touch_mpk_file(void* opaque);
+void rvip_rumble(void* opaque, enum rumble_action action);
 
 #endif

--- a/src/si/af_rtc.c
+++ b/src/si/af_rtc.c
@@ -32,7 +32,12 @@ static unsigned char byte2bcd(int n)
     return ((n / 10) << 4) | (n % 10);
 }
 
-void af_rtc_status_command(struct pif* pif, int channel, uint8_t* cmd)
+const struct tm* af_rtc_get_time(struct af_rtc* rtc)
+{
+    return rtc->get_time(rtc->user_data);
+}
+
+void af_rtc_status_command(struct af_rtc* rtc, uint8_t* cmd)
 {
     /* AF-RTC status query */
     cmd[3] = 0x00;
@@ -40,10 +45,9 @@ void af_rtc_status_command(struct pif* pif, int channel, uint8_t* cmd)
     cmd[5] = 0x00;
 }
 
-void af_rtc_read_command(struct pif* pif, int channel, uint8_t* cmd)
+void af_rtc_read_command(struct af_rtc* rtc, uint8_t* cmd)
 {
-    time_t curtime_time;
-    struct tm *curtime;
+    const struct tm *rtc_time;
 
     /* read RTC block (cmd[3]: block number) */
     switch (cmd[3])
@@ -57,22 +61,21 @@ void af_rtc_read_command(struct pif* pif, int channel, uint8_t* cmd)
         DebugMessage(M64MSG_ERROR, "AF-RTC read command: cannot read block 1");
         break;
     case 2:
-        time(&curtime_time);
-        curtime = localtime(&curtime_time);
-        cmd[4] = byte2bcd(curtime->tm_sec);
-        cmd[5] = byte2bcd(curtime->tm_min);
-        cmd[6] = 0x80 + byte2bcd(curtime->tm_hour);
-        cmd[7] = byte2bcd(curtime->tm_mday);
-        cmd[8] = byte2bcd(curtime->tm_wday);
-        cmd[9] = byte2bcd(curtime->tm_mon + 1);
-        cmd[10] = byte2bcd(curtime->tm_year);
-        cmd[11] = byte2bcd(curtime->tm_year / 100);
+        rtc_time = af_rtc_get_time(rtc);
+        cmd[4] = byte2bcd(rtc_time->tm_sec);
+        cmd[5] = byte2bcd(rtc_time->tm_min);
+        cmd[6] = 0x80 + byte2bcd(rtc_time->tm_hour);
+        cmd[7] = byte2bcd(rtc_time->tm_mday);
+        cmd[8] = byte2bcd(rtc_time->tm_wday);
+        cmd[9] = byte2bcd(rtc_time->tm_mon + 1);
+        cmd[10] = byte2bcd(rtc_time->tm_year);
+        cmd[11] = byte2bcd(rtc_time->tm_year / 100);
         cmd[12] = 0x00;	// status
         break;
     }
 }
 
-void af_rtc_write_command(struct pif* pif, int channel, uint8_t* cmd)
+void af_rtc_write_command(struct af_rtc* rtc, uint8_t* cmd)
 {
     /* write RTC block */
     DebugMessage(M64MSG_ERROR, "AF-RTC write command: not yet implemented");

--- a/src/si/af_rtc.h
+++ b/src/si/af_rtc.h
@@ -24,10 +24,19 @@
 
 #include <stdint.h>
 
-struct pif;
+struct tm;
 
-void af_rtc_status_command(struct pif* pif, int channel, uint8_t* cmd);
-void af_rtc_read_command(struct pif* pif, int channel, uint8_t* cmd);
-void af_rtc_write_command(struct pif* pif, int channel, uint8_t* cmd);
+struct af_rtc
+{
+    /* external time source */
+    void* user_data;
+    const struct tm* (*get_time)(void*);
+};
+
+const struct tm* af_rtc_get_time(struct af_rtc* rtc);
+
+void af_rtc_status_command(struct af_rtc* rtc, uint8_t* cmd);
+void af_rtc_read_command(struct af_rtc* rtc, uint8_t* cmd);
+void af_rtc_write_command(struct af_rtc* rtc, uint8_t* cmd);
 
 #endif

--- a/src/si/eeprom.c
+++ b/src/si/eeprom.c
@@ -27,9 +27,9 @@
 #include <string.h>
 
 
-void eeprom_touch(struct eeprom* eeprom)
+void eeprom_save(struct eeprom* eeprom)
 {
-    eeprom->touch(eeprom->user_data);
+    eeprom->save(eeprom->user_data);
 }
 
 void format_eeprom(uint8_t* eeprom, size_t size)
@@ -84,7 +84,7 @@ void eeprom_write_command(struct eeprom* eeprom, uint8_t* cmd)
     if (address < eeprom->size)
     {
         memcpy(&eeprom->data[address], data, 8);
-        eeprom_touch(eeprom);
+        eeprom_save(eeprom);
     }
     else
     {

--- a/src/si/eeprom.c
+++ b/src/si/eeprom.c
@@ -20,67 +20,24 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "eeprom.h"
-#include "pif.h"
 
-#include "api/m64p_types.h"
-#include "api/callbacks.h"
-
-#include "main/main.h"
 #include "main/rom.h"
-#include "main/util.h"
 
-#include <stdlib.h>
 #include <string.h>
 
-static char *get_eeprom_path(void)
+
+void eeprom_touch(struct eeprom* eeprom)
 {
-    return formatstr("%s%s.eep", get_savesrampath(), ROM_SETTINGS.goodname);
+    eeprom->touch(eeprom->user_data);
 }
 
-static void eeprom_format(void* eeprom)
+void format_eeprom(uint8_t* eeprom)
 {
     memset(eeprom, 0xff, EEPROM_MAX_SIZE);
 }
 
-static void eeprom_read_file(void* eeprom)
-{
-    char *filename = get_eeprom_path();
 
-    switch (read_from_file(filename, eeprom, EEPROM_MAX_SIZE))
-    {
-        case file_open_error:
-            DebugMessage(M64MSG_VERBOSE, "couldn't open eeprom file '%s' for reading", filename);
-            eeprom_format(eeprom);
-            break;
-        case file_read_error:
-            DebugMessage(M64MSG_WARNING, "fread() failed for 2kb eeprom file '%s'", filename);
-            break;
-        default: break;
-    }
-
-    free(filename);
-}
-
-static void eeprom_write_file(void* eeprom)
-{
-    char *filename = get_eeprom_path();
-
-    switch (write_to_file(filename, eeprom, EEPROM_MAX_SIZE))
-    {
-        case file_open_error:
-            DebugMessage(M64MSG_WARNING, "couldn't open eeprom file '%s' for writing", filename);
-            break;
-        case file_write_error:
-            DebugMessage(M64MSG_WARNING, "fwrite() failed for 2kb eeprom file '%s'", filename);
-            break;
-        default: break;
-    }
-
-    free(filename);
-}
-
-
-void eeprom_status_command(struct pif* pif, int channel, uint8_t* cmd)
+void eeprom_status_command(struct eeprom* eeprom, uint8_t* cmd)
 {
     /* check size */
     if (cmd[1] != 3)
@@ -101,18 +58,16 @@ void eeprom_status_command(struct pif* pif, int channel, uint8_t* cmd)
     }
 }
 
-void eeprom_read_command(struct pif* pif, int channel, uint8_t* cmd)
+void eeprom_read_command(struct eeprom* eeprom, uint8_t* cmd)
 {
     /* read 8-byte block */
-    eeprom_read_file(pif->eeprom);
-    memcpy(&cmd[4], pif->eeprom + cmd[3]*8, 8);
+    memcpy(&cmd[4], eeprom->data + cmd[3]*8, 8);
 }
 
-void eeprom_write_command(struct pif* pif, int channel, uint8_t* cmd)
+void eeprom_write_command(struct eeprom* eeprom, uint8_t* cmd)
 {
     /* write 8-byte block */
-    eeprom_read_file(pif->eeprom);
-    memcpy(pif->eeprom + cmd[3]*8, &cmd[4], 8);
-    eeprom_write_file(pif->eeprom);
+    memcpy(eeprom->data + cmd[3]*8, &cmd[4], 8);
+    eeprom_touch(eeprom);
 }
 

--- a/src/si/eeprom.h
+++ b/src/si/eeprom.h
@@ -29,14 +29,14 @@ struct eeprom
 {
     /* external eep storage */
     void* user_data;
-    void (*touch)(void*);
+    void (*save)(void*);
     uint8_t* data;
     size_t size;
     uint16_t id;
 };
 
 
-void eeprom_touch(struct eeprom* eeprom);
+void eeprom_save(struct eeprom* eeprom);
 
 void format_eeprom(uint8_t* eeprom, size_t size);
 

--- a/src/si/eeprom.h
+++ b/src/si/eeprom.h
@@ -22,9 +22,8 @@
 #ifndef M64P_SI_EEPROM_H
 #define M64P_SI_EEPROM_H
 
+#include <stddef.h>
 #include <stdint.h>
-
-enum { EEPROM_MAX_SIZE = 0x800 };
 
 struct eeprom
 {
@@ -32,12 +31,14 @@ struct eeprom
     void* user_data;
     void (*touch)(void*);
     uint8_t* data;
+    size_t size;
+    uint16_t id;
 };
 
 
 void eeprom_touch(struct eeprom* eeprom);
 
-void format_eeprom(uint8_t* eeprom);
+void format_eeprom(uint8_t* eeprom, size_t size);
 
 void eeprom_status_command(struct eeprom* eeprom, uint8_t* cmd);
 void eeprom_read_command(struct eeprom* eeprom, uint8_t* cmd);

--- a/src/si/eeprom.h
+++ b/src/si/eeprom.h
@@ -24,12 +24,23 @@
 
 #include <stdint.h>
 
-struct pif;
-
 enum { EEPROM_MAX_SIZE = 0x800 };
 
-void eeprom_status_command(struct pif* pif, int channel, uint8_t* cmd);
-void eeprom_read_command(struct pif* pif, int channel, uint8_t* cmd);
-void eeprom_write_command(struct pif* pif, int channel, uint8_t* cmd);
+struct eeprom
+{
+    /* external eep storage */
+    void* user_data;
+    void (*touch)(void*);
+    uint8_t* data;
+};
+
+
+void eeprom_touch(struct eeprom* eeprom);
+
+void format_eeprom(uint8_t* eeprom);
+
+void eeprom_status_command(struct eeprom* eeprom, uint8_t* cmd);
+void eeprom_read_command(struct eeprom* eeprom, uint8_t* cmd);
+void eeprom_write_command(struct eeprom* eeprom, uint8_t* cmd);
 
 #endif

--- a/src/si/game_controller.c
+++ b/src/si/game_controller.c
@@ -108,7 +108,7 @@ static void controller_read_pak_command(struct pif* pif, int channel, uint8_t* c
 
     switch (Controls[channel].Plugin)
     {
-    case PLUGIN_MEMPAK: mempak_read_command(&pif->controllers, channel, cmd); break;
+    case PLUGIN_MEMPAK: mempak_read_command(&pif->controllers.mempaks[channel], cmd); break;
     case PLUGIN_RAW:
         if (input.controllerCommand)
             input.controllerCommand(channel, cmd);
@@ -129,7 +129,7 @@ static void controller_write_pak_command(struct pif* pif, int channel, uint8_t* 
 
     switch (Controls[channel].Plugin)
     {
-    case PLUGIN_MEMPAK: mempak_write_command(&pif->controllers, channel, cmd); break;
+    case PLUGIN_MEMPAK: mempak_write_command(&pif->controllers.mempaks[channel], cmd); break;
     case PLUGIN_RAW:
         if (input.controllerCommand)
             input.controllerCommand(channel, cmd);

--- a/src/si/game_controller.h
+++ b/src/si/game_controller.h
@@ -30,7 +30,7 @@ struct pif;
 
 struct game_controllers
 {
-    uint8_t mempaks[MEMPAK_COUNT][MEMPAK_SIZE]; 
+    struct mempak mempaks[MEMPAK_COUNT];
 };
 
 void process_controller_command(struct pif* pif, int channel, uint8_t* cmd);

--- a/src/si/game_controller.h
+++ b/src/si/game_controller.h
@@ -25,17 +25,31 @@
 #include <stdint.h>
 
 #include "mempak.h"
+#include "rumblepak.h"
 
-struct pif;
-
-struct game_controllers
+enum pak_type
 {
-    struct mempak mempaks[MEMPAK_COUNT];
+    PAK_NONE,
+    PAK_MEM,
+    PAK_RUMBLE,
+    PAK_TRANSFER
 };
 
-void process_controller_command(struct pif* pif, int channel, uint8_t* cmd);
-void read_controller(struct pif* pif, int channel, uint8_t* cmd);
+struct game_controller
+{
+    /* external controller input */
+    void* user_data;
+    int (*is_connected)(void*,enum pak_type*);
+    uint32_t (*get_input)(void*);
 
-uint8_t pak_crc(uint8_t* data);
+    struct mempak mempak;
+    struct rumblepak rumblepak;
+};
+
+int game_controller_is_connected(struct game_controller* cont, enum pak_type* pak);
+uint32_t game_controller_get_input(struct game_controller* cont);
+
+void process_controller_command(struct game_controller* cont, uint8_t* cmd);
+void read_controller(struct game_controller* cont, uint8_t* cmd);
 
 #endif

--- a/src/si/mempak.c
+++ b/src/si/mempak.c
@@ -65,44 +65,30 @@ void format_mempak(uint8_t* mpk_data)
 
 void mempak_read_command(struct mempak* mpk, uint8_t* cmd)
 {
-    /* address is in fact an offset (11bit) | CRC (5 bits) */
-    uint16_t address = (cmd[3] << 8) | cmd[4];
+    uint16_t address = (cmd[3] << 8) | (cmd[4] & 0xe0);
 
-    if (address == 0x8001)
+    if (address < 0x8000)
     {
-        memset(&cmd[5], 0, 0x20);
+        memcpy(&cmd[5], &mpk->data[address], 0x20);
     }
     else
     {
-        address &= 0xFFE0;
-        if (address <= 0x7FE0)
-        {
-            memcpy(&cmd[5], &mpk->data[address], 0x20);
-        }
-        else
-        {
-            memset(&cmd[5], 0, 0x20);
-        }
+        memset(&cmd[5], 0x00, 0x20);
     }
 }
 
 void mempak_write_command(struct mempak* mpk, uint8_t* cmd)
 {
-    /* address is in fact an offset (11bit) | CRC (5 bits) */
-    uint16_t address = (cmd[3] << 8) | cmd[4];
+    uint16_t address = (cmd[3] << 8) | (cmd[4] & 0xe0);
 
-    if (address == 0x8001)
+    if (address < 0x8000)
     {
-        /* do nothing */
+        memcpy(&mpk->data[address], &cmd[5], 0x20);
+        mempak_touch(mpk);
     }
     else
     {
-        address &= 0xFFE0;
-        if (address <= 0x7FE0)
-        {
-            memcpy(&mpk->data[address], &cmd[5], 0x20);
-            mempak_touch(mpk);
-        }
+        /* do nothing */
     }
 }
 

--- a/src/si/mempak.c
+++ b/src/si/mempak.c
@@ -24,9 +24,9 @@
 #include <stdint.h>
 #include <string.h>
 
-void mempak_touch(struct mempak* mpk)
+void mempak_save(struct mempak* mpk)
 {
-    mpk->touch(mpk->user_data);
+    mpk->save(mpk->user_data);
 }
 
 void format_mempak(uint8_t* mpk_data)
@@ -84,7 +84,7 @@ void mempak_write_command(struct mempak* mpk, uint8_t* cmd)
     if (address < 0x8000)
     {
         memcpy(&mpk->data[address], &cmd[5], 0x20);
-        mempak_touch(mpk);
+        mempak_save(mpk);
     }
     else
     {

--- a/src/si/mempak.c
+++ b/src/si/mempak.c
@@ -20,7 +20,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "mempak.h"
-#include "game_controller.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -72,7 +71,6 @@ void mempak_read_command(struct mempak* mpk, uint8_t* cmd)
     if (address == 0x8001)
     {
         memset(&cmd[5], 0, 0x20);
-        cmd[0x25] = pak_crc(&cmd[5]);
     }
     else
     {
@@ -85,7 +83,6 @@ void mempak_read_command(struct mempak* mpk, uint8_t* cmd)
         {
             memset(&cmd[5], 0, 0x20);
         }
-        cmd[0x25] = pak_crc(&cmd[5]);
     }
 }
 
@@ -96,7 +93,7 @@ void mempak_write_command(struct mempak* mpk, uint8_t* cmd)
 
     if (address == 0x8001)
     {
-        cmd[0x25] = pak_crc(&cmd[5]);
+        /* do nothing */
     }
     else
     {
@@ -106,7 +103,6 @@ void mempak_write_command(struct mempak* mpk, uint8_t* cmd)
             memcpy(&mpk->data[address], &cmd[5], 0x20);
             mempak_touch(mpk);
         }
-        cmd[0x25] = pak_crc(&cmd[5]);
     }
 }
 

--- a/src/si/mempak.h
+++ b/src/si/mempak.h
@@ -28,13 +28,13 @@ struct mempak
 {
     /* external mpk storage */
     void* user_data;
-    void (*touch)(void*);
+    void (*save)(void*);
     uint8_t* data;
 };
 
 enum { MEMPAK_SIZE = 0x8000 };
 
-void mempak_touch(struct mempak* mpk);
+void mempak_save(struct mempak* mpk);
 
 void format_mempak(uint8_t* mempak);
 

--- a/src/si/mempak.h
+++ b/src/si/mempak.h
@@ -32,7 +32,6 @@ struct mempak
     uint8_t* data;
 };
 
-enum { MEMPAK_COUNT = 4 };
 enum { MEMPAK_SIZE = 0x8000 };
 
 void mempak_touch(struct mempak* mpk);

--- a/src/si/pif.c
+++ b/src/si/pif.c
@@ -44,13 +44,13 @@ void print_pif(struct pif* pif)
 }
 #endif
 
-static void process_cart_command(struct pif* pif, int channel, uint8_t* cmd)
+static void process_cart_command(struct pif* pif, uint8_t* cmd)
 {
     switch (cmd[2])
     {
-    case PIF_CMD_STATUS: eeprom_status_command(pif, channel, cmd); break;
-    case PIF_CMD_EEPROM_READ: eeprom_read_command(pif, channel, cmd); break;
-    case PIF_CMD_EEPROM_WRITE: eeprom_write_command(pif, channel, cmd); break;
+    case PIF_CMD_STATUS: eeprom_status_command(&pif->eeprom, cmd); break;
+    case PIF_CMD_EEPROM_READ: eeprom_read_command(&pif->eeprom, cmd); break;
+    case PIF_CMD_EEPROM_WRITE: eeprom_write_command(&pif->eeprom, cmd); break;
     case PIF_CMD_AF_RTC_STATUS: af_rtc_status_command(&pif->af_rtc, cmd); break;
     case PIF_CMD_AF_RTC_READ: af_rtc_read_command(&pif->af_rtc, cmd); break;
     case PIF_CMD_AF_RTC_WRITE: af_rtc_write_command(&pif->af_rtc, cmd); break;
@@ -177,7 +177,7 @@ void update_pif_write(struct si_controller* si)
                         process_controller_command(&pif->controllers[channel], &pif->ram[i]);
                 }
                 else if (channel == 4)
-                    process_cart_command(pif, channel, &pif->ram[i]);
+                    process_cart_command(pif, &pif->ram[i]);
                 else
                     DebugMessage(M64MSG_ERROR, "channel >= 4 in update_pif_write");
                 i += pif->ram[i] + (pif->ram[(i+1)] & 0x3F) + 1;

--- a/src/si/pif.c
+++ b/src/si/pif.c
@@ -51,9 +51,9 @@ static void process_cart_command(struct pif* pif, int channel, uint8_t* cmd)
     case PIF_CMD_STATUS: eeprom_status_command(pif, channel, cmd); break;
     case PIF_CMD_EEPROM_READ: eeprom_read_command(pif, channel, cmd); break;
     case PIF_CMD_EEPROM_WRITE: eeprom_write_command(pif, channel, cmd); break;
-    case PIF_CMD_AF_RTC_STATUS: af_rtc_status_command(pif, channel, cmd); break;
-    case PIF_CMD_AF_RTC_READ: af_rtc_read_command(pif, channel, cmd); break;
-    case PIF_CMD_AF_RTC_WRITE: af_rtc_write_command(pif, channel, cmd); break;
+    case PIF_CMD_AF_RTC_STATUS: af_rtc_status_command(&pif->af_rtc, cmd); break;
+    case PIF_CMD_AF_RTC_READ: af_rtc_read_command(&pif->af_rtc, cmd); break;
+    case PIF_CMD_AF_RTC_WRITE: af_rtc_write_command(&pif->af_rtc, cmd); break;
     default:
         DebugMessage(M64MSG_ERROR, "unknown PIF command: %02x", cmd[2]);
     }

--- a/src/si/pif.c
+++ b/src/si/pif.c
@@ -174,7 +174,7 @@ void update_pif_write(struct si_controller* si)
                     if (Controls[channel].Present && Controls[channel].RawData)
                         input.controllerCommand(channel, &pif->ram[i]);
                     else
-                        process_controller_command(pif, channel, &pif->ram[i]);
+                        process_controller_command(&pif->controllers[channel], &pif->ram[i]);
                 }
                 else if (channel == 4)
                     process_cart_command(pif, channel, &pif->ram[i]);
@@ -225,7 +225,7 @@ void update_pif_read(struct si_controller* si)
                     if (Controls[channel].Present && Controls[channel].RawData)
                         input.readController(channel, &pif->ram[i]);
                     else
-                        read_controller(pif, channel, &pif->ram[i]);
+                        read_controller(&pif->controllers[channel], &pif->ram[i]);
                 }
 
                 i += pif->ram[i] + (pif->ram[(i+1)] & 0x3F) + 1;

--- a/src/si/pif.h
+++ b/src/si/pif.h
@@ -29,6 +29,8 @@
 #include "eeprom.h"
 #include "game_controller.h"
 
+enum { GAME_CONTROLLERS_COUNT = 4 };
+
 struct si_controller;
 
 enum { PIF_RAM_SIZE = 0x40 };
@@ -53,7 +55,7 @@ struct pif
 
     uint8_t eeprom[EEPROM_MAX_SIZE];
 
-    struct game_controllers controllers;
+    struct game_controller controllers[GAME_CONTROLLERS_COUNT];
 
     struct af_rtc af_rtc;
 

--- a/src/si/rumblepak.c
+++ b/src/si/rumblepak.c
@@ -31,16 +31,19 @@ void rumblepak_rumble(struct rumblepak* rpk, enum rumble_action action)
 
 void rumblepak_read_command(struct rumblepak* rpk, uint8_t* cmd)
 {
+    uint8_t data;
     uint16_t address = (cmd[3] << 8) | (cmd[4] & 0xe0);
 
     if ((address >= 0x8000) && (address < 0x9000))
     {
-        memset(&cmd[5], 0x80, 0x20);
+        data = 0x80;
     }
     else
     {
-        memset(&cmd[5], 0x00, 0x20);
+        data = 0x00;
     }
+
+    memset(&cmd[5], data, 0x20);
 }
 
 void rumblepak_write_command(struct rumblepak* rpk, uint8_t* cmd)

--- a/src/si/rumblepak.h
+++ b/src/si/rumblepak.h
@@ -1,5 +1,5 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - mpk_file.h                                              *
+ *   Mupen64plus - rumblepak.h                                             *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
  *   Copyright (C) 2014 Bobby Smiles                                       *
  *                                                                         *
@@ -19,27 +19,27 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_MAIN_MPK_FILE_H
-#define M64P_MAIN_MPK_FILE_H
+#ifndef M64P_SI_RUMBLEPAK_H
+#define M64P_SI_RUMBLEPAK_H
 
-#include "si/mempak.h"
-#include "si/pif.h"
-
-#include <stddef.h>
 #include <stdint.h>
 
-struct mpk_file
+enum rumble_action
 {
-    uint8_t mempaks[GAME_CONTROLLERS_COUNT][MEMPAK_SIZE];
-    const char* filename;
-    int touched;
+    RUMBLE_STOP,
+    RUMBLE_START
 };
 
-void open_mpk_file(struct mpk_file* mpk, const char* filename);
-void close_mpk_file(struct mpk_file* mpk);
+struct rumblepak
+{
+    /* external rumble sink */
+    void* user_data;
+    void (*rumble)(void*,enum rumble_action);
+};
 
-uint8_t* mpk_file_ptr(struct mpk_file* mpk, size_t controller_idx);
+void rumblepak_rumble(struct rumblepak* rpk, enum rumble_action action);
 
-void touch_mpk_file(void* opaque);
+void rumblepak_read_command(struct rumblepak* rpk, uint8_t* cmd);
+void rumblepak_write_command(struct rumblepak* rpk, uint8_t* cmd);
 
 #endif


### PR DESCRIPTION
This PR should be applied after PR #62 .

Main features of this PR includes:
- separation of save chips emulation (mempak,eeprom,sram,flashram) from their file-based storage.
- no more file accesses everytime a save chip is accessed. Files are read/written only at the beginning/end of emulation.
- separation of game controller emulation from the input plugin. For now we still call the input plugin to read controllers buttons, but in the future, we should let the frontend decide what to do (input via touchscreen, via keypress file (TAS), ...)
- integration of rumblepak emulation inside the core. For now we still call the input plugin to rumble, but in the future, we should let the frontend decide what to do (shake screen, trigger sound, rumble controller, ...)
- allow to specify alternate time source for RTC emulation. For now we only provide a C localtime time source, but other possibilities could be implemented (for instance a user defined date whoch could be helpful for TAS).
- various refactorings

All in all, this PR provides more flexibility "under the hood", and should be seen as a first step toward moving more responsibilities to the frontend, and removing dependencies in the core.

EDIT: due to concerns about saved data loss, we now flush saved data to disk immediately.