### PR TITLE
AI refactorings

### DIFF
--- a/projects/msvc11/mupen64plus-core.vcxproj
+++ b/projects/msvc11/mupen64plus-core.vcxproj
@@ -132,6 +132,7 @@
     <ClCompile Include="..\..\src\main\eep_file.c" />
     <ClCompile Include="..\..\src\si\eeprom.c" />
     <ClCompile Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.c" />
+    <ClCompile Include="..\..\src\plugin\emulate_speaker_via_audio_plugin.c" />
     <ClCompile Include="..\..\src\main\eventloop.c" />
     <ClCompile Include="..\..\src\r4300\exception.c" />
     <ClCompile Include="..\..\src\rdp\fb.c" />
@@ -225,6 +226,7 @@
     <ClInclude Include="..\..\src\main\eep_file.h" />
     <ClInclude Include="..\..\src\si\eeprom.h" />
     <ClInclude Include="..\..\src\plugin\emulate_game_controller_via_input_plugin.h" />
+    <ClInclude Include="..\..\src\plugin\emulate_speaker_via_audio_plugin.h" />
     <ClInclude Include="..\..\src\main\eventloop.h" />
     <ClInclude Include="..\..\src\r4300\exception.h" />
     <ClInclude Include="..\..\src\rdp\fb.h" />

--- a/projects/msvc8/mupen64plus-core.vcproj
+++ b/projects/msvc8/mupen64plus-core.vcproj
@@ -301,6 +301,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\plugin\emulate_speaker_via_audio_plugin.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\main\eventloop.c"
 				>
 			</File>
@@ -668,6 +672,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\plugin\emulate_game_controller_via_input_plugin.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\plugin\emulate_speaker_via_audio_plugin.h"
 				>
 			</File>
 			<File

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -432,6 +432,7 @@ SOURCE = \
 	$(SRCDIR)/pi/pi_controller.c \
 	$(SRCDIR)/pi/sram.c \
 	$(SRCDIR)/plugin/emulate_game_controller_via_input_plugin.c \
+	$(SRCDIR)/plugin/emulate_speaker_via_audio_plugin.c \
 	$(SRCDIR)/plugin/get_time_using_C_localtime.c \
 	$(SRCDIR)/plugin/rumble_via_input_plugin.c \
 	$(SRCDIR)/plugin/plugin.c \

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -63,6 +63,7 @@
 #include "pi/pi_controller.h"
 #include "plugin/plugin.h"
 #include "plugin/emulate_game_controller_via_input_plugin.h"
+#include "plugin/emulate_speaker_via_audio_plugin.h"
 #include "plugin/get_time_using_C_localtime.h"
 #include "plugin/rumble_via_input_plugin.h"
 #include "r4300/r4300.h"
@@ -851,7 +852,7 @@ static void connect_all(
 {
     connect_rdp(dp, r4300, sp, ri);
     connect_rsp(sp, r4300, dp, ri);
-    connect_ai(ai, r4300, vi);
+    connect_ai(ai, r4300, ri, vi);
     connect_pi(pi, r4300, ri, rom, rom_size);
     connect_ri(ri, dram, dram_size);
     connect_si(si, r4300, ri);
@@ -924,6 +925,11 @@ m64p_error main_run(void)
 
     // setup rendering callback from video plugin to the core, for screenshots and On-Screen-Display
     gfx.setRenderingCallback(video_plugin_render_callback);
+
+    /* connect external audio sink to AI component */
+    g_ai.user_data = &g_ai;
+    g_ai.set_audio_format = set_audio_format_via_audio_plugin;
+    g_ai.push_audio_samples = push_audio_samples_via_audio_plugin;
 
     /* connect external time source to AF_RTC component */
     g_si.pif.af_rtc.user_data = NULL;

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -364,11 +364,17 @@ static int savestates_load_m64p(char *filepath)
     g_ai.regs[AI_STATUS_REG]    = GETDATA(curr, uint32_t);
     g_ai.regs[AI_DACRATE_REG]   = GETDATA(curr, uint32_t);
     g_ai.regs[AI_BITRATE_REG]   = GETDATA(curr, uint32_t);
-    g_ai.fifo[1].delay  = GETDATA(curr, unsigned int);
+    g_ai.fifo[1].duration  = GETDATA(curr, unsigned int);
     g_ai.fifo[1].length = GETDATA(curr, uint32_t);
-    g_ai.fifo[0].delay  = GETDATA(curr, unsigned int);
+    g_ai.fifo[0].duration  = GETDATA(curr, unsigned int);
     g_ai.fifo[0].length = GETDATA(curr, uint32_t);
-    audio.aiDacrateChanged(ROM_PARAMS.systemtype);
+    /* best effort initialization of fifo addresses...
+     * You might get a small sound "pop" because address might be wrong.
+     * Proper initialization requires changes to savestate format
+     */
+    g_ai.fifo[0].address = g_ai.regs[AI_DRAM_ADDR_REG];
+    g_ai.fifo[1].address = g_ai.regs[AI_DRAM_ADDR_REG];
+    g_ai.samples_format_changed = 1;
 
     g_dp.dpc_regs[DPC_START_REG]    = GETDATA(curr, uint32_t);
     g_dp.dpc_regs[DPC_END_REG]      = GETDATA(curr, uint32_t);
@@ -648,7 +654,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     g_ai.regs[AI_STATUS_REG]    = GETDATA(curr, uint32_t);
     g_ai.regs[AI_DACRATE_REG]   = GETDATA(curr, uint32_t);
     g_ai.regs[AI_BITRATE_REG]   = GETDATA(curr, uint32_t);
-    audio.aiDacrateChanged(ROM_PARAMS.systemtype);
+    g_ai.samples_format_changed = 1;
 
     // pi_register
     g_pi.regs[PI_DRAM_ADDR_REG]    = GETDATA(curr, uint32_t);
@@ -1133,9 +1139,9 @@ static int savestates_save_m64p(char *filepath)
     PUTDATA(curr, uint32_t, g_ai.regs[AI_STATUS_REG]);
     PUTDATA(curr, uint32_t, g_ai.regs[AI_DACRATE_REG]);
     PUTDATA(curr, uint32_t, g_ai.regs[AI_BITRATE_REG]);
-    PUTDATA(curr, unsigned int, g_ai.fifo[1].delay);
+    PUTDATA(curr, unsigned int, g_ai.fifo[1].duration);
     PUTDATA(curr, uint32_t    , g_ai.fifo[1].length);
-    PUTDATA(curr, unsigned int, g_ai.fifo[0].delay);
+    PUTDATA(curr, unsigned int, g_ai.fifo[0].duration);
     PUTDATA(curr, uint32_t    , g_ai.fifo[0].length);
 
     PUTDATA(curr, uint32_t, g_dp.dpc_regs[DPC_START_REG]);

--- a/src/plugin/emulate_speaker_via_audio_plugin.c
+++ b/src/plugin/emulate_speaker_via_audio_plugin.c
@@ -1,0 +1,62 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - emulate_speaker_via_audio_plugin.c                      *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "emulate_speaker_via_audio_plugin.h"
+
+#include "ai/ai_controller.h"
+#include "main/rom.h"
+#include "plugin/plugin.h"
+#include "ri/ri_controller.h"
+
+#include <stdint.h>
+
+void set_audio_format_via_audio_plugin(void* user_data, unsigned int frequency, unsigned int bits)
+{
+    /* not really implementable with just the zilmar spec.
+     * Try a best effort approach
+     */
+    struct ai_controller* ai = (struct ai_controller*)user_data;
+    uint32_t saved_ai_dacrate = ai->regs[AI_DACRATE_REG];
+    
+    ai->regs[AI_DACRATE_REG] = ROM_PARAMS.aidacrate / frequency - 1;
+
+    audio.aiDacrateChanged(ROM_PARAMS.systemtype);
+
+    ai->regs[AI_DACRATE_REG] = saved_ai_dacrate;
+}
+
+void push_audio_samples_via_audio_plugin(void* user_data, const void* buffer, size_t size)
+{
+    /* abuse core & audio plugin implementation to approximate desired effect */
+    struct ai_controller* ai = (struct ai_controller*)user_data;
+    uint32_t saved_ai_length = ai->regs[AI_LEN_REG];
+    uint32_t saved_ai_dram = ai->regs[AI_DRAM_ADDR_REG];
+
+    /* exploit the fact that buffer points in g_rdram to retreive dram_addr_reg value */
+    ai->regs[AI_DRAM_ADDR_REG] = (uint8_t*)buffer - (uint8_t*)ai->ri->rdram.dram;
+    ai->regs[AI_LEN_REG] = size;
+
+    audio.aiLenChanged();
+
+    ai->regs[AI_LEN_REG] = saved_ai_length;
+    ai->regs[AI_DRAM_ADDR_REG] = saved_ai_dram;
+}
+

--- a/src/plugin/emulate_speaker_via_audio_plugin.h
+++ b/src/plugin/emulate_speaker_via_audio_plugin.h
@@ -1,0 +1,30 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - emulate_speaker_via_audio_plugin.h                      *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2014 Bobby Smiles                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef M64P_PLUGIN_EMULATE_SPEAKER_VIA_AUDIO_PLUGIN_H
+#define M64P_PLUGIN_EMULATE_SPEAKER_VIA_AUDIO_PLUGIN_H
+
+#include <stddef.h>
+
+void set_audio_format_via_audio_plugin(void* user_data, unsigned int frequency, unsigned int bits);
+void push_audio_samples_via_audio_plugin(void* user_data, const void* buffer, size_t size);
+
+#endif

--- a/src/r4300/interupt.c
+++ b/src/r4300/interupt.c
@@ -486,8 +486,6 @@ static void nmi_int_handler(void)
 
 void gen_interupt(void)
 {
-    unsigned int ai_event;
-
     if (stop == 1)
     {
         g_gs_vi_counter = 0; // debug
@@ -556,9 +554,8 @@ void gen_interupt(void)
             break;
     
         case AI_INT:
-            ai_event = q.first->data.count;
             remove_interupt_event();
-            ai_end_of_dma_event(&g_ai, ai_event);
+            ai_end_of_dma_event(&g_ai);
             break;
 
         case SP_INT:


### PR DESCRIPTION
With this PR I propose small refactorings (the first 3 commits), and a more ambitious change which isolate the AI subsystem from the audio plugin.

The AI subsystem now expect two callbacks (set_audio_format, push_audio_samples) in order to play audio.
A simple implementation of these 2 callbacks has been done using the audio plugin in order to keep retro-compatibility with existing audio plugin.

@littleguy77 , @twinaphex, @gen2brain, @ricrpi, @Nebuleon :
I'd like your opinions on the 2 new possible callbacks for audio output.
Would it be easy for your frontends to provide their own implementation of these callbacks (in case we deprecate the audio plugin, or if you want to get rid the audio plugin in your frontends) ?
Basically set_audio_format allows you to setup the audio device (frequency + sample format), and in push_audio_samples you should push (and eventually resample) the given samples to your audio device.

Edit: Just to make it clear, we don't intend to remove/deprecate the audio plugin now.
This is just preliminary work to better isolate core components.