### PR TITLE
Raspberry Pi fix and ARM NEON/VFP_HARD cleanup

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -97,10 +97,10 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
     NEW_DYNAREC := 1
     CFLAGS += -marm
     ifeq ($(NEON), 1)
-        CFLAGS += -mfpu=neon -mfloat-abi=hard -DNEON
+        CFLAGS += -mfpu=neon -mfloat-abi=hard
     else
       ifeq ($(VFP_HARD), 1)
-        CFLAGS += -mfpu=vfp -mfloat-abi=hard -DVFP_HARD
+        CFLAGS += -mfpu=vfp -mfloat-abi=hard
       else
         CFLAGS += -mfpu=vfp -mfloat-abi=softfp
       endif

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -96,6 +96,14 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
     PIC ?= 1
     NEW_DYNAREC := 1
     CFLAGS += -marm
+    ifneq ("$(filter armv5%,$(HOST_CPU))","")
+    	CFLAGS += -DARMv5_ONLY
+    	$(warning Using ARMv5_ONLY)
+    endif
+    ifneq ("$(filter armv6%,$(HOST_CPU))","")
+    	CFLAGS += -DARMv5_ONLY
+    	$(warning Using ARMv5_ONLY)
+    endif
     ifeq ($(NEON), 1)
         CFLAGS += -mfpu=neon -mfloat-abi=hard
     else

--- a/src/r4300/new_dynarec/linkage_arm.S
+++ b/src/r4300/new_dynarec/linkage_arm.S
@@ -18,25 +18,27 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 	.cpu arm9tdmi
-#ifndef NEON
-#ifndef VFP_HARD
-	.fpu softvfp
+#ifndef __ARM_NEON__
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
+ 	.fpu vfp
 #else
-	.fpu vfp
+	.fpu softvfp
 #endif
 #else
     	.fpu neon
 #endif
 	.eabi_attribute 20, 1
 	.eabi_attribute 21, 1
-#ifndef NEON
+#ifndef __ARM_NEON__
 	.eabi_attribute 23, 3
 #endif
 	.eabi_attribute 24, 1
 	.eabi_attribute 25, 1
 	.eabi_attribute 26, 2
-#ifdef VFP_HARD
+#ifndef __ARM_NEON__
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__))
 	.eabi_attribute 28, 1
+#endif
 #endif
 	.eabi_attribute 30, 6
 	.eabi_attribute 18, 4


### PR DESCRIPTION
-ARMv5 and ARMv6 (like Raspberry PIs CPU) need -DARMv5_ONLY (assem_arm.c). Check CPU and set define if ARMv5 or ARMv6 is present.
-Use gcc macros instead of -DNEON and -DVFP_HARD (linkage_arm.S and Makefile)
-Raspberry PI: Mupen64plus-core is running now with "make VFP_HARD=1 VC=1 OSD=0". Default rice plugin still fails with a core error (SDL_SetVideoMode failed). mupen64plus-video-gles2n64 plugin from ricrpi is working. GLES stuff needs some investigation.
