### PR TITLE
Copy and byte-swap incoming N64 ROMs in one step (version 2)

### DIFF
--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -20,6 +20,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -65,17 +66,16 @@ static m64p_system_type rom_country_code_to_system_type(unsigned short country_c
 static int rom_system_type_to_ai_dac_rate(m64p_system_type system_type);
 static int rom_system_type_to_vi_limit(m64p_system_type system_type);
 
+static const uint8_t Z64_SIGNATURE[4] = { 0x80, 0x37, 0x12, 0x40 };
+static const uint8_t V64_SIGNATURE[4] = { 0x37, 0x80, 0x40, 0x12 };
+static const uint8_t N64_SIGNATURE[4] = { 0x40, 0x12, 0x37, 0x80 };
+
 /* Tests if a file is a valid N64 rom by checking the first 4 bytes. */
 static int is_valid_rom(const unsigned char *buffer)
 {
-    /* Test if rom is a native .z64 image with header 0x80371240. [ABCD] */
-    if((buffer[0]==0x80)&&(buffer[1]==0x37)&&(buffer[2]==0x12)&&(buffer[3]==0x40))
-        return 1;
-    /* Test if rom is a byteswapped .v64 image with header 0x37804012. [BADC] */
-    else if((buffer[0]==0x37)&&(buffer[1]==0x80)&&(buffer[2]==0x40)&&(buffer[3]==0x12))
-        return 1;
-    /* Test if rom is a wordswapped .n64 image with header  0x40123780. [DCBA] */
-    else if((buffer[0]==0x40)&&(buffer[1]==0x12)&&(buffer[2]==0x37)&&(buffer[3]==0x80))
+    if (memcmp(buffer, Z64_SIGNATURE, sizeof(Z64_SIGNATURE)) == 0
+     || memcmp(buffer, V64_SIGNATURE, sizeof(V64_SIGNATURE)) == 0
+     || memcmp(buffer, N64_SIGNATURE, sizeof(N64_SIGNATURE)) == 0)
         return 1;
     else
         return 0;

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -81,42 +81,51 @@ static int is_valid_rom(const unsigned char *buffer)
         return 0;
 }
 
-/* If rom is a .v64 or .n64 image, byteswap or wordswap loadlength amount of
- * rom data to native .z64 before forwarding. Makes sure that data extraction
- * and MD5ing routines always deal with a .z64 image.
+/* Copies the source block of memory to the destination block of memory while
+ * switching the endianness of .v64 and .n64 images to the .z64 format, which
+ * is native to the Nintendo 64. The data extraction routines and MD5 hashing
+ * function may only act on the .z64 big-endian format.
+ *
+ * IN: src: The source block of memory. This must be a valid Nintendo 64 ROM
+ *          image of 'len' bytes.
+ *     len: The length of the source and destination, in bytes.
+ * OUT: dst: The destination block of memory. This must be a valid buffer for
+ *           at least 'len' bytes.
+ *      imagetype: A pointer to a byte that gets updated with the value of
+ *                 V64IMAGE, N64IMAGE or Z64IMAGE according to the format of
+ *                 the source block. The value is undefined if 'src' does not
+ *                 represent a valid Nintendo 64 ROM image.
  */
-static void swap_rom(unsigned char* localrom, unsigned char* imagetype, int loadlength)
+static void swap_copy_rom(void* dst, const void* src, size_t len, unsigned char* imagetype)
 {
-    unsigned char temp;
-    int i;
-
-    /* Btyeswap if .v64 image. */
-    if(localrom[0]==0x37)
-        {
+    if (memcmp(src, V64_SIGNATURE, sizeof(V64_SIGNATURE)) == 0)
+    {
         *imagetype = V64IMAGE;
-        for (i = 0; i < loadlength; i+=2)
-            {
-            temp=localrom[i];
-            localrom[i]=localrom[i+1];
-            localrom[i+1]=temp;
-            }
-        }
-    /* Wordswap if .n64 image. */
-    else if(localrom[0]==0x40)
+        /* .v64 images have byte-swapped half-words (16-bit). */
+        size_t i;
+        const uint16_t* src16 = (const uint16_t*) src;
+        uint16_t* dst16 = (uint16_t*) dst;
+        for (i = 0; i < len; i += 2)
         {
-        *imagetype = N64IMAGE;
-        for (i = 0; i < loadlength; i+=4)
-            {
-            temp=localrom[i];
-            localrom[i]=localrom[i+3];
-            localrom[i+3]=temp;
-            temp=localrom[i+1];
-            localrom[i+1]=localrom[i+2];
-            localrom[i+2]=temp;
-            }
+            *dst16++ = m64p_swap16(*src16++);
         }
-    else
+    }
+    else if (memcmp(src, N64_SIGNATURE, sizeof(N64_SIGNATURE)) == 0)
+    {
+        *imagetype = N64IMAGE;
+        /* .n64 images have byte-swapped words (32-bit). */
+        size_t i;
+        const uint32_t* src32 = (const uint32_t*) src;
+        uint32_t* dst32 = (uint32_t*) dst;
+        for (i = 0; i < len; i += 4)
+        {
+            *dst32++ = m64p_swap32(*src32++);
+        }
+    }
+    else {
         *imagetype = Z64IMAGE;
+        memcpy(dst, src, len);
+    }
 }
 
 m64p_error open_rom(const unsigned char* romimage, unsigned int size)
@@ -147,8 +156,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     g_rom = (unsigned char *) malloc(size);
     if (g_rom == NULL)
         return M64ERR_NO_MEMORY;
-    memcpy(g_rom, romimage, size);
-    swap_rom(g_rom, &imagetype, g_rom_size);
+    swap_copy_rom(g_rom, romimage, size, &imagetype);
 
     memcpy(&ROM_HEADER, g_rom, sizeof(m64p_rom_header));
 


### PR DESCRIPTION
*This pull request is a new version of the defunct pull request #78, with more changes as suggested by @Narann to remove magic constants from the code. I don't think I could switch the branch on the old pull request once it was made...*

main/rom.c's open_rom function does memcpy from the source buffer into the Core's buffer, and then swap_rom on the Core's buffer. With .z64 and .n64 input ROMs, the second pass has to read each word back after the memcpy, and they were likely kicked out of the data cache.

This pull request proposes a one-step operation that copies and swaps bytes from the source buffer into the Core's buffer. It also uses named 4-byte signature arrays to detect an image's endianness.