### PR TITLE
Fix vi->field update when in interlaced mode.

### DIFF
--- a/src/vi/vi_controller.c
+++ b/src/vi/vi_controller.c
@@ -102,8 +102,8 @@ void vi_vertical_interrupt_event(struct vi_controller* vi)
     /* allow main module to do things on VI event */
     new_vi();
 
-    /* update field (if in interlaced mode) */
-    vi->field = (vi->regs[VI_STATUS_REG] >> 6) & ~vi->field;
+    /* toggle vi field if in interlaced mode */
+    vi->field ^= (vi->regs[VI_STATUS_REG] >> 6) & 0x1;
 
     /* schedule next vertical interrupt */
     vi->delay = (vi->regs[VI_V_SYNC_REG] == 0)


### PR DESCRIPTION
vi->field value is assumed to be either 0 or 1 for VI_CURRENT_REG
update. The previous vi->field update formula did not guarantee that,
and therefore could lead to corrupted VI_CURRENT_REG values.

This regression was introduced in commit f9308ad.