### PR TITLE
Use [u]intN_t for Nintendo 64 data

### DIFF
--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -177,21 +177,21 @@ typedef enum
 
 typedef struct
 {
-   unsigned char init_PI_BSB_DOM1_LAT_REG;  /* 0x00 */
-   unsigned char init_PI_BSB_DOM1_PGS_REG;  /* 0x01 */
-   unsigned char init_PI_BSB_DOM1_PWD_REG;  /* 0x02 */
-   unsigned char init_PI_BSB_DOM1_PGS_REG2; /* 0x03 */
-   unsigned int ClockRate;                  /* 0x04 */
-   unsigned int PC;                         /* 0x08 */
-   unsigned int Release;                    /* 0x0C */
-   unsigned int CRC1;                       /* 0x10 */
-   unsigned int CRC2;                       /* 0x14 */
-   unsigned int Unknown[2];                 /* 0x18 */
-   unsigned char Name[20];                  /* 0x20 */
-   unsigned int unknown;                    /* 0x34 */
-   unsigned int Manufacturer_ID;            /* 0x38 */
-   unsigned short Cartridge_ID;             /* 0x3C - Game serial number  */
-   unsigned short Country_code;             /* 0x3E */
+   uint8_t  init_PI_BSB_DOM1_LAT_REG;  /* 0x00 */
+   uint8_t  init_PI_BSB_DOM1_PGS_REG;  /* 0x01 */
+   uint8_t  init_PI_BSB_DOM1_PWD_REG;  /* 0x02 */
+   uint8_t  init_PI_BSB_DOM1_PGS_REG2; /* 0x03 */
+   uint32_t ClockRate;                 /* 0x04 */
+   uint32_t PC;                        /* 0x08 */
+   uint32_t Release;                   /* 0x0C */
+   uint32_t CRC1;                      /* 0x10 */
+   uint32_t CRC2;                      /* 0x14 */
+   uint32_t Unknown[2];                /* 0x18 */
+   uint8_t  Name[20];                  /* 0x20 */
+   uint32_t unknown;                   /* 0x34 */
+   uint32_t Manufacturer_ID;           /* 0x38 */
+   uint16_t Cartridge_ID;              /* 0x3C - Game serial number  */
+   uint16_t Country_code;              /* 0x3E */
 } m64p_rom_header;
 
 typedef struct

--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -28,6 +28,7 @@
 /* ----------------------------------------- */
 
 /* necessary headers */
+#include <stdint.h>
 #if defined(WIN32)
   #include <windows.h>
 #endif
@@ -159,8 +160,8 @@ typedef enum {
 } m64p_command;
 
 typedef struct {
-  unsigned int address;
-  int          value;
+  uint32_t address;
+  int      value;
 } m64p_cheat_code;
 
 /* ----------------------------------------- */
@@ -310,8 +311,8 @@ typedef enum {
 #define BPT_TOGGLE_FLAG(a, b) a.flags = (a.flags ^ b);
 
 typedef struct {
-  unsigned int address;
-  unsigned int endaddr;
+  uint32_t     address;
+  uint32_t     endaddr;
   unsigned int flags;
 } m64p_breakpoint;
 

--- a/src/debugger/dbg_decoder.c
+++ b/src/debugger/dbg_decoder.c
@@ -62,6 +62,7 @@
  *
  *	from: @(#)kadb.c	8.1 (Berkeley) 6/10/93
  */
+#include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -800,7 +801,7 @@ r4k_disassemble_split_quick ( uint32_t instruction,
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=[ DECODE_OP ]=-=-=-=-=-=-=-=-=-=-=-=-=-=-=[//
 
-void r4300_decode_op ( uint32 instr, char * opcode, char * arguments, int counter )
+void r4300_decode_op ( uint32_t instr, char * opcode, char * arguments, uint32_t counter )
 {
     char * _op, * _args;
     

--- a/src/debugger/dbg_decoder.h
+++ b/src/debugger/dbg_decoder.h
@@ -54,7 +54,7 @@ struct r4k_dis_t
 }
 R4kDis;
 
-extern void r4300_decode_op ( uint32, char *, char *, int );
+extern void r4300_decode_op ( uint32_t, char *, char *, uint32_t );
 
 
 #endif /* __DECODER_H__ */

--- a/src/main/cheat.c
+++ b/src/main/cheat.c
@@ -469,7 +469,7 @@ static int cheat_parse_hacks_code(char *code, m64p_cheat_code **hack)
     while ((token = strtok_compat(input, ",", &saveptr))) {
         input = NULL;
 
-        ret = sscanf(token, "%08" SCNX32 " %04X", &hackbuf[num_codes].address,
+        ret = sscanf(token, "%08" SCNx32 " %04X", &hackbuf[num_codes].address,
                      &hackbuf[num_codes].value);
         if (ret == 2)
             num_codes++;

--- a/src/main/cheat.c
+++ b/src/main/cheat.c
@@ -39,6 +39,9 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 // local definitions
 #define CHEAT_CODE_MAGIC_VALUE 0xDEAD0000
@@ -466,7 +469,7 @@ static int cheat_parse_hacks_code(char *code, m64p_cheat_code **hack)
     while ((token = strtok_compat(input, ",", &saveptr))) {
         input = NULL;
 
-        ret = sscanf(token, "%08X %04X", &hackbuf[num_codes].address,
+        ret = sscanf(token, "%08" SCNX32 " %04X", &hackbuf[num_codes].address,
                      &hackbuf[num_codes].value);
         if (ret == 2)
             num_codes++;

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -25,6 +25,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <stddef.h>
+#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 #define M64P_CORE_PROTOTYPES 1
 #include "api/m64p_types.h"
@@ -61,7 +64,7 @@ m64p_rom_header   ROM_HEADER;
 rom_params        ROM_PARAMS;
 m64p_rom_settings ROM_SETTINGS;
 
-static m64p_system_type rom_country_code_to_system_type(unsigned short country_code);
+static m64p_system_type rom_country_code_to_system_type(uint16_t country_code);
 static int rom_system_type_to_ai_dac_rate(m64p_system_type system_type);
 static int rom_system_type_to_vi_limit(m64p_system_type system_type);
 
@@ -202,19 +205,19 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     DebugMessage(M64MSG_INFO, "Name: %s", ROM_HEADER.Name);
     imagestring(imagetype, buffer);
     DebugMessage(M64MSG_INFO, "MD5: %s", ROM_SETTINGS.MD5);
-    DebugMessage(M64MSG_INFO, "CRC: %x %x", sl(ROM_HEADER.CRC1), sl(ROM_HEADER.CRC2));
+    DebugMessage(M64MSG_INFO, "CRC: %" PRIX32 " %" PRIX32, sl(ROM_HEADER.CRC1), sl(ROM_HEADER.CRC2));
     DebugMessage(M64MSG_INFO, "Imagetype: %s", buffer);
     DebugMessage(M64MSG_INFO, "Rom size: %d bytes (or %d Mb or %d Megabits)", g_rom_size, g_rom_size/1024/1024, g_rom_size/1024/1024*8);
-    DebugMessage(M64MSG_VERBOSE, "ClockRate = %x", sl(ROM_HEADER.ClockRate));
-    DebugMessage(M64MSG_INFO, "Version: %x", sl(ROM_HEADER.Release));
+    DebugMessage(M64MSG_VERBOSE, "ClockRate = %" PRIX32, sl(ROM_HEADER.ClockRate));
+    DebugMessage(M64MSG_INFO, "Version: %" PRIX32, sl(ROM_HEADER.Release));
     if(sl(ROM_HEADER.Manufacturer_ID) == 'N')
         DebugMessage(M64MSG_INFO, "Manufacturer: Nintendo");
     else
-        DebugMessage(M64MSG_INFO, "Manufacturer: %x", sl(ROM_HEADER.Manufacturer_ID));
-    DebugMessage(M64MSG_VERBOSE, "Cartridge_ID: %x", ROM_HEADER.Cartridge_ID);
+        DebugMessage(M64MSG_INFO, "Manufacturer: %" PRIX32, sl(ROM_HEADER.Manufacturer_ID));
+    DebugMessage(M64MSG_VERBOSE, "Cartridge_ID: %" PRIX16, ROM_HEADER.Cartridge_ID);
     countrycodestring(ROM_HEADER.Country_code, buffer);
     DebugMessage(M64MSG_INFO, "Country: %s", buffer);
-    DebugMessage(M64MSG_VERBOSE, "PC = %x", sl((unsigned int)ROM_HEADER.PC));
+    DebugMessage(M64MSG_VERBOSE, "PC = %" PRIX32, sl(ROM_HEADER.PC));
     DebugMessage(M64MSG_VERBOSE, "Save type: %d", ROM_SETTINGS.savetype);
 
     //Prepare Hack for GOLDENEYE
@@ -244,9 +247,9 @@ m64p_error close_rom(void)
 /* ROM utility functions */
 
 // Get the system type associated to a ROM country code.
-static m64p_system_type rom_country_code_to_system_type(unsigned short country_code)
+static m64p_system_type rom_country_code_to_system_type(uint16_t country_code)
 {
-    switch (country_code & 0xFF)
+    switch (country_code & UINT16_C(0xFF))
     {
         // PAL codes
         case 0x44:

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -407,13 +407,13 @@ static int savestates_load_m64p(char *filepath)
 
     llbit = GETDATA(curr, unsigned int);
     COPYARRAY(reg, curr, int64_t, 32);
-    COPYARRAY(g_cp0_regs, curr, unsigned int, CP0_REGS_COUNT);
+    COPYARRAY(g_cp0_regs, curr, uint32_t, CP0_REGS_COUNT);
     set_fpr_pointers(g_cp0_regs[CP0_STATUS_REG]);
     lo = GETDATA(curr, int64_t);
     hi = GETDATA(curr, int64_t);
     COPYARRAY(reg_cop1_fgr_64, curr, long long int, 32);
-    if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0)  // 32-bit FPR mode requires data shuffling because 64-bit layout is always stored in savestate file
-        shuffle_fpr_data(0x04000000, 0);
+    if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0)  // 32-bit FPR mode requires data shuffling because 64-bit layout is always stored in savestate file
+        shuffle_fpr_data(UINT32_C(0x04000000), 0);
     FCR0 = GETDATA(curr, int);
     FCR31 = GETDATA(curr, int);
 
@@ -556,11 +556,11 @@ static int savestates_load_pj64(char *filepath, void *handle,
     COPYARRAY(reg_cop1_fgr_64, curr, long long int, 32);
 
     // CP0
-    COPYARRAY(g_cp0_regs, curr, unsigned int, CP0_REGS_COUNT);
+    COPYARRAY(g_cp0_regs, curr, uint32_t, CP0_REGS_COUNT);
 
     set_fpr_pointers(g_cp0_regs[CP0_STATUS_REG]);
-    if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0) // TODO not sure how pj64 handles this
-        shuffle_fpr_data(0x04000000, 0);
+    if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // TODO not sure how pj64 handles this
+        shuffle_fpr_data(UINT32_C(0x04000000), 0);
 
     // Initialze the interupts
     vi_timer += g_cp0_regs[CP0_COUNT_REG];
@@ -1186,15 +1186,15 @@ static int savestates_save_m64p(char *filepath)
 
     PUTDATA(curr, unsigned int, llbit);
     PUTARRAY(reg, curr, int64_t, 32);
-    PUTARRAY(g_cp0_regs, curr, unsigned int, CP0_REGS_COUNT);
+    PUTARRAY(g_cp0_regs, curr, uint32_t, CP0_REGS_COUNT);
     PUTDATA(curr, int64_t, lo);
     PUTDATA(curr, int64_t, hi);
 
-    if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0) // FR bit == 0 means 32-bit (MIPS I) FGR mode
-        shuffle_fpr_data(0, 0x04000000);  // shuffle data into 64-bit register format for storage
+    if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // FR bit == 0 means 32-bit (MIPS I) FGR mode
+        shuffle_fpr_data(0, UINT32_C(0x04000000));  // shuffle data into 64-bit register format for storage
     PUTARRAY(reg_cop1_fgr_64, curr, long long int, 32);
-    if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0)
-        shuffle_fpr_data(0x04000000, 0);  // put it back in 32-bit mode
+    if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0)
+        shuffle_fpr_data(UINT32_C(0x04000000), 0);  // put it back in 32-bit mode
 
     PUTDATA(curr, int, FCR0);
     PUTDATA(curr, int, FCR31);
@@ -1270,7 +1270,7 @@ static int savestates_save_pj64(char *filepath, void *handle,
     PUTARRAY(pj64_magic, curr, unsigned char, 4);
     PUTDATA(curr, unsigned int, SaveRDRAMSize);
     PUTARRAY(g_rom, curr, unsigned int, 0x40/4);
-    PUTDATA(curr, unsigned int, get_event(VI_INT) - g_cp0_regs[CP0_COUNT_REG]); // vi_timer
+    PUTDATA(curr, uint32_t, get_event(VI_INT) - g_cp0_regs[CP0_COUNT_REG]); // vi_timer
 #ifdef NEW_DYNAREC
     if (r4300emu == CORE_DYNAREC)
         PUTDATA(curr, uint32_t, pcaddr);
@@ -1280,12 +1280,12 @@ static int savestates_save_pj64(char *filepath, void *handle,
     PUTDATA(curr, uint32_t, PC->addr);
 #endif
     PUTARRAY(reg, curr, int64_t, 32);
-    if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0) // TODO not sure how pj64 handles this
-        shuffle_fpr_data(0x04000000, 0);
+    if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // TODO not sure how pj64 handles this
+        shuffle_fpr_data(UINT32_C(0x04000000), 0);
     PUTARRAY(reg_cop1_fgr_64, curr, long long int, 32);
-    if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0) // TODO not sure how pj64 handles this
-        shuffle_fpr_data(0x04000000, 0);
-    PUTARRAY(g_cp0_regs, curr, unsigned int, CP0_REGS_COUNT);
+    if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // TODO not sure how pj64 handles this
+        shuffle_fpr_data(UINT32_C(0x04000000), 0);
+    PUTARRAY(g_cp0_regs, curr, uint32_t, CP0_REGS_COUNT);
     PUTDATA(curr, int, FCR0);
     for (i = 0; i < 30; i++)
         PUTDATA(curr, int, 0); // FCR1-30 not implemented

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -406,11 +406,11 @@ static int savestates_load_m64p(char *filepath)
     COPYARRAY(tlb_LUT_w, curr, unsigned int, 0x100000);
 
     llbit = GETDATA(curr, unsigned int);
-    COPYARRAY(reg, curr, long long int, 32);
+    COPYARRAY(reg, curr, int64_t, 32);
     COPYARRAY(g_cp0_regs, curr, unsigned int, CP0_REGS_COUNT);
     set_fpr_pointers(g_cp0_regs[CP0_STATUS_REG]);
-    lo = GETDATA(curr, long long int);
-    hi = GETDATA(curr, long long int);
+    lo = GETDATA(curr, int64_t);
+    hi = GETDATA(curr, int64_t);
     COPYARRAY(reg_cop1_fgr_64, curr, long long int, 32);
     if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0)  // 32-bit FPR mode requires data shuffling because 64-bit layout is always stored in savestate file
         shuffle_fpr_data(0x04000000, 0);
@@ -550,7 +550,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     last_addr = GETDATA(curr, unsigned int);
 
     // GPR
-    COPYARRAY(reg, curr, long long int, 32);
+    COPYARRAY(reg, curr, int64_t, 32);
 
     // FPR
     COPYARRAY(reg_cop1_fgr_64, curr, long long int, 32);
@@ -583,8 +583,8 @@ static int savestates_load_pj64(char *filepath, void *handle,
     FCR31 = GETDATA(curr, int);
 
     // hi / lo
-    hi = GETDATA(curr, long long int);
-    lo = GETDATA(curr, long long int);
+    hi = GETDATA(curr, int64_t);
+    lo = GETDATA(curr, int64_t);
 
     // rdram register
     g_ri.rdram.regs[RDRAM_CONFIG_REG]       = GETDATA(curr, uint32_t);
@@ -1185,10 +1185,10 @@ static int savestates_save_m64p(char *filepath)
     PUTARRAY(tlb_LUT_w, curr, unsigned int, 0x100000);
 
     PUTDATA(curr, unsigned int, llbit);
-    PUTARRAY(reg, curr, long long int, 32);
+    PUTARRAY(reg, curr, int64_t, 32);
     PUTARRAY(g_cp0_regs, curr, unsigned int, CP0_REGS_COUNT);
-    PUTDATA(curr, long long int, lo);
-    PUTDATA(curr, long long int, hi);
+    PUTDATA(curr, int64_t, lo);
+    PUTDATA(curr, int64_t, hi);
 
     if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0) // FR bit == 0 means 32-bit (MIPS I) FGR mode
         shuffle_fpr_data(0, 0x04000000);  // shuffle data into 64-bit register format for storage
@@ -1279,7 +1279,7 @@ static int savestates_save_pj64(char *filepath, void *handle,
 #else
     PUTDATA(curr, unsigned int, PC->addr);
 #endif
-    PUTARRAY(reg, curr, long long int, 32);
+    PUTARRAY(reg, curr, int64_t, 32);
     if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0) // TODO not sure how pj64 handles this
         shuffle_fpr_data(0x04000000, 0);
     PUTARRAY(reg_cop1_fgr_64, curr, long long int, 32);
@@ -1290,8 +1290,8 @@ static int savestates_save_pj64(char *filepath, void *handle,
     for (i = 0; i < 30; i++)
         PUTDATA(curr, int, 0); // FCR1-30 not implemented
     PUTDATA(curr, int, FCR31);
-    PUTDATA(curr, long long int, hi);
-    PUTDATA(curr, long long int, lo);
+    PUTDATA(curr, int64_t, hi);
+    PUTDATA(curr, int64_t, lo);
 
     PUTDATA(curr, uint32_t, g_ri.rdram.regs[RDRAM_CONFIG_REG]);
     PUTDATA(curr, uint32_t, g_ri.rdram.regs[RDRAM_DEVICE_ID_REG]);

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -411,11 +411,11 @@ static int savestates_load_m64p(char *filepath)
     set_fpr_pointers(g_cp0_regs[CP0_STATUS_REG]);
     lo = GETDATA(curr, int64_t);
     hi = GETDATA(curr, int64_t);
-    COPYARRAY(reg_cop1_fgr_64, curr, long long int, 32);
+    COPYARRAY(reg_cop1_fgr_64, curr, int64_t, 32);
     if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0)  // 32-bit FPR mode requires data shuffling because 64-bit layout is always stored in savestate file
         shuffle_fpr_data(UINT32_C(0x04000000), 0);
-    FCR0 = GETDATA(curr, int);
-    FCR31 = GETDATA(curr, int);
+    FCR0 = GETDATA(curr, int32_t);
+    FCR31 = GETDATA(curr, int32_t);
 
     for (i = 0; i < 32; i++)
     {
@@ -553,7 +553,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     COPYARRAY(reg, curr, int64_t, 32);
 
     // FPR
-    COPYARRAY(reg_cop1_fgr_64, curr, long long int, 32);
+    COPYARRAY(reg_cop1_fgr_64, curr, int64_t, 32);
 
     // CP0
     COPYARRAY(g_cp0_regs, curr, uint32_t, CP0_REGS_COUNT);
@@ -578,9 +578,9 @@ static int savestates_load_pj64(char *filepath, void *handle,
     load_eventqueue_infos(buffer);
 
     // FPCR
-    FCR0 = GETDATA(curr, int);
+    FCR0 = GETDATA(curr, int32_t);
     curr += 30 * 4; // FCR1...FCR30 not supported
-    FCR31 = GETDATA(curr, int);
+    FCR31 = GETDATA(curr, int32_t);
 
     // hi / lo
     hi = GETDATA(curr, int64_t);
@@ -1192,12 +1192,12 @@ static int savestates_save_m64p(char *filepath)
 
     if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // FR bit == 0 means 32-bit (MIPS I) FGR mode
         shuffle_fpr_data(0, UINT32_C(0x04000000));  // shuffle data into 64-bit register format for storage
-    PUTARRAY(reg_cop1_fgr_64, curr, long long int, 32);
+    PUTARRAY(reg_cop1_fgr_64, curr, int64_t, 32);
     if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0)
         shuffle_fpr_data(UINT32_C(0x04000000), 0);  // put it back in 32-bit mode
 
-    PUTDATA(curr, int, FCR0);
-    PUTDATA(curr, int, FCR31);
+    PUTDATA(curr, int32_t, FCR0);
+    PUTDATA(curr, int32_t, FCR31);
     for (i = 0; i < 32; i++)
     {
         PUTDATA(curr, short, tlb_e[i].mask);
@@ -1282,14 +1282,14 @@ static int savestates_save_pj64(char *filepath, void *handle,
     PUTARRAY(reg, curr, int64_t, 32);
     if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // TODO not sure how pj64 handles this
         shuffle_fpr_data(UINT32_C(0x04000000), 0);
-    PUTARRAY(reg_cop1_fgr_64, curr, long long int, 32);
+    PUTARRAY(reg_cop1_fgr_64, curr, int64_t, 32);
     if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // TODO not sure how pj64 handles this
         shuffle_fpr_data(UINT32_C(0x04000000), 0);
     PUTARRAY(g_cp0_regs, curr, uint32_t, CP0_REGS_COUNT);
-    PUTDATA(curr, int, FCR0);
+    PUTDATA(curr, int32_t, FCR0);
     for (i = 0; i < 30; i++)
         PUTDATA(curr, int, 0); // FCR1-30 not implemented
-    PUTDATA(curr, int, FCR31);
+    PUTDATA(curr, int32_t, FCR31);
     PUTDATA(curr, int64_t, hi);
     PUTDATA(curr, int64_t, lo);
 

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -446,7 +446,7 @@ static int savestates_load_m64p(char *filepath)
 
 #ifdef NEW_DYNAREC
     if (r4300emu == CORE_DYNAREC) {
-        pcaddr = GETDATA(curr, unsigned int);
+        pcaddr = GETDATA(curr, uint32_t);
         pending_exception = 1;
         invalidate_all_pages();
     } else {
@@ -455,7 +455,7 @@ static int savestates_load_m64p(char *filepath)
             for (i = 0; i < 0x100000; i++)
                 invalid_code[i] = 1;
         }
-        generic_jump_to(GETDATA(curr, unsigned int)); // PC
+        generic_jump_to(GETDATA(curr, uint32_t)); // PC
     }
 #else
     if(r4300emu != CORE_PURE_INTERPRETER)
@@ -463,7 +463,7 @@ static int savestates_load_m64p(char *filepath)
         for (i = 0; i < 0x100000; i++)
             invalid_code[i] = 1;
     }
-    generic_jump_to(GETDATA(curr, unsigned int)); // PC
+    generic_jump_to(GETDATA(curr, uint32_t)); // PC
 #endif
 
     next_interupt = GETDATA(curr, unsigned int);
@@ -547,7 +547,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     vi_timer = GETDATA(curr, unsigned int);
 
     // Program Counter
-    last_addr = GETDATA(curr, unsigned int);
+    last_addr = GETDATA(curr, uint32_t);
 
     // GPR
     COPYARRAY(reg, curr, int64_t, 32);
@@ -752,7 +752,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
 
 #ifdef NEW_DYNAREC
     if (r4300emu == CORE_DYNAREC) {
-        pcaddr = GETDATA(curr, unsigned int);
+        pcaddr = last_addr;
         pending_exception = 1;
         invalidate_all_pages();
     } else {
@@ -1226,11 +1226,11 @@ static int savestates_save_m64p(char *filepath)
     }
 #ifdef NEW_DYNAREC
     if (r4300emu == CORE_DYNAREC)
-        PUTDATA(curr, unsigned int, pcaddr);
+        PUTDATA(curr, uint32_t, pcaddr);
     else
-        PUTDATA(curr, unsigned int, PC->addr);
+        PUTDATA(curr, uint32_t, PC->addr);
 #else
-    PUTDATA(curr, unsigned int, PC->addr);
+    PUTDATA(curr, uint32_t, PC->addr);
 #endif
 
     PUTDATA(curr, unsigned int, next_interupt);
@@ -1273,11 +1273,11 @@ static int savestates_save_pj64(char *filepath, void *handle,
     PUTDATA(curr, unsigned int, get_event(VI_INT) - g_cp0_regs[CP0_COUNT_REG]); // vi_timer
 #ifdef NEW_DYNAREC
     if (r4300emu == CORE_DYNAREC)
-        PUTDATA(curr, unsigned int, pcaddr);
+        PUTDATA(curr, uint32_t, pcaddr);
     else
-        PUTDATA(curr, unsigned int, PC->addr);
+        PUTDATA(curr, uint32_t, PC->addr);
 #else
-    PUTDATA(curr, unsigned int, PC->addr);
+    PUTDATA(curr, uint32_t, PC->addr);
 #endif
     PUTARRAY(reg, curr, int64_t, 32);
     if ((g_cp0_regs[CP0_STATUS_REG] & 0x04000000) == 0) // TODO not sure how pj64 handles this

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -25,6 +25,7 @@
  *  -String functions
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -87,19 +88,19 @@ void swap_buffer(void *buffer, size_t length, size_t count)
     size_t i;
     if (length == 2)
     {
-        unsigned short *pun = (unsigned short *)buffer;
+        uint16_t *pun = (uint16_t *) buffer;
         for (i = 0; i < count; i++)
             pun[i] = m64p_swap16(pun[i]);
     }
     else if (length == 4)
     {
-        unsigned int *pun = (unsigned int *)buffer;
+        uint32_t *pun = (uint32_t *) buffer;
         for (i = 0; i < count; i++)
             pun[i] = m64p_swap32(pun[i]);
     }
     else if (length == 8)
     {
-        unsigned long long *pun = (unsigned long long *)buffer;
+        uint64_t *pun = (uint64_t *) buffer;
         for (i = 0; i < count; i++)
             pun[i] = m64p_swap64(pun[i]);
     }

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -34,6 +34,8 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <limits.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 #include "rom.h"
 #include "util.h"
@@ -123,7 +125,7 @@ void to_big_endian_buffer(void *buffer, size_t length, size_t count)
 /**********************
      GUI utilities
  **********************/
-void countrycodestring(unsigned short countrycode, char *string)
+void countrycodestring(uint16_t countrycode, char *string)
 {
     switch (countrycode)
     {
@@ -164,16 +166,16 @@ void countrycodestring(unsigned short countrycode, char *string)
         break;
 
     case 0x55: case 0x59:  /* Australia */
-        sprintf(string, "Australia (0x%02X)", countrycode);
+        sprintf(string, "Australia (0x%02" PRIX16 ")", countrycode);
         break;
 
     case 0x50: case 0x58: case 0x20:
     case 0x21: case 0x38: case 0x70:
-        sprintf(string, "Europe (0x%02X)", countrycode);
+        sprintf(string, "Europe (0x%02" PRIX16 ")", countrycode);
         break;
 
     default:
-        sprintf(string, "Unknown (0x%02X)", countrycode);
+        sprintf(string, "Unknown (0x%02" PRIX16 ")", countrycode);
         break;
     }
 }

--- a/src/main/util.h
+++ b/src/main/util.h
@@ -128,7 +128,7 @@ void to_big_endian_buffer(void *buffer, size_t length, size_t count);
 /**********************
      GUI utilities
  **********************/
-void countrycodestring(unsigned short countrycode, char *string);
+void countrycodestring(uint16_t countrycode, char *string);
 void imagestring(unsigned char imagetype, char *string);
 
 /**********************

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -57,19 +57,19 @@
 
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
 // address : address of the read/write operation being done
-unsigned int address = 0;
+uint32_t address = 0;
 #endif
 
 // values that are being written are stored in these variables
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
-unsigned int cpu_word;
-unsigned char cpu_byte;
-unsigned short cpu_hword;
-unsigned long long int cpu_dword;
+uint32_t cpu_word;
+uint8_t cpu_byte;
+uint16_t cpu_hword;
+uint64_t cpu_dword;
 #endif
 
 // addresse where the read value will be stored
-unsigned long long int* rdword;
+uint64_t* rdword;
 
 // hash tables of read functions
 void (*readmem[0x10000])(void);
@@ -96,7 +96,7 @@ static inline unsigned int hshift(uint32_t address)
     return ((address & 2) ^ 2) << 3;
 }
 
-static int readb(readfn read_word, void* opaque, uint32_t address, unsigned long long int* value)
+static int readb(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
 {
     uint32_t w;
     unsigned shift = bshift(address);
@@ -106,7 +106,7 @@ static int readb(readfn read_word, void* opaque, uint32_t address, unsigned long
     return result;
 }
 
-static int readh(readfn read_word, void* opaque, uint32_t address, unsigned long long int* value)
+static int readh(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
 {
     uint32_t w;
     unsigned shift = hshift(address);
@@ -116,7 +116,7 @@ static int readh(readfn read_word, void* opaque, uint32_t address, unsigned long
     return result;
 }
 
-static int readw(readfn read_word, void* opaque, uint32_t address, unsigned long long int* value)
+static int readw(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
 {
     uint32_t w;
     int result = read_word(opaque, address, &w);
@@ -125,7 +125,7 @@ static int readw(readfn read_word, void* opaque, uint32_t address, unsigned long
     return result;
 }
 
-static int readd(readfn read_word, void* opaque, uint32_t address, unsigned long long int* value)
+static int readd(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
 {
     uint32_t w[2];
     int result =
@@ -1443,22 +1443,22 @@ void map_region(uint16_t region,
     map_region_w(region, write8, write16, write32, write64);
 }
 
-unsigned int *fast_mem_access(unsigned int address)
+unsigned int *fast_mem_access(uint32_t address)
 {
     /* This code is performance critical, specially on pure interpreter mode.
      * Removing error checking saves some time, but the emulator may crash. */
 
-    if ((address & 0xc0000000) != 0x80000000)
+    if ((address & UINT32_C(0xc0000000)) != UINT32_C(0x80000000))
         address = virtual_to_physical_address(address, 2);
 
-    address &= 0x1ffffffc;
+    address &= UINT32_C(0x1ffffffc);
 
     if (address < RDRAM_MAX_SIZE)
         return (unsigned int*)((unsigned char*)g_rdram + address);
-    else if (address >= 0x10000000)
-        return (unsigned int*)((unsigned char*)g_rom + address - 0x10000000);
-    else if ((address & 0xffffe000) == 0x04000000)
-        return (unsigned int*)((unsigned char*)g_sp.mem + (address & 0x1ffc));
+    else if (address >= UINT32_C(0x10000000))
+        return (unsigned int*)((unsigned char*)g_rom + address - UINT32_C(0x10000000));
+    else if ((address & UINT32_C(0xffffe000)) == UINT32_C(0x04000000))
+        return (unsigned int*)((unsigned char*)g_sp.mem + (address & UINT32_C(0x1ffc)));
     else
         return NULL;
 }

--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -1443,7 +1443,7 @@ void map_region(uint16_t region,
     map_region_w(region, write8, write16, write32, write64);
 }
 
-unsigned int *fast_mem_access(uint32_t address)
+uint32_t *fast_mem_access(uint32_t address)
 {
     /* This code is performance critical, specially on pure interpreter mode.
      * Removing error checking saves some time, but the emulator may crash. */
@@ -1454,11 +1454,11 @@ unsigned int *fast_mem_access(uint32_t address)
     address &= UINT32_C(0x1ffffffc);
 
     if (address < RDRAM_MAX_SIZE)
-        return (unsigned int*)((unsigned char*)g_rdram + address);
+        return (uint32_t*) ((uint8_t*) g_rdram + address);
     else if (address >= UINT32_C(0x10000000))
-        return (unsigned int*)((unsigned char*)g_rom + address - UINT32_C(0x10000000));
+        return (uint32_t*) ((uint8_t*) g_rom + (address - UINT32_C(0x10000000)));
     else if ((address & UINT32_C(0xffffe000)) == UINT32_C(0x04000000))
-        return (unsigned int*)((unsigned char*)g_sp.mem + (address & UINT32_C(0x1ffc)));
+        return (uint32_t*) ((uint8_t*) g_sp.mem + (address & UINT32_C(0x1ffc)));
     else
         return NULL;
 }

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -111,7 +111,7 @@ void write_rdramFBd(void);
 /* Returns a pointer to a block of contiguous memory
  * Can access RDRAM, SP_DMEM, SP_IMEM and ROM, using TLB if necessary
  * Useful for getting fast access to a zone with executable code. */
-unsigned int *fast_mem_access(uint32_t address);
+uint32_t *fast_mem_access(uint32_t address);
 
 #ifdef DBG
 void activate_memory_break_read(uint32_t address);

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -33,10 +33,10 @@
 #define write_hword_in_memory() writememh[address >>16]()
 #define write_dword_in_memory() writememd[address >>16]()
 
-extern unsigned int address, cpu_word;
-extern unsigned char cpu_byte;
-extern unsigned short cpu_hword;
-extern unsigned long long cpu_dword, *rdword;
+extern uint32_t address, cpu_word;
+extern uint8_t cpu_byte;
+extern uint16_t cpu_hword;
+extern uint64_t cpu_dword, *rdword;
 
 extern void (*readmem[0x10000])(void);
 extern void (*readmemb[0x10000])(void);
@@ -111,7 +111,7 @@ void write_rdramFBd(void);
 /* Returns a pointer to a block of contiguous memory
  * Can access RDRAM, SP_DMEM, SP_IMEM and ROM, using TLB if necessary
  * Useful for getting fast access to a zone with executable code. */
-unsigned int *fast_mem_access(unsigned int address);
+unsigned int *fast_mem_access(uint32_t address);
 
 #ifdef DBG
 void activate_memory_break_read(uint32_t address);

--- a/src/pi/flashram.c
+++ b/src/pi/flashram.c
@@ -30,6 +30,8 @@
 #include "ri/ri_controller.h"
 
 #include <string.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 
 static void flashram_command(struct pi_controller* pi, uint32_t command)
@@ -92,7 +94,7 @@ static void flashram_command(struct pi_controller* pi, uint32_t command)
         flashram->status = 0x11118004f0000000LL;
         break;
     default:
-        DebugMessage(M64MSG_WARNING, "unknown flashram command: %x", command);
+        DebugMessage(M64MSG_WARNING, "unknown flashram command: %" PRIX32, command);
         break;
     }
 }

--- a/src/pi/pi_controller.c
+++ b/src/pi/pi_controller.c
@@ -37,6 +37,9 @@
 #include "ri/ri_controller.h"
 
 #include <string.h>
+#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 static void dma_pi_read(struct pi_controller* pi)
 {
@@ -86,7 +89,7 @@ static void dma_pi_write(struct pi_controller* pi)
         }
         else
         {
-            DebugMessage(M64MSG_WARNING, "Unknown dma write 0x%x in dma_pi_write()", (int)pi->regs[PI_CART_ADDR_REG]);
+            DebugMessage(M64MSG_WARNING, "Unknown dma write 0x%" PRIX32 " in dma_pi_write()", pi->regs[PI_CART_ADDR_REG]);
         }
 
         pi->regs[PI_STATUS_REG] |= 1;

--- a/src/r4300/cached_interp.c
+++ b/src/r4300/cached_interp.c
@@ -67,7 +67,7 @@ unsigned int jump_to_address;
    static void name(void) \
    { \
       const int take_jump = (condition); \
-      const unsigned int jump_target = (destination); \
+      const uint32_t jump_target = (destination); \
       int64_t *link_register = (link); \
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \
@@ -99,7 +99,7 @@ unsigned int jump_to_address;
    static void name##_OUT(void) \
    { \
       const int take_jump = (condition); \
-      const unsigned int jump_target = (destination); \
+      const uint32_t jump_target = (destination); \
       int64_t *link_register = (link); \
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \

--- a/src/r4300/cached_interp.c
+++ b/src/r4300/cached_interp.c
@@ -19,6 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
+
 #include "cached_interp.h"
 
 #include "api/m64p_types.h"
@@ -66,7 +68,7 @@ unsigned int jump_to_address;
    { \
       const int take_jump = (condition); \
       const unsigned int jump_target = (destination); \
-      long long int *link_register = (link); \
+      int64_t *link_register = (link); \
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \
       { \
@@ -98,7 +100,7 @@ unsigned int jump_to_address;
    { \
       const int take_jump = (condition); \
       const unsigned int jump_target = (destination); \
-      long long int *link_register = (link); \
+      int64_t *link_register = (link); \
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \
       { \

--- a/src/r4300/cached_interp.c
+++ b/src/r4300/cached_interp.c
@@ -200,13 +200,13 @@ Used by dynarec only, check should be unnecessary
 
 static void NOTCOMPILED(void)
 {
-   unsigned int *mem = fast_mem_access(blocks[PC->addr>>12]->start);
+   uint32_t *mem = fast_mem_access(blocks[PC->addr>>12]->start);
 #ifdef CORE_DBG
    DebugMessage(M64MSG_INFO, "NOTCOMPILED: addr = %x ops = %lx", PC->addr, (long) PC->ops);
 #endif
 
    if (mem != NULL)
-      recompile_block((int *)mem, blocks[PC->addr >> 12], PC->addr);
+      recompile_block(mem, blocks[PC->addr >> 12], PC->addr);
    else
       DebugMessage(M64MSG_ERROR, "not compiled exception");
 

--- a/src/r4300/cached_interp.c
+++ b/src/r4300/cached_interp.c
@@ -137,7 +137,7 @@ unsigned int jump_to_address;
       { \
          update_count(); \
          skip = next_interupt - g_cp0_regs[CP0_COUNT_REG]; \
-         if (skip > 3) g_cp0_regs[CP0_COUNT_REG] += (skip & 0xFFFFFFFC); \
+         if (skip > 3) g_cp0_regs[CP0_COUNT_REG] += (skip & UINT32_C(0xFFFFFFFC)); \
          else name(); \
       } \
       else name(); \

--- a/src/r4300/cached_interp.c
+++ b/src/r4300/cached_interp.c
@@ -72,8 +72,7 @@ unsigned int jump_to_address;
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \
       { \
-         *link_register=PC->addr + 8; \
-         sign_extended(*link_register); \
+         *link_register = SE32(PC->addr + 8); \
       } \
       if (!likely || take_jump) \
       { \
@@ -104,8 +103,7 @@ unsigned int jump_to_address;
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \
       { \
-         *link_register=PC->addr + 8; \
-         sign_extended(*link_register); \
+         *link_register = SE32(PC->addr + 8); \
       } \
       if (!likely || take_jump) \
       { \

--- a/src/r4300/cached_interp.c
+++ b/src/r4300/cached_interp.c
@@ -20,6 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 #include "cached_interp.h"
 

--- a/src/r4300/cached_interp.h
+++ b/src/r4300/cached_interp.h
@@ -29,7 +29,7 @@
 extern char invalid_code[0x100000];
 extern precomp_block *blocks[0x100000];
 extern precomp_block *actual;
-extern unsigned int jump_to_address;
+extern uint32_t jump_to_address;
 extern const cpu_instruction_table cached_interpreter_table;
 
 void init_blocks(void);

--- a/src/r4300/cp0.c
+++ b/src/r4300/cp0.c
@@ -19,6 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
+
 #include "r4300.h"
 #include "cp0.h"
 #include "exception.h"
@@ -36,15 +38,15 @@
 
 /* global variable */
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
-unsigned int g_cp0_regs[CP0_REGS_COUNT];
+uint32_t g_cp0_regs[CP0_REGS_COUNT];
 #endif
 
 /* global functions */
 int check_cop1_unusable(void)
 {
-   if (!(g_cp0_regs[CP0_STATUS_REG] & 0x20000000))
+   if (!(g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x20000000)))
      {
-    g_cp0_regs[CP0_CAUSE_REG] = (11 << 2) | 0x10000000;
+    g_cp0_regs[CP0_CAUSE_REG] = (UINT32_C(11) << 2) | UINT32_C(0x10000000);
     exception_general();
     return 1;
      }

--- a/src/r4300/cp0.h
+++ b/src/r4300/cp0.h
@@ -22,6 +22,8 @@
 #ifndef M64P_R4300_CP0_H
 #define M64P_R4300_CP0_H
 
+#include <stdint.h>
+
 enum {
     CP0_INDEX_REG,
     CP0_RANDOM_REG,
@@ -52,7 +54,7 @@ enum {
     CP0_REGS_COUNT = 32
 };
 
-extern unsigned int g_cp0_regs[CP0_REGS_COUNT];
+extern uint32_t g_cp0_regs[CP0_REGS_COUNT];
 
 int check_cop1_unusable(void);
 void update_count(void);

--- a/src/r4300/cp1.c
+++ b/src/r4300/cp1.c
@@ -19,6 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
+
 #include "new_dynarec/new_dynarec.h"
 
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
@@ -39,7 +41,7 @@ int rounding_mode = 0x33F, trunc_mode = 0xF3F, round_mode = 0x33F,
    of MIPS R4000 Microprocessor User's Manual (Second Edition)
    by Joe Heinrich.
 */
-void shuffle_fpr_data(int oldStatus, int newStatus)
+void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus)
 {
 #if defined(M64P_BIG_ENDIAN)
     const int isBigEndian = 1;
@@ -47,13 +49,13 @@ void shuffle_fpr_data(int oldStatus, int newStatus)
     const int isBigEndian = 0;
 #endif
 
-    if ((newStatus & 0x04000000) != (oldStatus & 0x04000000))
+    if ((newStatus & UINT32_C(0x04000000)) != (oldStatus & UINT32_C(0x04000000)))
     {
         int i;
         int temp_fgr_32[32];
 
         // pack or unpack the FGR register data
-        if (newStatus & 0x04000000)
+        if (newStatus & UINT32_C(0x04000000))
         {   // switching into 64-bit mode
             // retrieve 32 FPR values from packed 32-bit FGR registers
             for (i = 0; i < 32; i++)
@@ -91,7 +93,7 @@ void shuffle_fpr_data(int oldStatus, int newStatus)
     }
 }
 
-void set_fpr_pointers(int newStatus)
+void set_fpr_pointers(uint32_t newStatus)
 {
     int i;
 #if defined(M64P_BIG_ENDIAN)
@@ -101,7 +103,7 @@ void set_fpr_pointers(int newStatus)
 #endif
 
     // update the FPR register pointers
-    if (newStatus & 0x04000000)
+    if (newStatus & UINT32_C(0x04000000))
     {
         for (i = 0; i < 32; i++)
         {

--- a/src/r4300/cp1.c
+++ b/src/r4300/cp1.c
@@ -26,13 +26,13 @@
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
 float *reg_cop1_simple[32];
 double *reg_cop1_double[32];
-int FCR0, FCR31;
+int32_t FCR0, FCR31;
 #else
 extern float *reg_cop1_simple[32];
 extern double *reg_cop1_double[32];
-extern int FCR0, FCR31;
+extern int32_t FCR0, FCR31;
 #endif
-long long int reg_cop1_fgr_64[32];
+int64_t reg_cop1_fgr_64[32];
 
 int rounding_mode = 0x33F, trunc_mode = 0xF3F, round_mode = 0x33F,
     ceil_mode = 0xB3F, floor_mode = 0x73F;
@@ -52,7 +52,7 @@ void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus)
     if ((newStatus & UINT32_C(0x04000000)) != (oldStatus & UINT32_C(0x04000000)))
     {
         int i;
-        int temp_fgr_32[32];
+        int32_t temp_fgr_32[32];
 
         // pack or unpack the FGR register data
         if (newStatus & UINT32_C(0x04000000))
@@ -60,14 +60,14 @@ void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus)
             // retrieve 32 FPR values from packed 32-bit FGR registers
             for (i = 0; i < 32; i++)
             {
-                temp_fgr_32[i] = *((int *) &reg_cop1_fgr_64[i>>1] + ((i & 1) ^ isBigEndian));
+                temp_fgr_32[i] = *((int32_t *) &reg_cop1_fgr_64[i>>1] + ((i & 1) ^ isBigEndian));
             }
             // unpack them into 32 64-bit registers, taking the high 32-bits from their temporary place in the upper 16 FGRs
             for (i = 0; i < 32; i++)
             {
-                int high32 = *((int *) &reg_cop1_fgr_64[(i>>1)+16] + (i & 1));
-                *((int *) &reg_cop1_fgr_64[i] + isBigEndian)     = temp_fgr_32[i];
-                *((int *) &reg_cop1_fgr_64[i] + (isBigEndian^1)) = high32;
+                int32_t high32 = *((int32_t *) &reg_cop1_fgr_64[(i>>1)+16] + (i & 1));
+                *((int32_t *) &reg_cop1_fgr_64[i] + isBigEndian)     = temp_fgr_32[i];
+                *((int32_t *) &reg_cop1_fgr_64[i] + (isBigEndian^1)) = high32;
             }
         }
         else
@@ -75,19 +75,19 @@ void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus)
             // retrieve the high 32 bits from each 64-bit FGR register and store in temp array
             for (i = 0; i < 32; i++)
             {
-                temp_fgr_32[i] = *((int *) &reg_cop1_fgr_64[i] + (isBigEndian^1));
+                temp_fgr_32[i] = *((int32_t *) &reg_cop1_fgr_64[i] + (isBigEndian^1));
             }
             // take the low 32 bits from each register and pack them together into 64-bit pairs
             for (i = 0; i < 16; i++)
             {
-                unsigned int least32 = *((unsigned int *) &reg_cop1_fgr_64[i*2] + isBigEndian);
-                unsigned int most32 = *((unsigned int *) &reg_cop1_fgr_64[i*2+1] + isBigEndian);
-                reg_cop1_fgr_64[i] = ((unsigned long long) most32 << 32) | (unsigned long long) least32;
+                uint32_t least32 = *((uint32_t *) &reg_cop1_fgr_64[i*2] + isBigEndian);
+                uint32_t most32 = *((uint32_t *) &reg_cop1_fgr_64[i*2+1] + isBigEndian);
+                reg_cop1_fgr_64[i] = ((uint64_t) most32 << 32) | (uint64_t) least32;
             }
             // store the high bits in the upper 16 FGRs, which wont be accessible in 32-bit mode
             for (i = 0; i < 32; i++)
             {
-                *((int *) &reg_cop1_fgr_64[(i>>1)+16] + (i & 1)) = temp_fgr_32[i];
+                *((int32_t *) &reg_cop1_fgr_64[(i>>1)+16] + (i & 1)) = temp_fgr_32[i];
             }
         }
     }

--- a/src/r4300/cp1.h
+++ b/src/r4300/cp1.h
@@ -26,8 +26,8 @@
 
 extern float *reg_cop1_simple[32];
 extern double *reg_cop1_double[32];
-extern int FCR0, FCR31;
-extern long long int reg_cop1_fgr_64[32];
+extern int32_t FCR0, FCR31;
+extern int64_t reg_cop1_fgr_64[32];
 extern int rounding_mode, trunc_mode, round_mode, ceil_mode, floor_mode;
 
 void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus);

--- a/src/r4300/cp1.h
+++ b/src/r4300/cp1.h
@@ -22,14 +22,16 @@
 #ifndef M64P_R4300_CP1_H
 #define M64P_R4300_CP1_H
 
+#include <stdint.h>
+
 extern float *reg_cop1_simple[32];
 extern double *reg_cop1_double[32];
 extern int FCR0, FCR31;
 extern long long int reg_cop1_fgr_64[32];
 extern int rounding_mode, trunc_mode, round_mode, ceil_mode, floor_mode;
 
-void shuffle_fpr_data(int oldStatus, int newStatus);
-void set_fpr_pointers(int newStatus);
+void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus);
+void set_fpr_pointers(uint32_t newStatus);
 
 #endif /* M64P_R4300_CP1_H */
 

--- a/src/r4300/exception.c
+++ b/src/r4300/exception.c
@@ -29,7 +29,7 @@
 #include "recomph.h"
 #include "tlb.h"
 
-void TLB_refill_exception(unsigned int address, int w)
+void TLB_refill_exception(uint32_t address, int w)
 {
    int usual_handler = 0, i;
 
@@ -59,7 +59,7 @@ void TLB_refill_exception(unsigned int address, int w)
     g_cp0_regs[CP0_CAUSE_REG] &= ~0x80000000;
     g_cp0_regs[CP0_STATUS_REG] |= 0x2; //EXL=1
     
-    if (address >= 0x80000000 && address < 0xc0000000)
+    if (address >= UINT32_C(0x80000000) && address < UINT32_C(0xc0000000))
       usual_handler = 1;
     for (i=0; i<32; i++)
       {

--- a/src/r4300/exception.c
+++ b/src/r4300/exception.c
@@ -34,16 +34,16 @@ void TLB_refill_exception(uint32_t address, int w)
    int usual_handler = 0, i;
 
    if (r4300emu != CORE_DYNAREC && w != 2) update_count();
-   if (w == 1) g_cp0_regs[CP0_CAUSE_REG] = (3 << 2);
-   else g_cp0_regs[CP0_CAUSE_REG] = (2 << 2);
+   if (w == 1) g_cp0_regs[CP0_CAUSE_REG] = (UINT32_C(3) << 2);
+   else g_cp0_regs[CP0_CAUSE_REG] = (UINT32_C(2) << 2);
    g_cp0_regs[CP0_BADVADDR_REG] = address;
-   g_cp0_regs[CP0_CONTEXT_REG] = (g_cp0_regs[CP0_CONTEXT_REG] & 0xFF80000F) | ((address >> 9) & 0x007FFFF0);
-   g_cp0_regs[CP0_ENTRYHI_REG] = address & 0xFFFFE000;
-   if (g_cp0_regs[CP0_STATUS_REG] & 0x2) // Test de EXL
+   g_cp0_regs[CP0_CONTEXT_REG] = (g_cp0_regs[CP0_CONTEXT_REG] & UINT32_C(0xFF80000F)) | ((address >> 9) & UINT32_C(0x007FFFF0));
+   g_cp0_regs[CP0_ENTRYHI_REG] = address & UINT32_C(0xFFFFE000);
+   if (g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x2)) // Test de EXL
      {
     generic_jump_to(UINT32_C(0x80000180));
-    if(delay_slot==1 || delay_slot==3) g_cp0_regs[CP0_CAUSE_REG] |= 0x80000000;
-    else g_cp0_regs[CP0_CAUSE_REG] &= 0x7FFFFFFF;
+    if(delay_slot==1 || delay_slot==3) g_cp0_regs[CP0_CAUSE_REG] |= UINT32_C(0x80000000);
+    else g_cp0_regs[CP0_CAUSE_REG] &= UINT32_C(0x7FFFFFFF);
      }
    else
      {
@@ -56,8 +56,8 @@ void TLB_refill_exception(uint32_t address, int w)
       }
     else g_cp0_regs[CP0_EPC_REG] = PC->addr;
          
-    g_cp0_regs[CP0_CAUSE_REG] &= ~0x80000000;
-    g_cp0_regs[CP0_STATUS_REG] |= 0x2; //EXL=1
+    g_cp0_regs[CP0_CAUSE_REG] &= ~UINT32_C(0x80000000);
+    g_cp0_regs[CP0_STATUS_REG] |= UINT32_C(0x2); //EXL=1
     
     if (address >= UINT32_C(0x80000000) && address < UINT32_C(0xc0000000))
       usual_handler = 1;
@@ -81,12 +81,12 @@ void TLB_refill_exception(uint32_t address, int w)
      }
    if(delay_slot==1 || delay_slot==3)
      {
-    g_cp0_regs[CP0_CAUSE_REG] |= 0x80000000;
+    g_cp0_regs[CP0_CAUSE_REG] |= UINT32_C(0x80000000);
     g_cp0_regs[CP0_EPC_REG]-=4;
      }
    else
      {
-    g_cp0_regs[CP0_CAUSE_REG] &= 0x7FFFFFFF;
+    g_cp0_regs[CP0_CAUSE_REG] &= UINT32_C(0x7FFFFFFF);
      }
    if(w != 2) g_cp0_regs[CP0_EPC_REG]-=4;
    
@@ -118,12 +118,12 @@ void exception_general(void)
    
    if(delay_slot==1 || delay_slot==3)
      {
-    g_cp0_regs[CP0_CAUSE_REG] |= 0x80000000;
+    g_cp0_regs[CP0_CAUSE_REG] |= UINT32_C(0x80000000);
     g_cp0_regs[CP0_EPC_REG]-=4;
      }
    else
      {
-    g_cp0_regs[CP0_CAUSE_REG] &= 0x7FFFFFFF;
+    g_cp0_regs[CP0_CAUSE_REG] &= UINT32_C(0x7FFFFFFF);
      }
    generic_jump_to(UINT32_C(0x80000180));
    last_addr = PC->addr;

--- a/src/r4300/exception.c
+++ b/src/r4300/exception.c
@@ -41,7 +41,7 @@ void TLB_refill_exception(uint32_t address, int w)
    g_cp0_regs[CP0_ENTRYHI_REG] = address & 0xFFFFE000;
    if (g_cp0_regs[CP0_STATUS_REG] & 0x2) // Test de EXL
      {
-    generic_jump_to(0x80000180);
+    generic_jump_to(UINT32_C(0x80000180));
     if(delay_slot==1 || delay_slot==3) g_cp0_regs[CP0_CAUSE_REG] |= 0x80000000;
     else g_cp0_regs[CP0_CAUSE_REG] &= 0x7FFFFFFF;
      }
@@ -72,11 +72,11 @@ void TLB_refill_exception(uint32_t address, int w)
       }
     if (usual_handler)
       {
-         generic_jump_to(0x80000180);
+         generic_jump_to(UINT32_C(0x80000180));
       }
     else
       {
-         generic_jump_to(0x80000000);
+         generic_jump_to(UINT32_C(0x80000000));
       }
      }
    if(delay_slot==1 || delay_slot==3)
@@ -125,7 +125,7 @@ void exception_general(void)
      {
     g_cp0_regs[CP0_CAUSE_REG] &= 0x7FFFFFFF;
      }
-   generic_jump_to(0x80000180);
+   generic_jump_to(UINT32_C(0x80000180));
    last_addr = PC->addr;
    if (r4300emu == CORE_DYNAREC)
      {

--- a/src/r4300/exception.h
+++ b/src/r4300/exception.h
@@ -22,7 +22,9 @@
 #ifndef M64P_R4300_EXCEPTION_H
 #define M64P_R4300_EXCEPTION_H
 
-void TLB_refill_exception(unsigned int addresse, int w);
+#include <stdint.h>
+
+void TLB_refill_exception(uint32_t addresse, int w);
 void exception_general(void);
 
 #endif /* M64P_R4300_EXCEPTION_H */

--- a/src/r4300/fpu.h
+++ b/src/r4300/fpu.h
@@ -22,6 +22,7 @@
 #ifndef M64P_R4300_FPU_H
 #define M64P_R4300_FPU_H
 
+#include <stdint.h>
 #include <math.h>
 
 #include "r4300.h"
@@ -46,6 +47,8 @@
   #include <fenv.h>
 #endif
 
+#define FCR31_CMP_BIT UINT32_C(0x800000)
+
 
 M64P_FPU_INLINE void set_rounding(void)
 {
@@ -65,102 +68,102 @@ M64P_FPU_INLINE void set_rounding(void)
   }
 }
 
-M64P_FPU_INLINE void cvt_s_w(int *source,float *dest)
+M64P_FPU_INLINE void cvt_s_w(const int32_t *source,float *dest)
 {
   set_rounding();
   *dest = (float) *source;
 }
-M64P_FPU_INLINE void cvt_d_w(int *source,double *dest)
+M64P_FPU_INLINE void cvt_d_w(const int32_t *source,double *dest)
 {
   *dest = (double) *source;
 }
-M64P_FPU_INLINE void cvt_s_l(long long *source,float *dest)
+M64P_FPU_INLINE void cvt_s_l(const int64_t *source,float *dest)
 {
   set_rounding();
   *dest = (float) *source;
 }
-M64P_FPU_INLINE void cvt_d_l(long long *source,double *dest)
+M64P_FPU_INLINE void cvt_d_l(const int64_t *source,double *dest)
 {
   set_rounding();
   *dest = (double) *source;
 }
-M64P_FPU_INLINE void cvt_d_s(float *source,double *dest)
+M64P_FPU_INLINE void cvt_d_s(const float *source,double *dest)
 {
   *dest = (double) *source;
 }
-M64P_FPU_INLINE void cvt_s_d(double *source,float *dest)
+M64P_FPU_INLINE void cvt_s_d(const double *source,float *dest)
 {
   set_rounding();
   *dest = (float) *source;
 }
 
-M64P_FPU_INLINE void round_l_s(float *source,long long *dest)
+M64P_FPU_INLINE void round_l_s(const float *source,int64_t *dest)
 {
-  *dest = (long long) roundf(*source);
+  *dest = (int64_t) roundf(*source);
 }
-M64P_FPU_INLINE void round_w_s(float *source,int *dest)
+M64P_FPU_INLINE void round_w_s(const float *source,int32_t *dest)
 {
-  *dest = (int) roundf(*source);
+  *dest = (int32_t) roundf(*source);
 }
-M64P_FPU_INLINE void trunc_l_s(float *source,long long *dest)
+M64P_FPU_INLINE void trunc_l_s(const float *source,int64_t *dest)
 {
-  *dest = (long long) truncf(*source);
+  *dest = (int64_t) truncf(*source);
 }
-M64P_FPU_INLINE void trunc_w_s(float *source,int *dest)
+M64P_FPU_INLINE void trunc_w_s(const float *source,int32_t *dest)
 {
-  *dest = (int) truncf(*source);
+  *dest = (int32_t) truncf(*source);
 }
-M64P_FPU_INLINE void ceil_l_s(float *source,long long *dest)
+M64P_FPU_INLINE void ceil_l_s(const float *source,int64_t *dest)
 {
-  *dest = (long long) ceilf(*source);
+  *dest = (int64_t) ceilf(*source);
 }
-M64P_FPU_INLINE void ceil_w_s(float *source,int *dest)
+M64P_FPU_INLINE void ceil_w_s(const float *source,int32_t *dest)
 {
-  *dest = (int) ceilf(*source);
+  *dest = (int32_t) ceilf(*source);
 }
-M64P_FPU_INLINE void floor_l_s(float *source,long long *dest)
+M64P_FPU_INLINE void floor_l_s(const float *source,int64_t *dest)
 {
-  *dest = (long long) floorf(*source);
+  *dest = (int64_t) floorf(*source);
 }
-M64P_FPU_INLINE void floor_w_s(float *source,int *dest)
+M64P_FPU_INLINE void floor_w_s(const float *source,int32_t *dest)
 {
-  *dest = (int) floorf(*source);
-}
-
-M64P_FPU_INLINE void round_l_d(double *source,long long *dest)
-{
-  *dest = (long long) round(*source);
-}
-M64P_FPU_INLINE void round_w_d(double *source,int *dest)
-{
-  *dest = (int) round(*source);
-}
-M64P_FPU_INLINE void trunc_l_d(double *source,long long *dest)
-{
-  *dest = (long long) trunc(*source);
-}
-M64P_FPU_INLINE void trunc_w_d(double *source,int *dest)
-{
-  *dest = (int) trunc(*source);
-}
-M64P_FPU_INLINE void ceil_l_d(double *source,long long *dest)
-{
-  *dest = (long long) ceil(*source);
-}
-M64P_FPU_INLINE void ceil_w_d(double *source,int *dest)
-{
-  *dest = (int) ceil(*source);
-}
-M64P_FPU_INLINE void floor_l_d(double *source,long long *dest)
-{
-  *dest = (long long) floor(*source);
-}
-M64P_FPU_INLINE void floor_w_d(double *source,int *dest)
-{
-  *dest = (int) floor(*source);
+  *dest = (int32_t) floorf(*source);
 }
 
-M64P_FPU_INLINE void cvt_w_s(float *source,int *dest)
+M64P_FPU_INLINE void round_l_d(const double *source,int64_t *dest)
+{
+  *dest = (int64_t) round(*source);
+}
+M64P_FPU_INLINE void round_w_d(const double *source,int32_t *dest)
+{
+  *dest = (int32_t) round(*source);
+}
+M64P_FPU_INLINE void trunc_l_d(const double *source,int64_t *dest)
+{
+  *dest = (int64_t) trunc(*source);
+}
+M64P_FPU_INLINE void trunc_w_d(const double *source,int32_t *dest)
+{
+  *dest = (int32_t) trunc(*source);
+}
+M64P_FPU_INLINE void ceil_l_d(const double *source,int64_t *dest)
+{
+  *dest = (int64_t) ceil(*source);
+}
+M64P_FPU_INLINE void ceil_w_d(const double *source,int32_t *dest)
+{
+  *dest = (int32_t) ceil(*source);
+}
+M64P_FPU_INLINE void floor_l_d(const double *source,int64_t *dest)
+{
+  *dest = (int64_t) floor(*source);
+}
+M64P_FPU_INLINE void floor_w_d(const double *source,int32_t *dest)
+{
+  *dest = (int32_t) floor(*source);
+}
+
+M64P_FPU_INLINE void cvt_w_s(const float *source,int32_t *dest)
 {
   switch(FCR31&3)
   {
@@ -170,7 +173,7 @@ M64P_FPU_INLINE void cvt_w_s(float *source,int *dest)
     case 3: floor_w_s(source,dest);return;
   }
 }
-M64P_FPU_INLINE void cvt_w_d(double *source,int *dest)
+M64P_FPU_INLINE void cvt_w_d(const double *source,int32_t *dest)
 {
   switch(FCR31&3)
   {
@@ -180,7 +183,7 @@ M64P_FPU_INLINE void cvt_w_d(double *source,int *dest)
     case 3: floor_w_d(source,dest);return;
   }
 }
-M64P_FPU_INLINE void cvt_l_s(float *source,long long *dest)
+M64P_FPU_INLINE void cvt_l_s(const float *source,int64_t *dest)
 {
   switch(FCR31&3)
   {
@@ -190,7 +193,7 @@ M64P_FPU_INLINE void cvt_l_s(float *source,long long *dest)
     case 3: floor_l_s(source,dest);return;
   }
 }
-M64P_FPU_INLINE void cvt_l_d(double *source,long long *dest)
+M64P_FPU_INLINE void cvt_l_d(const double *source,int64_t *dest)
 {
   switch(FCR31&3)
   {
@@ -203,248 +206,248 @@ M64P_FPU_INLINE void cvt_l_d(double *source,long long *dest)
 
 M64P_FPU_INLINE void c_f_s()
 {
-  FCR31 &= ~0x800000;
+  FCR31 &= ~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_un_s(float *source,float *target)
+M64P_FPU_INLINE void c_un_s(const float *source,const float *target)
 {
-  FCR31=(isnan(*source) || isnan(*target)) ? FCR31|0x800000 : FCR31&~0x800000;
+  FCR31=(isnan(*source) || isnan(*target)) ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
                           
-M64P_FPU_INLINE void c_eq_s(float *source,float *target)
+M64P_FPU_INLINE void c_eq_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~0x800000;return;}
-  FCR31 = *source==*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
+  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_ueq_s(float *source,float *target)
+M64P_FPU_INLINE void c_ueq_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=0x800000;return;}
-  FCR31 = *source==*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-
-M64P_FPU_INLINE void c_olt_s(float *source,float *target)
-{
-  if (isnan(*source) || isnan(*target)) {FCR31&=~0x800000;return;}
-  FCR31 = *source<*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-M64P_FPU_INLINE void c_ult_s(float *source,float *target)
-{
-  if (isnan(*source) || isnan(*target)) {FCR31|=0x800000;return;}
-  FCR31 = *source<*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
+  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
 
-M64P_FPU_INLINE void c_ole_s(float *source,float *target)
+M64P_FPU_INLINE void c_olt_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~0x800000;return;}
-  FCR31 = *source<=*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
+  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_ule_s(float *source,float *target)
+M64P_FPU_INLINE void c_ult_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=0x800000;return;}
-  FCR31 = *source<=*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-
-M64P_FPU_INLINE void c_sf_s(float *source,float *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31&=~0x800000;
-}
-M64P_FPU_INLINE void c_ngle_s(float *source,float *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31&=~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
+  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
 
-M64P_FPU_INLINE void c_seq_s(float *source,float *target)
+M64P_FPU_INLINE void c_ole_s(const float *source,const float *target)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source==*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
+  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_ngl_s(float *source,float *target)
+M64P_FPU_INLINE void c_ule_s(const float *source,const float *target)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source==*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-
-M64P_FPU_INLINE void c_lt_s(float *source,float *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-M64P_FPU_INLINE void c_nge_s(float *source,float *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
+  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
 
-M64P_FPU_INLINE void c_le_s(float *source,float *target)
+M64P_FPU_INLINE void c_sf_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<=*target ? FCR31|0x800000 : FCR31&~0x800000;
+  FCR31&=~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_ngt_s(float *source,float *target)
+M64P_FPU_INLINE void c_ngle_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<=*target ? FCR31|0x800000 : FCR31&~0x800000;
+  FCR31&=~FCR31_CMP_BIT;
+}
+
+M64P_FPU_INLINE void c_seq_s(const float *source,const float *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+M64P_FPU_INLINE void c_ngl_s(const float *source,const float *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+
+M64P_FPU_INLINE void c_lt_s(const float *source,const float *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+M64P_FPU_INLINE void c_nge_s(const float *source,const float *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+
+M64P_FPU_INLINE void c_le_s(const float *source,const float *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+M64P_FPU_INLINE void c_ngt_s(const float *source,const float *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_f_d()
 {
-  FCR31 &= ~0x800000;
+  FCR31 &= ~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_un_d(double *source,double *target)
+M64P_FPU_INLINE void c_un_d(const double *source,const double *target)
 {
-  FCR31=(isnan(*source) || isnan(*target)) ? FCR31|0x800000 : FCR31&~0x800000;
+  FCR31=(isnan(*source) || isnan(*target)) ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
                           
-M64P_FPU_INLINE void c_eq_d(double *source,double *target)
+M64P_FPU_INLINE void c_eq_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~0x800000;return;}
-  FCR31 = *source==*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
+  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_ueq_d(double *source,double *target)
+M64P_FPU_INLINE void c_ueq_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=0x800000;return;}
-  FCR31 = *source==*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-
-M64P_FPU_INLINE void c_olt_d(double *source,double *target)
-{
-  if (isnan(*source) || isnan(*target)) {FCR31&=~0x800000;return;}
-  FCR31 = *source<*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-M64P_FPU_INLINE void c_ult_d(double *source,double *target)
-{
-  if (isnan(*source) || isnan(*target)) {FCR31|=0x800000;return;}
-  FCR31 = *source<*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
+  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
 
-M64P_FPU_INLINE void c_ole_d(double *source,double *target)
+M64P_FPU_INLINE void c_olt_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~0x800000;return;}
-  FCR31 = *source<=*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
+  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_ule_d(double *source,double *target)
+M64P_FPU_INLINE void c_ult_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=0x800000;return;}
-  FCR31 = *source<=*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-
-M64P_FPU_INLINE void c_sf_d(double *source,double *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31&=~0x800000;
-}
-M64P_FPU_INLINE void c_ngle_d(double *source,double *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31&=~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
+  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
 
-M64P_FPU_INLINE void c_seq_d(double *source,double *target)
+M64P_FPU_INLINE void c_ole_d(const double *source,const double *target)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source==*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
+  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_ngl_d(double *source,double *target)
+M64P_FPU_INLINE void c_ule_d(const double *source,const double *target)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source==*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-
-M64P_FPU_INLINE void c_lt_d(double *source,double *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<*target ? FCR31|0x800000 : FCR31&~0x800000;
-}
-M64P_FPU_INLINE void c_nge_d(double *source,double *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<*target ? FCR31|0x800000 : FCR31&~0x800000;
+  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
+  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
 
-M64P_FPU_INLINE void c_le_d(double *source,double *target)
+M64P_FPU_INLINE void c_sf_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<=*target ? FCR31|0x800000 : FCR31&~0x800000;
+  FCR31&=~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_ngt_d(double *source,double *target)
+M64P_FPU_INLINE void c_ngle_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<=*target ? FCR31|0x800000 : FCR31&~0x800000;
+  FCR31&=~FCR31_CMP_BIT;
+}
+
+M64P_FPU_INLINE void c_seq_d(const double *source,const double *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+M64P_FPU_INLINE void c_ngl_d(const double *source,const double *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+
+M64P_FPU_INLINE void c_lt_d(const double *source,const double *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+M64P_FPU_INLINE void c_nge_d(const double *source,const double *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+
+M64P_FPU_INLINE void c_le_d(const double *source,const double *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+}
+M64P_FPU_INLINE void c_ngt_d(const double *source,const double *target)
+{
+  //if (isnan(*source) || isnan(*target)) // FIXME - exception
+  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
 }
 
 
-M64P_FPU_INLINE void add_s(float *source1,float *source2,float *target)
+M64P_FPU_INLINE void add_s(const float *source1,const float *source2,float *target)
 {
   set_rounding();
   *target=(*source1)+(*source2);
 }
-M64P_FPU_INLINE void sub_s(float *source1,float *source2,float *target)
+M64P_FPU_INLINE void sub_s(const float *source1,const float *source2,float *target)
 {
   set_rounding();
   *target=(*source1)-(*source2);
 }
-M64P_FPU_INLINE void mul_s(float *source1,float *source2,float *target)
+M64P_FPU_INLINE void mul_s(const float *source1,const float *source2,float *target)
 {
   set_rounding();
   *target=(*source1)*(*source2);
 }
-M64P_FPU_INLINE void div_s(float *source1,float *source2,float *target)
+M64P_FPU_INLINE void div_s(const float *source1,const float *source2,float *target)
 {
   set_rounding();
   *target=(*source1)/(*source2);
 }
-M64P_FPU_INLINE void sqrt_s(float *source,float *target)
+M64P_FPU_INLINE void sqrt_s(const float *source,float *target)
 {
   set_rounding();
   *target=sqrtf(*source);
 }
-M64P_FPU_INLINE void abs_s(float *source,float *target)
+M64P_FPU_INLINE void abs_s(const float *source,float *target)
 {
   *target=fabsf(*source);
 }
-M64P_FPU_INLINE void mov_s(float *source,float *target)
+M64P_FPU_INLINE void mov_s(const float *source,float *target)
 {
   *target=*source;
 }
-M64P_FPU_INLINE void neg_s(float *source,float *target)
+M64P_FPU_INLINE void neg_s(const float *source,float *target)
 {
   *target=-(*source);
 }
-M64P_FPU_INLINE void add_d(double *source1,double *source2,double *target)
+M64P_FPU_INLINE void add_d(const double *source1,const double *source2,double *target)
 {
   set_rounding();
   *target=(*source1)+(*source2);
 }
-M64P_FPU_INLINE void sub_d(double *source1,double *source2,double *target)
+M64P_FPU_INLINE void sub_d(const double *source1,const double *source2,double *target)
 {
   set_rounding();
   *target=(*source1)-(*source2);
 }
-M64P_FPU_INLINE void mul_d(double *source1,double *source2,double *target)
+M64P_FPU_INLINE void mul_d(const double *source1,const double *source2,double *target)
 {
   set_rounding();
   *target=(*source1)*(*source2);
 }
-M64P_FPU_INLINE void div_d(double *source1,double *source2,double *target)
+M64P_FPU_INLINE void div_d(const double *source1,const double *source2,double *target)
 {
   set_rounding();
   *target=(*source1)/(*source2);
 }
-M64P_FPU_INLINE void sqrt_d(double *source,double *target)
+M64P_FPU_INLINE void sqrt_d(const double *source,double *target)
 {
   set_rounding();
   *target=sqrt(*source);
 }
-M64P_FPU_INLINE void abs_d(double *source,double *target)
+M64P_FPU_INLINE void abs_d(const double *source,double *target)
 {
   *target=fabs(*source);
 }
-M64P_FPU_INLINE void mov_d(double *source,double *target)
+M64P_FPU_INLINE void mov_d(const double *source,double *target)
 {
   *target=*source;
 }
-M64P_FPU_INLINE void neg_d(double *source,double *target)
+M64P_FPU_INLINE void neg_d(const double *source,double *target)
 {
   *target=-(*source);
 }

--- a/src/r4300/interpreter.def
+++ b/src/r4300/interpreter.def
@@ -19,7 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Before #including this file, the following macros should be defined:
+/* Before #including this file, <stdint.h> must be included, and the following
+ * macros must be defined:
  *
  * PCADDR: Program counter (memory address of the current instruction).
  *

--- a/src/r4300/interpreter.def
+++ b/src/r4300/interpreter.def
@@ -19,8 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-/* Before #including this file, <stdint.h> must be included, and the following
- * macros must be defined:
+/* Before #including this file, <stdint.h> and <inttypes.h> must be included,
+ * and the following macros must be defined:
  *
  * PCADDR: Program counter (memory address of the current instruction).
  *
@@ -48,14 +48,14 @@
 
 DECLARE_INSTRUCTION(NI)
 {
-   DebugMessage(M64MSG_ERROR, "NI() @ 0x%x", PCADDR);
-   DebugMessage(M64MSG_ERROR, "opcode not implemented: %x:%x", PCADDR, *fast_mem_access(PCADDR));
+   DebugMessage(M64MSG_ERROR, "NI() @ 0x%" PRIX32, PCADDR);
+   DebugMessage(M64MSG_ERROR, "opcode not implemented: %" PRIX32 ":%" PRIX32, PCADDR, *fast_mem_access(PCADDR));
    stop=1;
 }
 
 DECLARE_INSTRUCTION(RESERVED)
 {
-   DebugMessage(M64MSG_ERROR, "reserved opcode: %x:%x", PCADDR, *fast_mem_access(PCADDR));
+   DebugMessage(M64MSG_ERROR, "reserved opcode: %" PRIX32 ":%" PRIX32, PCADDR, *fast_mem_access(PCADDR));
    stop=1;
 }
 

--- a/src/r4300/interpreter_cop0.def
+++ b/src/r4300/interpreter_cop0.def
@@ -40,8 +40,8 @@ DECLARE_INSTRUCTION(MTC0)
   switch(rfs)
   {
     case CP0_INDEX_REG:
-      g_cp0_regs[CP0_INDEX_REG] = (unsigned int) rrt & 0x8000003F;
-      if ((g_cp0_regs[CP0_INDEX_REG] & 0x3F) > 31)
+      g_cp0_regs[CP0_INDEX_REG] = rrt32 & UINT32_C(0x8000003F);
+      if ((g_cp0_regs[CP0_INDEX_REG] & UINT32_C(0x3F)) > UINT32_C(31))
       {
         DebugMessage(M64MSG_ERROR, "MTC0 instruction writing Index register with TLB index > 31");
         stop=1;
@@ -50,21 +50,21 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_RANDOM_REG:
       break;
     case CP0_ENTRYLO0_REG:
-      g_cp0_regs[CP0_ENTRYLO0_REG] = (unsigned int) rrt & 0x3FFFFFFF;
+      g_cp0_regs[CP0_ENTRYLO0_REG] = rrt32 & UINT32_C(0x3FFFFFFF);
       break;
     case CP0_ENTRYLO1_REG:
-      g_cp0_regs[CP0_ENTRYLO1_REG] = (unsigned int) rrt & 0x3FFFFFFF;
+      g_cp0_regs[CP0_ENTRYLO1_REG] = rrt32 & UINT32_C(0x3FFFFFFF);
       break;
     case CP0_CONTEXT_REG:
-      g_cp0_regs[CP0_CONTEXT_REG] = ((unsigned int) rrt & 0xFF800000)
-                                  | (g_cp0_regs[CP0_CONTEXT_REG] & 0x007FFFF0);
+      g_cp0_regs[CP0_CONTEXT_REG] = (rrt32 & UINT32_C(0xFF800000))
+                                  | (g_cp0_regs[CP0_CONTEXT_REG] & UINT32_C(0x007FFFF0));
       break;
     case CP0_PAGEMASK_REG:
-      g_cp0_regs[CP0_PAGEMASK_REG] = (unsigned int) rrt & 0x01FFE000;
+      g_cp0_regs[CP0_PAGEMASK_REG] = rrt32 & UINT32_C(0x01FFE000);
       break;
     case CP0_WIRED_REG:
-      g_cp0_regs[CP0_WIRED_REG] = (unsigned int) rrt;
-      g_cp0_regs[CP0_RANDOM_REG] = 31;
+      g_cp0_regs[CP0_WIRED_REG] = rrt32;
+      g_cp0_regs[CP0_RANDOM_REG] = UINT32_C(31);
       break;
     case CP0_BADVADDR_REG:
       break;
@@ -73,26 +73,26 @@ DECLARE_INSTRUCTION(MTC0)
       interupt_unsafe_state = 1;
       if (next_interupt <= g_cp0_regs[CP0_COUNT_REG]) gen_interupt();
       interupt_unsafe_state = 0;
-      translate_event_queue((unsigned int) rrt & 0xFFFFFFFF);
-      g_cp0_regs[CP0_COUNT_REG] = (unsigned int) rrt & 0xFFFFFFFF;
+      translate_event_queue(rrt32);
+      g_cp0_regs[CP0_COUNT_REG] = rrt32;
       break;
     case CP0_ENTRYHI_REG:
-      g_cp0_regs[CP0_ENTRYHI_REG] = (unsigned int) rrt & 0xFFFFE0FF;
+      g_cp0_regs[CP0_ENTRYHI_REG] = rrt32 & UINT32_C(0xFFFFE0FF);
       break;
     case CP0_COMPARE_REG:
       update_count();
       remove_event(COMPARE_INT);
-      add_interupt_event_count(COMPARE_INT, (unsigned int)rrt);
-      g_cp0_regs[CP0_COMPARE_REG] = (unsigned int) rrt;
-      g_cp0_regs[CP0_CAUSE_REG] &= 0xFFFF7FFF; //Timer interupt is clear
+      add_interupt_event_count(COMPARE_INT, rrt32);
+      g_cp0_regs[CP0_COMPARE_REG] = rrt32;
+      g_cp0_regs[CP0_CAUSE_REG] &= UINT32_C(0xFFFF7FFF); //Timer interupt is clear
       break;
     case CP0_STATUS_REG:
-      if((rrt & 0x04000000) != (g_cp0_regs[CP0_STATUS_REG] & 0x04000000))
+      if((rrt32 & UINT32_C(0x04000000)) != (g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)))
       {
-          shuffle_fpr_data(g_cp0_regs[CP0_STATUS_REG], (unsigned int) rrt);
-          set_fpr_pointers((unsigned int) rrt);
+          shuffle_fpr_data(g_cp0_regs[CP0_STATUS_REG], rrt32);
+          set_fpr_pointers(rrt32);
       }
-      g_cp0_regs[CP0_STATUS_REG] = (unsigned int) rrt;
+      g_cp0_regs[CP0_STATUS_REG] = rrt32;
       update_count();
       ADD_TO_PC(1);
       check_interupt();
@@ -102,32 +102,32 @@ DECLARE_INSTRUCTION(MTC0)
       ADD_TO_PC(-1);
       break;
     case CP0_CAUSE_REG:
-      if (rrt!=0)
+      if (rrt32!=0)
       {
          DebugMessage(M64MSG_ERROR, "MTC0 instruction trying to write Cause register with non-0 value");
          stop = 1;
       }
-      else g_cp0_regs[CP0_CAUSE_REG] = (unsigned int) rrt;
+      else g_cp0_regs[CP0_CAUSE_REG] = rrt32;
       break;
     case CP0_EPC_REG:
-      g_cp0_regs[CP0_EPC_REG] = (unsigned int) rrt;
+      g_cp0_regs[CP0_EPC_REG] = rrt32;
       break;
     case CP0_PREVID_REG:
       break;
     case CP0_CONFIG_REG:
-      g_cp0_regs[CP0_CONFIG_REG] = (unsigned int) rrt;
+      g_cp0_regs[CP0_CONFIG_REG] = rrt32;
       break;
     case CP0_WATCHLO_REG:
-      g_cp0_regs[CP0_WATCHLO_REG] = (unsigned int) rrt & 0xFFFFFFFF;
+      g_cp0_regs[CP0_WATCHLO_REG] = rrt32;
       break;
     case CP0_WATCHHI_REG:
-      g_cp0_regs[CP0_WATCHHI_REG] = (unsigned int) rrt & 0xFFFFFFFF;
+      g_cp0_regs[CP0_WATCHHI_REG] = rrt32;
       break;
     case CP0_TAGLO_REG:
-      g_cp0_regs[CP0_TAGLO_REG] = (unsigned int) rrt & 0x0FFFFFC0;
+      g_cp0_regs[CP0_TAGLO_REG] = rrt32 & UINT32_C(0x0FFFFFC0);
       break;
     case CP0_TAGHI_REG:
-      g_cp0_regs[CP0_TAGHI_REG] =0;
+      g_cp0_regs[CP0_TAGHI_REG] = 0;
       break;
     default:
       DebugMessage(M64MSG_ERROR, "Unknown MTC0 write: %d", rfs);

--- a/src/r4300/interpreter_cop0.def
+++ b/src/r4300/interpreter_cop0.def
@@ -29,8 +29,7 @@ DECLARE_INSTRUCTION(MFC0)
       case CP0_COUNT_REG:
         update_count();
       default:
-        rrt32 = g_cp0_regs[rfs];
-        sign_extended(rrt);
+        rrt = SE32(g_cp0_regs[rfs]);
    }
    ADD_TO_PC(1);
 }

--- a/src/r4300/interpreter_cop1.def
+++ b/src/r4300/interpreter_cop1.def
@@ -21,15 +21,15 @@
 
 #include "fpu.h"
 
-DECLARE_JUMP(BC1F,  PCADDR + (iimmediate+1)*4, (FCR31 & 0x800000)==0, &reg[0], 0, 1)
-DECLARE_JUMP(BC1T,  PCADDR + (iimmediate+1)*4, (FCR31 & 0x800000)!=0, &reg[0], 0, 1)
-DECLARE_JUMP(BC1FL, PCADDR + (iimmediate+1)*4, (FCR31 & 0x800000)==0, &reg[0], 1, 1)
-DECLARE_JUMP(BC1TL, PCADDR + (iimmediate+1)*4, (FCR31 & 0x800000)!=0, &reg[0], 1, 1)
+DECLARE_JUMP(BC1F,  PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)==0, &reg[0], 0, 1)
+DECLARE_JUMP(BC1T,  PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)!=0, &reg[0], 0, 1)
+DECLARE_JUMP(BC1FL, PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)==0, &reg[0], 1, 1)
+DECLARE_JUMP(BC1TL, PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)!=0, &reg[0], 1, 1)
 
 DECLARE_INSTRUCTION(MFC1)
 {
    if (check_cop1_unusable()) return;
-   rrt32 = *((int*)reg_cop1_simple[rfs]);
+   rrt32 = *((int32_t*) reg_cop1_simple[rfs]);
    sign_extended(rrt);
    ADD_TO_PC(1);
 }
@@ -37,7 +37,7 @@ DECLARE_INSTRUCTION(MFC1)
 DECLARE_INSTRUCTION(DMFC1)
 {
    if (check_cop1_unusable()) return;
-   rrt = *((long long*)reg_cop1_double[rfs]);
+   rrt = *((int64_t*) reg_cop1_double[rfs]);
    ADD_TO_PC(1);
 }
 
@@ -60,14 +60,14 @@ DECLARE_INSTRUCTION(CFC1)
 DECLARE_INSTRUCTION(MTC1)
 {
    if (check_cop1_unusable()) return;
-   *((int*)reg_cop1_simple[rfs]) = rrt32;
+   *((int32_t*) reg_cop1_simple[rfs]) = rrt32;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DMTC1)
 {
    if (check_cop1_unusable()) return;
-   *((long long*)reg_cop1_double[rfs]) = rrt;
+   *((int64_t*) reg_cop1_double[rfs]) = rrt;
    ADD_TO_PC(1);
 }
 
@@ -121,7 +121,7 @@ DECLARE_INSTRUCTION(MUL_D)
 DECLARE_INSTRUCTION(DIV_D)
 {
    if (check_cop1_unusable()) return;
-   if((FCR31 & 0x400) && *reg_cop1_double[cfft] == 0)
+   if((FCR31 & UINT32_C(0x400)) && *reg_cop1_double[cfft] == 0)
    {
       //FCR31 |= 0x8020;
       /*FCR31 |= 0x8000;
@@ -165,56 +165,56 @@ DECLARE_INSTRUCTION(NEG_D)
 DECLARE_INSTRUCTION(ROUND_L_D)
 {
    if (check_cop1_unusable()) return;
-   round_l_d(reg_cop1_double[cffs], (long long*)(reg_cop1_double[cffd]));
+   round_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_L_D)
 {
    if (check_cop1_unusable()) return;
-   trunc_l_d(reg_cop1_double[cffs], (long long*)(reg_cop1_double[cffd]));
+   trunc_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_L_D)
 {
    if (check_cop1_unusable()) return;
-   ceil_l_d(reg_cop1_double[cffs], (long long*)(reg_cop1_double[cffd]));
+   ceil_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_L_D)
 {
    if (check_cop1_unusable()) return;
-   floor_l_d(reg_cop1_double[cffs], (long long*)(reg_cop1_double[cffd]));
+   floor_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_W_D)
 {
    if (check_cop1_unusable()) return;
-   round_w_d(reg_cop1_double[cffs], (int*)reg_cop1_simple[cffd]);
+   round_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_W_D)
 {
    if (check_cop1_unusable()) return;
-   trunc_w_d(reg_cop1_double[cffs], (int*)reg_cop1_simple[cffd]);
+   trunc_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_W_D)
 {
    if (check_cop1_unusable()) return;
-   ceil_w_d(reg_cop1_double[cffs], (int*)reg_cop1_simple[cffd]);
+   ceil_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_W_D)
 {
    if (check_cop1_unusable()) return;
-   floor_w_d(reg_cop1_double[cffs], (int*)reg_cop1_simple[cffd]);
+   floor_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
@@ -228,14 +228,14 @@ DECLARE_INSTRUCTION(CVT_S_D)
 DECLARE_INSTRUCTION(CVT_W_D)
 {
    if (check_cop1_unusable()) return;
-   cvt_w_d(reg_cop1_double[cffs], (int*)reg_cop1_simple[cffd]);
+   cvt_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_L_D)
 {
    if (check_cop1_unusable()) return;
-   cvt_l_d(reg_cop1_double[cffs], (long long*)(reg_cop1_double[cffd]));
+   cvt_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
@@ -391,14 +391,14 @@ DECLARE_INSTRUCTION(C_NGT_D)
 DECLARE_INSTRUCTION(CVT_S_L)
 {
    if (check_cop1_unusable()) return;
-   cvt_s_l((long long*)(reg_cop1_double[cffs]), reg_cop1_simple[cffd]);
+   cvt_s_l((int64_t*) reg_cop1_double[cffs], reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_D_L)
 {
    if (check_cop1_unusable()) return;
-   cvt_d_l((long long*)(reg_cop1_double[cffs]), reg_cop1_double[cffd]);
+   cvt_d_l((int64_t*) reg_cop1_double[cffs], reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
@@ -427,7 +427,7 @@ DECLARE_INSTRUCTION(MUL_S)
 DECLARE_INSTRUCTION(DIV_S)
 {  
    if (check_cop1_unusable()) return;
-   if((FCR31 & 0x400) && *reg_cop1_simple[cfft] == 0)
+   if((FCR31 & UINT32_C(0x400)) && *reg_cop1_simple[cfft] == 0)
    {
      DebugMessage(M64MSG_ERROR, "DIV_S by 0");
    }
@@ -466,56 +466,56 @@ DECLARE_INSTRUCTION(NEG_S)
 DECLARE_INSTRUCTION(ROUND_L_S)
 {
    if (check_cop1_unusable()) return;
-   round_l_s(reg_cop1_simple[cffs], (long long*)(reg_cop1_double[cffd]));
+   round_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_L_S)
 {
    if (check_cop1_unusable()) return;
-   trunc_l_s(reg_cop1_simple[cffs], (long long*)(reg_cop1_double[cffd]));
+   trunc_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_L_S)
 {
    if (check_cop1_unusable()) return;
-   ceil_l_s(reg_cop1_simple[cffs], (long long*)(reg_cop1_double[cffd]));
+   ceil_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_L_S)
 {
    if (check_cop1_unusable()) return;
-   floor_l_s(reg_cop1_simple[cffs], (long long*)(reg_cop1_double[cffd]));
+   floor_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_W_S)
 {
    if (check_cop1_unusable()) return;
-   round_w_s(reg_cop1_simple[cffs], (int*)reg_cop1_simple[cffd]);
+   round_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_W_S)
 {
    if (check_cop1_unusable()) return;
-   trunc_w_s(reg_cop1_simple[cffs], (int*)reg_cop1_simple[cffd]);
+   trunc_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_W_S)
 {
    if (check_cop1_unusable()) return;
-   ceil_w_s(reg_cop1_simple[cffs], (int*)reg_cop1_simple[cffd]);
+   ceil_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_W_S)
 {
    if (check_cop1_unusable()) return;
-   floor_w_s(reg_cop1_simple[cffs], (int*)reg_cop1_simple[cffd]);
+   floor_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
@@ -529,14 +529,14 @@ DECLARE_INSTRUCTION(CVT_D_S)
 DECLARE_INSTRUCTION(CVT_W_S)
 {
    if (check_cop1_unusable()) return;
-   cvt_w_s(reg_cop1_simple[cffs], (int*)reg_cop1_simple[cffd]);
+   cvt_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_L_S)
 {
    if (check_cop1_unusable()) return;
-   cvt_l_s(reg_cop1_simple[cffs], (long long*)(reg_cop1_double[cffd]));
+   cvt_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }
 
@@ -696,13 +696,13 @@ DECLARE_INSTRUCTION(C_NGT_S)
 DECLARE_INSTRUCTION(CVT_S_W)
 {  
    if (check_cop1_unusable()) return;
-   cvt_s_w((int*)reg_cop1_simple[cffs], reg_cop1_simple[cffd]);
+   cvt_s_w((int32_t*) reg_cop1_simple[cffs], reg_cop1_simple[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_D_W)
 {
    if (check_cop1_unusable()) return;
-   cvt_d_w((int*)reg_cop1_simple[cffs], reg_cop1_double[cffd]);
+   cvt_d_w((int32_t*) reg_cop1_simple[cffs], reg_cop1_double[cffd]);
    ADD_TO_PC(1);
 }

--- a/src/r4300/interpreter_cop1.def
+++ b/src/r4300/interpreter_cop1.def
@@ -29,8 +29,7 @@ DECLARE_JUMP(BC1TL, PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)!=0, &reg[
 DECLARE_INSTRUCTION(MFC1)
 {
    if (check_cop1_unusable()) return;
-   rrt32 = *((int32_t*) reg_cop1_simple[rfs]);
-   sign_extended(rrt);
+   rrt = SE32(*((int32_t*) reg_cop1_simple[rfs]));
    ADD_TO_PC(1);
 }
 
@@ -46,13 +45,11 @@ DECLARE_INSTRUCTION(CFC1)
    if (check_cop1_unusable()) return;
    if (rfs==31)
    {
-      rrt32 = FCR31;
-      sign_extended(rrt);
+      rrt32 = SE32(FCR31);
    }
    if (rfs==0)
    {
-      rrt32 = FCR0;
-      sign_extended(rrt);
+      rrt32 = SE32(FCR0);
    }
    ADD_TO_PC(1);
 }

--- a/src/r4300/interpreter_r4300.def
+++ b/src/r4300/interpreter_r4300.def
@@ -102,61 +102,61 @@ DECLARE_INSTRUCTION(DADDIU)
 
 DECLARE_INSTRUCTION(LDL)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
-   unsigned long long int word = 0;
+   uint64_t word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 7)
      {
       case 0:
-    address = (unsigned int) lsaddr;
-    rdword = (unsigned long long *) lsrtp;
+    address = lsaddr;
+    rdword = (uint64_t*) lsrtp;
     read_dword_in_memory();
     break;
       case 1:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFF)) | (word << 8);
     break;
       case 2:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFF)) | (word << 16);
     break;
       case 3:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFF)) | (word << 24);
     break;
       case 4:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFF)) | (word << 32);
     break;
       case 5:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFF)) | (word << 40);
     break;
       case 6:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFF)) | (word << 48);
     break;
       case 7:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
@@ -167,64 +167,64 @@ DECLARE_INSTRUCTION(LDL)
 
 DECLARE_INSTRUCTION(LDR)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
-   unsigned long long int word = 0;
+   uint64_t word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 7)
      {
       case 0:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFFFF00)) | (word >> 56);
     break;
       case 1:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFF0000)) | (word >> 48);
     break;
       case 2:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFF000000)) | (word >> 40);
     break;
       case 3:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFF00000000)) | (word >> 32);
     break;
       case 4:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFF0000000000)) | (word >> 24);
     break;
       case 5:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFF000000000000)) | (word >> 16);
     break;
       case 6:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFF00000000000000)) | (word >> 8);
     break;
       case 7:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
-    rdword = (unsigned long long *) lsrtp;
+    address = lsaddr & 0xFFFFFFF8;
+    rdword = (uint64_t*) lsrtp;
     read_dword_in_memory();
     break;
      }
@@ -232,11 +232,11 @@ DECLARE_INSTRUCTION(LDR)
 
 DECLARE_INSTRUCTION(LB)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   rdword = (unsigned long long *) lsrtp;
+   address = lsaddr;
+   rdword = (uint64_t*) lsrtp;
    read_byte_in_memory();
    if (address)
      sign_extendedb(*lsrtp);
@@ -244,11 +244,11 @@ DECLARE_INSTRUCTION(LB)
 
 DECLARE_INSTRUCTION(LH)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   rdword = (unsigned long long *) lsrtp;
+   address = lsaddr;
+   rdword = (uint64_t*) lsrtp;
    read_hword_in_memory();
    if (address)
      sign_extendedh(*lsrtp);
@@ -256,33 +256,33 @@ DECLARE_INSTRUCTION(LH)
 
 DECLARE_INSTRUCTION(LWL)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
-   unsigned long long int word = 0;
+   uint64_t word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 3)
      {
       case 0:
-    address = (unsigned int) lsaddr;
-    rdword = (unsigned long long *) lsrtp;
+    address = lsaddr;
+    rdword = (uint64_t*) lsrtp;
     read_word_in_memory();
     break;
       case 1:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFF)) | (word << 8);
     break;
       case 2:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFF)) | (word << 16);
     break;
       case 3:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
@@ -295,11 +295,11 @@ DECLARE_INSTRUCTION(LWL)
 
 DECLARE_INSTRUCTION(LW)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   rdword = (unsigned long long *) lsrtp;
+   address = lsaddr;
+   rdword = (uint64_t*) lsrtp;
    read_word_in_memory();
    if (address)
      sign_extended(*lsrtp);
@@ -307,56 +307,56 @@ DECLARE_INSTRUCTION(LW)
 
 DECLARE_INSTRUCTION(LBU)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   rdword = (unsigned long long *) lsrtp;
+   address = lsaddr;
+   rdword = (uint64_t*) lsrtp;
    read_byte_in_memory();
 }
 
 DECLARE_INSTRUCTION(LHU)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   rdword = (unsigned long long *) lsrtp;
+   address = lsaddr;
+   rdword = (uint64_t*) lsrtp;
    read_hword_in_memory();
 }
 
 DECLARE_INSTRUCTION(LWR)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
-   unsigned long long int word = 0;
+   uint64_t word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 3)
      {
       case 0:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFFFF00)) | ((word >> 24) & INT64_C(0xFF));
     break;
       case 1:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFF0000)) | ((word >> 16) & INT64_C(0xFFFF));
     break;
       case 2:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
       *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFF000000)) | ((word >> 8) & INT64_C(0xFFFFFF));
     break;
       case 3:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
-    rdword = (unsigned long long *) lsrtp;
+    address = lsaddr & 0xFFFFFFFC;
+    rdword = (uint64_t*) lsrtp;
     read_word_in_memory();
     if(address)
       sign_extended(*lsrtp);
@@ -365,75 +365,75 @@ DECLARE_INSTRUCTION(LWR)
 
 DECLARE_INSTRUCTION(LWU)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   rdword = (unsigned long long *) lsrtp;
+   address = lsaddr;
+   rdword = (uint64_t*) lsrtp;
    read_word_in_memory();
 }
 
 DECLARE_INSTRUCTION(SB)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   cpu_byte = (unsigned char)(*lsrtp & 0xFF);
+   address = lsaddr;
+   cpu_byte = (uint8_t) *lsrtp;
    write_byte_in_memory();
    CHECK_MEMORY();
 }
 
 DECLARE_INSTRUCTION(SH)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   cpu_hword = (unsigned short)(*lsrtp & 0xFFFF);
+   address = lsaddr;
+   cpu_hword = (uint16_t) *lsrtp;
    write_hword_in_memory();
    CHECK_MEMORY();
 }
 
 DECLARE_INSTRUCTION(SWL)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
-   unsigned long long int old_word = 0;
+   uint64_t old_word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 3)
      {
       case 0:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
-    cpu_word = (unsigned int)*lsrtp;
+    address = lsaddr & 0xFFFFFFFC;
+    cpu_word = (uint32_t) *lsrtp;
     write_word_in_memory();
     CHECK_MEMORY();
     break;
       case 1:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &old_word;
     read_word_in_memory();
     if(address)
       {
-         cpu_word = ((unsigned int)*lsrtp >> 8) | ((unsigned int) old_word & 0xFF000000);
+         cpu_word = ((uint32_t) *lsrtp >> 8) | ((uint32_t) old_word & UINT32_C(0xFF000000));
          write_word_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 2:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &old_word;
     read_word_in_memory();
     if(address)
       {
-         cpu_word = ((unsigned int)*lsrtp >> 16) | ((unsigned int) old_word & 0xFFFF0000);
+         cpu_word = ((uint32_t) *lsrtp >> 16) | ((uint32_t) old_word & UINT32_C(0xFFFF0000));
          write_word_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 3:
-    address = (unsigned int) lsaddr;
-    cpu_byte = (unsigned char)(*lsrtp >> 24);
+    address = lsaddr;
+    cpu_byte = (uint8_t) (*lsrtp >> 24);
     write_byte_in_memory();
     CHECK_MEMORY();
     break;
@@ -442,102 +442,102 @@ DECLARE_INSTRUCTION(SWL)
 
 DECLARE_INSTRUCTION(SW)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   cpu_word = (unsigned int)(*lsrtp & 0xFFFFFFFF);
+   address = lsaddr;
+   cpu_word = (uint32_t) *lsrtp;
    write_word_in_memory();
    CHECK_MEMORY();
 }
 
 DECLARE_INSTRUCTION(SDL)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
-   unsigned long long int old_word = 0;
+   uint64_t old_word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 7)
      {
       case 0:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     cpu_dword = *lsrtp;
     write_dword_in_memory();
     CHECK_MEMORY();
     break;
       case 1:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = ((unsigned long long)*lsrtp >> 8)|(old_word & 0xFF00000000000000LL);
+         cpu_dword = ((uint64_t) *lsrtp >> 8) | (old_word & INT64_C(0xFF00000000000000));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 2:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = ((unsigned long long)*lsrtp >> 16)|(old_word & 0xFFFF000000000000LL);
+         cpu_dword = ((uint64_t) *lsrtp >> 16) | (old_word & INT64_C(0xFFFF000000000000));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 3:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = ((unsigned long long)*lsrtp >> 24)|(old_word & 0xFFFFFF0000000000LL);
+         cpu_dword = ((uint64_t) *lsrtp >> 24) | (old_word & INT64_C(0xFFFFFF0000000000));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 4:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = ((unsigned long long)*lsrtp >> 32)|(old_word & 0xFFFFFFFF00000000LL);
+         cpu_dword = ((uint64_t) *lsrtp >> 32) | (old_word & INT64_C(0xFFFFFFFF00000000));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 5:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = ((unsigned long long)*lsrtp >> 40)|(old_word & 0xFFFFFFFFFF000000LL);
+         cpu_dword = ((uint64_t) *lsrtp >> 40) | (old_word & INT64_C(0xFFFFFFFFFF000000));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 6:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = ((unsigned long long)*lsrtp >> 48)|(old_word & 0xFFFFFFFFFFFF0000LL);
+         cpu_dword = ((uint64_t) *lsrtp >> 48) | (old_word & INT64_C(0xFFFFFFFFFFFF0000));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 7:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = ((unsigned long long)*lsrtp >> 56)|(old_word & 0xFFFFFFFFFFFFFF00LL);
+         cpu_dword = ((uint64_t) *lsrtp >> 56) | (old_word & INT64_C(0xFFFFFFFFFFFFFF00));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
@@ -547,91 +547,91 @@ DECLARE_INSTRUCTION(SDL)
 
 DECLARE_INSTRUCTION(SDR)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
-   unsigned long long int old_word = 0;
+   uint64_t old_word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 7)
      {
       case 0:
-    address = (unsigned int) lsaddr;
+    address = lsaddr;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = (*lsrtp << 56) | (old_word & 0x00FFFFFFFFFFFFFFLL);
+         cpu_dword = (*lsrtp << 56) | (old_word & INT64_C(0x00FFFFFFFFFFFFFF));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 1:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = (*lsrtp << 48) | (old_word & 0x0000FFFFFFFFFFFFLL);
+         cpu_dword = (*lsrtp << 48) | (old_word & INT64_C(0x0000FFFFFFFFFFFF));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 2:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = (*lsrtp << 40) | (old_word & 0x000000FFFFFFFFFFLL);
+         cpu_dword = (*lsrtp << 40) | (old_word & INT64_C(0x000000FFFFFFFFFF));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 3:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = (*lsrtp << 32) | (old_word & 0x00000000FFFFFFFFLL);
+         cpu_dword = (*lsrtp << 32) | (old_word & INT64_C(0x00000000FFFFFFFF));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 4:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = (*lsrtp << 24) | (old_word & 0x0000000000FFFFFFLL);
+         cpu_dword = (*lsrtp << 24) | (old_word & INT64_C(0x0000000000FFFFFF));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 5:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = (*lsrtp << 16) | (old_word & 0x000000000000FFFFLL);
+         cpu_dword = (*lsrtp << 16) | (old_word & INT64_C(0x000000000000FFFF));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 6:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     rdword = &old_word;
     read_dword_in_memory();
     if(address)
       {
-         cpu_dword = (*lsrtp << 8) | (old_word & 0x00000000000000FFLL);
+         cpu_dword = (*lsrtp << 8) | (old_word & INT64_C(0x00000000000000FF));
          write_dword_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 7:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
+    address = lsaddr & 0xFFFFFFF8;
     cpu_dword = *lsrtp;
     write_dword_in_memory();
     CHECK_MEMORY();
@@ -641,48 +641,48 @@ DECLARE_INSTRUCTION(SDR)
 
 DECLARE_INSTRUCTION(SWR)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
-   unsigned long long int old_word = 0;
+   uint64_t old_word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 3)
      {
       case 0:
-    address = (unsigned int) lsaddr;
+    address = lsaddr;
     rdword = &old_word;
     read_word_in_memory();
     if(address)
       {
-         cpu_word = ((unsigned int)*lsrtp << 24) | ((unsigned int) old_word & 0x00FFFFFF);
+         cpu_word = ((uint32_t) *lsrtp << 24) | ((uint32_t) old_word & UINT32_C(0x00FFFFFF));
          write_word_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 1:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &old_word;
     read_word_in_memory();
     if(address)
       {
-         cpu_word = ((unsigned int)*lsrtp << 16) | ((unsigned int) old_word & 0x0000FFFF);
+         cpu_word = ((uint32_t) *lsrtp << 16) | ((uint32_t) old_word & UINT32_C(0x0000FFFF));
          write_word_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 2:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
+    address = lsaddr & 0xFFFFFFFC;
     rdword = &old_word;
     read_word_in_memory();
     if(address)
       {
-         cpu_word = ((unsigned int)*lsrtp << 8) | ((unsigned int) old_word & 0x000000FF);
+         cpu_word = ((uint32_t) *lsrtp << 8) | ((uint32_t) old_word & UINT32_C(0x000000FF));
          write_word_in_memory();
          CHECK_MEMORY();
       }
     break;
       case 3:
-    address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
-    cpu_word = (unsigned int)*lsrtp;
+    address = lsaddr & 0xFFFFFFFC;
+    cpu_word = (uint32_t) *lsrtp;
     write_word_in_memory();
     CHECK_MEMORY();
     break;
@@ -696,11 +696,11 @@ DECLARE_INSTRUCTION(CACHE)
 
 DECLARE_INSTRUCTION(LL)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   rdword = (unsigned long long *) lsrtp;
+   address = lsaddr;
+   rdword = (uint64_t*) lsrtp;
    read_word_in_memory();
    if (address)
      {
@@ -712,11 +712,11 @@ DECLARE_INSTRUCTION(LL)
 DECLARE_INSTRUCTION(LWC1)
 {
    const unsigned char lslfft = lfft;
-   const unsigned int lslfaddr = (unsigned int)(lfoffset + reg[lfbase]);
-   unsigned long long int temp;
+   const uint32_t lslfaddr = (uint32_t) reg[lfbase] + lfoffset;
+   uint64_t temp;
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
-   address = (unsigned int) lslfaddr;
+   address = lslfaddr;
    rdword = &temp;
    read_word_in_memory();
    if (address)
@@ -726,33 +726,33 @@ DECLARE_INSTRUCTION(LWC1)
 DECLARE_INSTRUCTION(LDC1)
 {
    const unsigned char lslfft = lfft;
-   const unsigned int lslfaddr = (unsigned int)(lfoffset + reg[lfbase]);
+   const uint32_t lslfaddr = (uint32_t) reg[lfbase] + lfoffset;
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
-   address = (unsigned int) lslfaddr;
-   rdword = (unsigned long long *)reg_cop1_double[lslfft];
+   address = lslfaddr;
+   rdword = (uint64_t*) reg_cop1_double[lslfft];
    read_dword_in_memory();
 }
 
 DECLARE_INSTRUCTION(LD)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
-   rdword = (unsigned long long *) lsrtp;
+   address = lsaddr;
+   rdword = (uint64_t*) lsrtp;
    read_dword_in_memory();
 }
 
 DECLARE_INSTRUCTION(SC)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    if(llbit)
    {
-      address = (unsigned int) lsaddr;
-      cpu_word = (unsigned int)(*lsrtp & 0xFFFFFFFF);
+      address = lsaddr;
+      cpu_word = (uint32_t) *lsrtp;
       write_word_in_memory();
       CHECK_MEMORY();
       llbit = 0;
@@ -767,10 +767,10 @@ DECLARE_INSTRUCTION(SC)
 DECLARE_INSTRUCTION(SWC1)
 {
    const unsigned char lslfft = lfft;
-   const unsigned int lslfaddr = (unsigned int)(lfoffset + reg[lfbase]);
+   const uint32_t lslfaddr = (uint32_t) reg[lfbase] + lfoffset;
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
-   address = (unsigned int) lslfaddr;
+   address = lslfaddr;
    cpu_word = *((int*)reg_cop1_simple[lslfft]);
    write_word_in_memory();
    CHECK_MEMORY();
@@ -779,10 +779,10 @@ DECLARE_INSTRUCTION(SWC1)
 DECLARE_INSTRUCTION(SDC1)
 {
    const unsigned char lslfft = lfft;
-   const unsigned int lslfaddr = (unsigned int)(lfoffset + reg[lfbase]);
+   const uint32_t lslfaddr = (uint32_t) reg[lfbase] + lfoffset;
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
-   address = (unsigned int) lslfaddr;
+   address = lslfaddr;
    cpu_dword = *((unsigned long long*)reg_cop1_double[lslfft]);
    write_dword_in_memory();
    CHECK_MEMORY();
@@ -790,10 +790,10 @@ DECLARE_INSTRUCTION(SDC1)
 
 DECLARE_INSTRUCTION(SD)
 {
-   const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
+   const uint32_t lsaddr = irs32 + iimmediate;
    int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
-   address = (unsigned int) lsaddr;
+   address = lsaddr;
    cpu_dword = *lsrtp;
    write_dword_in_memory();
    CHECK_MEMORY();

--- a/src/r4300/interpreter_r4300.def
+++ b/src/r4300/interpreter_r4300.def
@@ -19,8 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-DECLARE_JUMP(J,   (jinst_index<<2) | ((PCADDR+4) & 0xF0000000), 1, &reg[0],  0, 0)
-DECLARE_JUMP(JAL, (jinst_index<<2) | ((PCADDR+4) & 0xF0000000), 1, &reg[31], 0, 0)
+DECLARE_JUMP(J,   (jinst_index<<2) | ((PCADDR+4) & UINT32_C(0xF0000000)), 1, &reg[0],  0, 0)
+DECLARE_JUMP(JAL, (jinst_index<<2) | ((PCADDR+4) & UINT32_C(0xF0000000)), 1, &reg[31], 0, 0)
 DECLARE_JUMP(BEQ,     PCADDR + (iimmediate+1)*4, irs == irt, &reg[0], 0, 0)
 DECLARE_JUMP(BNE,     PCADDR + (iimmediate+1)*4, irs != irt, &reg[0], 0, 0)
 DECLARE_JUMP(BLEZ,    PCADDR + (iimmediate+1)*4, irs <= 0,   &reg[0], 0, 0)

--- a/src/r4300/interpreter_r4300.def
+++ b/src/r4300/interpreter_r4300.def
@@ -28,15 +28,13 @@ DECLARE_JUMP(BGTZ,    PCADDR + (iimmediate+1)*4, irs > 0,    &reg[0], 0, 0)
 
 DECLARE_INSTRUCTION(ADDI)
 {
-   irt32 = irs32 + iimmediate;
-   sign_extended(irt);
+   irt = SE32(irs32 + iimmediate);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ADDIU)
 {
-   irt32 = irs32 + iimmediate;
-   sign_extended(irt);
+   irt = SE32(irs32 + iimmediate);
    ADD_TO_PC(1);
 }
 
@@ -75,8 +73,7 @@ DECLARE_INSTRUCTION(XORI)
 
 DECLARE_INSTRUCTION(LUI)
 {
-   irt32 = iimmediate << 16;
-   sign_extended(irt);
+   irt = SE32(iimmediate << 16);
    ADD_TO_PC(1);
 }
 
@@ -239,7 +236,7 @@ DECLARE_INSTRUCTION(LB)
    rdword = (uint64_t*) lsrtp;
    read_byte_in_memory();
    if (address)
-     sign_extendedb(*lsrtp);
+     *lsrtp = SE8(*lsrtp);
 }
 
 DECLARE_INSTRUCTION(LH)
@@ -251,7 +248,7 @@ DECLARE_INSTRUCTION(LH)
    rdword = (uint64_t*) lsrtp;
    read_hword_in_memory();
    if (address)
-     sign_extendedh(*lsrtp);
+     *lsrtp = SE16(*lsrtp);
 }
 
 DECLARE_INSTRUCTION(LWL)
@@ -290,7 +287,7 @@ DECLARE_INSTRUCTION(LWL)
     break;
      }
    if(address)
-     sign_extended(*lsrtp);
+     *lsrtp = SE32(*lsrtp);
 }
 
 DECLARE_INSTRUCTION(LW)
@@ -302,7 +299,7 @@ DECLARE_INSTRUCTION(LW)
    rdword = (uint64_t*) lsrtp;
    read_word_in_memory();
    if (address)
-     sign_extended(*lsrtp);
+     *lsrtp = SE32(*lsrtp);
 }
 
 DECLARE_INSTRUCTION(LBU)
@@ -359,7 +356,7 @@ DECLARE_INSTRUCTION(LWR)
     rdword = (uint64_t*) lsrtp;
     read_word_in_memory();
     if(address)
-      sign_extended(*lsrtp);
+      *lsrtp = SE32(*lsrtp);
      }
 }
 
@@ -704,7 +701,7 @@ DECLARE_INSTRUCTION(LL)
    read_word_in_memory();
    if (address)
      {
-    sign_extended(*lsrtp);
+    *lsrtp = SE32(*lsrtp);
     llbit = 1;
      }
 }

--- a/src/r4300/interpreter_r4300.def
+++ b/src/r4300/interpreter_r4300.def
@@ -57,19 +57,19 @@ DECLARE_INSTRUCTION(SLTIU)
 
 DECLARE_INSTRUCTION(ANDI)
 {
-   irt = irs & (unsigned short)iimmediate;
+   irt = irs & (uint16_t) iimmediate;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ORI)
 {
-   irt = irs | (unsigned short)iimmediate;
+   irt = irs | (uint16_t) iimmediate;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(XORI)
 {
-   irt = irs ^ (unsigned short)iimmediate;
+   irt = irs ^ (uint16_t) iimmediate;
    ADD_TO_PC(1);
 }
 

--- a/src/r4300/interpreter_r4300.def
+++ b/src/r4300/interpreter_r4300.def
@@ -49,7 +49,7 @@ DECLARE_INSTRUCTION(SLTI)
 
 DECLARE_INSTRUCTION(SLTIU)
 {
-   if ((unsigned long long)irs < (unsigned long long)((long long)iimmediate))
+   if ((uint64_t) irs < (uint64_t) ((int64_t) iimmediate))
      irt = 1;
    else irt = 0;
    ADD_TO_PC(1);
@@ -103,7 +103,7 @@ DECLARE_INSTRUCTION(DADDIU)
 DECLARE_INSTRUCTION(LDL)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    unsigned long long int word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 7)
@@ -118,49 +118,49 @@ DECLARE_INSTRUCTION(LDL)
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFF) | (word << 8);
+      *lsrtp = (*lsrtp & INT64_C(0xFF)) | (word << 8);
     break;
       case 2:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFF) | (word << 16);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFF)) | (word << 16);
     break;
       case 3:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFF) | (word << 24);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFF)) | (word << 24);
     break;
       case 4:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFF) | (word << 32);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFF)) | (word << 32);
     break;
       case 5:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFFLL) | (word << 40);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFF)) | (word << 40);
     break;
       case 6:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFFFFLL) | (word << 48);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFF)) | (word << 48);
     break;
       case 7:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFFFFFFLL) | (word << 56);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFFFF)) | (word << 56);
     break;
      }
 }
@@ -168,7 +168,7 @@ DECLARE_INSTRUCTION(LDL)
 DECLARE_INSTRUCTION(LDR)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    unsigned long long int word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 7)
@@ -178,49 +178,49 @@ DECLARE_INSTRUCTION(LDR)
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFFFFFF00LL) | (word >> 56);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFFFF00)) | (word >> 56);
     break;
       case 1:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFFFF0000LL) | (word >> 48);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFF0000)) | (word >> 48);
     break;
       case 2:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFF000000LL) | (word >> 40);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFF000000)) | (word >> 40);
     break;
       case 3:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFF00000000LL) | (word >> 32);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFF00000000)) | (word >> 32);
     break;
       case 4:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFF0000000000LL) | (word >> 24);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFF0000000000)) | (word >> 24);
     break;
       case 5:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFF000000000000LL) | (word >> 16);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFF000000000000)) | (word >> 16);
     break;
       case 6:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
     rdword = &word;
     read_dword_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFF00000000000000LL) | (word >> 8);
+      *lsrtp = (*lsrtp & INT64_C(0xFF00000000000000)) | (word >> 8);
     break;
       case 7:
     address = ((unsigned int) lsaddr) & 0xFFFFFFF8;
@@ -233,7 +233,7 @@ DECLARE_INSTRUCTION(LDR)
 DECLARE_INSTRUCTION(LB)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    rdword = (unsigned long long *) lsrtp;
@@ -245,7 +245,7 @@ DECLARE_INSTRUCTION(LB)
 DECLARE_INSTRUCTION(LH)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    rdword = (unsigned long long *) lsrtp;
@@ -257,7 +257,7 @@ DECLARE_INSTRUCTION(LH)
 DECLARE_INSTRUCTION(LWL)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    unsigned long long int word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 3)
@@ -272,21 +272,21 @@ DECLARE_INSTRUCTION(LWL)
     rdword = &word;
     read_word_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFF) | (word << 8);
+      *lsrtp = (*lsrtp & INT64_C(0xFF)) | (word << 8);
     break;
       case 2:
     address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFF) | (word << 16);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFF)) | (word << 16);
     break;
       case 3:
     address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFF) | (word << 24);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFF)) | (word << 24);
     break;
      }
    if(address)
@@ -296,7 +296,7 @@ DECLARE_INSTRUCTION(LWL)
 DECLARE_INSTRUCTION(LW)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    rdword = (unsigned long long *) lsrtp;
@@ -308,7 +308,7 @@ DECLARE_INSTRUCTION(LW)
 DECLARE_INSTRUCTION(LBU)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    rdword = (unsigned long long *) lsrtp;
@@ -318,7 +318,7 @@ DECLARE_INSTRUCTION(LBU)
 DECLARE_INSTRUCTION(LHU)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    rdword = (unsigned long long *) lsrtp;
@@ -328,7 +328,7 @@ DECLARE_INSTRUCTION(LHU)
 DECLARE_INSTRUCTION(LWR)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    unsigned long long int word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 3)
@@ -338,21 +338,21 @@ DECLARE_INSTRUCTION(LWR)
     rdword = &word;
     read_word_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFFFFFF00LL) | ((word >> 24) & 0xFF);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFFFF00)) | ((word >> 24) & INT64_C(0xFF));
     break;
       case 1:
     address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFFFF0000LL) | ((word >> 16) & 0xFFFF);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFFFF0000)) | ((word >> 16) & INT64_C(0xFFFF));
     break;
       case 2:
     address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
     rdword = &word;
     read_word_in_memory();
     if(address)
-      *lsrtp = (*lsrtp & 0xFFFFFFFFFF000000LL) | ((word >> 8) & 0XFFFFFF);
+      *lsrtp = (*lsrtp & INT64_C(0xFFFFFFFFFF000000)) | ((word >> 8) & INT64_C(0xFFFFFF));
     break;
       case 3:
     address = ((unsigned int) lsaddr) & 0xFFFFFFFC;
@@ -366,7 +366,7 @@ DECLARE_INSTRUCTION(LWR)
 DECLARE_INSTRUCTION(LWU)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    rdword = (unsigned long long *) lsrtp;
@@ -376,7 +376,7 @@ DECLARE_INSTRUCTION(LWU)
 DECLARE_INSTRUCTION(SB)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    cpu_byte = (unsigned char)(*lsrtp & 0xFF);
@@ -387,7 +387,7 @@ DECLARE_INSTRUCTION(SB)
 DECLARE_INSTRUCTION(SH)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    cpu_hword = (unsigned short)(*lsrtp & 0xFFFF);
@@ -398,7 +398,7 @@ DECLARE_INSTRUCTION(SH)
 DECLARE_INSTRUCTION(SWL)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    unsigned long long int old_word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 3)
@@ -443,7 +443,7 @@ DECLARE_INSTRUCTION(SWL)
 DECLARE_INSTRUCTION(SW)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    cpu_word = (unsigned int)(*lsrtp & 0xFFFFFFFF);
@@ -454,7 +454,7 @@ DECLARE_INSTRUCTION(SW)
 DECLARE_INSTRUCTION(SDL)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    unsigned long long int old_word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 7)
@@ -548,7 +548,7 @@ DECLARE_INSTRUCTION(SDL)
 DECLARE_INSTRUCTION(SDR)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    unsigned long long int old_word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 7)
@@ -642,7 +642,7 @@ DECLARE_INSTRUCTION(SDR)
 DECLARE_INSTRUCTION(SWR)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    unsigned long long int old_word = 0;
    ADD_TO_PC(1);
    switch ((lsaddr) & 3)
@@ -697,7 +697,7 @@ DECLARE_INSTRUCTION(CACHE)
 DECLARE_INSTRUCTION(LL)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    rdword = (unsigned long long *) lsrtp;
@@ -737,7 +737,7 @@ DECLARE_INSTRUCTION(LDC1)
 DECLARE_INSTRUCTION(LD)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    rdword = (unsigned long long *) lsrtp;
@@ -747,7 +747,7 @@ DECLARE_INSTRUCTION(LD)
 DECLARE_INSTRUCTION(SC)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    if(llbit)
    {
@@ -791,7 +791,7 @@ DECLARE_INSTRUCTION(SDC1)
 DECLARE_INSTRUCTION(SD)
 {
    const unsigned int lsaddr = (unsigned int)(iimmediate + irs32);
-   long long int *lsrtp = &irt;
+   int64_t *lsrtp = &irt;
    ADD_TO_PC(1);
    address = (unsigned int) lsaddr;
    cpu_dword = *lsrtp;

--- a/src/r4300/interpreter_special.def
+++ b/src/r4300/interpreter_special.def
@@ -26,42 +26,42 @@ DECLARE_INSTRUCTION(NOP)
 
 DECLARE_INSTRUCTION(SLL)
 {
-   rrd32 = (unsigned int)(rrt32) << rsa;
+   rrd32 = (uint32_t) rrt32 << rsa;
    sign_extended(rrd);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SRL)
 {
-   rrd32 = (unsigned int)rrt32 >> rsa;
+   rrd32 = (uint32_t) rrt32 >> rsa;
    sign_extended(rrd);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SRA)
 {
-   rrd32 = (signed int)rrt32 >> rsa;
+   rrd32 = (int32_t) rrt32 >> rsa;
    sign_extended(rrd);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SLLV)
 {
-   rrd32 = (unsigned int)(rrt32) << (rrs32&0x1F);
+   rrd32 = (uint32_t) rrt32 << (rrs32 & 0x1F);
    sign_extended(rrd);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SRLV)
 {
-   rrd32 = (unsigned int)rrt32 >> (rrs32 & 0x1F);
+   rrd32 = (uint32_t) rrt32 >> (rrs32 & 0x1F);
    sign_extended(rrd);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SRAV)
 {
-   rrd32 = (signed int)rrt32 >> (rrs32 & 0x1F);
+   rrd32 = (int32_t) rrt32 >> (rrs32 & 0x1F);
    sign_extended(rrd);
    ADD_TO_PC(1);
 }
@@ -106,25 +106,25 @@ DECLARE_INSTRUCTION(MTLO)
 
 DECLARE_INSTRUCTION(DSLLV)
 {
-   rrd = rrt << (rrs32&0x3F);
+   rrd = rrt << (rrs32 & 0x3F);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DSRLV)
 {
-   rrd = (unsigned long long)rrt >> (rrs32 & 0x3F);
+   rrd = (uint64_t) rrt >> (rrs32 & 0x3F);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DSRAV)
 {
-   rrd = (long long)rrt >> (rrs32 & 0x3F);
+   rrd = (int64_t) rrt >> (rrs32 & 0x3F);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MULT)
 {
-   long long int temp;
+   int64_t temp;
    temp = rrs * rrt;
    hi = temp >> 32;
    lo = temp;
@@ -134,9 +134,9 @@ DECLARE_INSTRUCTION(MULT)
 
 DECLARE_INSTRUCTION(MULTU)
 {
-   unsigned long long int temp;
-   temp = (unsigned int)rrs * (unsigned long long)((unsigned int)rrt);
-   hi = (long long)temp >> 32;
+   uint64_t temp;
+   temp = (uint32_t) rrs * (uint64_t) ((uint32_t) rrt);
+   hi = (int64_t) temp >> 32;
    lo = temp;
    sign_extended(lo);
    ADD_TO_PC(1);
@@ -159,8 +159,8 @@ DECLARE_INSTRUCTION(DIVU)
 {
    if (rrt32)
    {
-     lo = (unsigned int)rrs32 / (unsigned int)rrt32;
-     hi = (unsigned int)rrs32 % (unsigned int)rrt32;
+     lo = (uint32_t) rrs32 / (uint32_t) rrt32;
+     hi = (uint32_t) rrs32 % (uint32_t) rrt32;
      sign_extended(lo);
      sign_extended(hi);
    }
@@ -170,9 +170,9 @@ DECLARE_INSTRUCTION(DIVU)
 
 DECLARE_INSTRUCTION(DMULT)
 {
-   unsigned long long int op1, op2, op3, op4;
-   unsigned long long int result1, result2, result3, result4;
-   unsigned long long int temp1, temp2, temp3, temp4;
+   uint64_t op1, op2, op3, op4;
+   uint64_t result1, result2, result3, result4;
+   uint64_t temp1, temp2, temp3, temp4;
    int sign = 0;
    
    if (rrs < 0)
@@ -188,23 +188,23 @@ DECLARE_INSTRUCTION(DMULT)
      }
    else op4 = rrt;
    
-   op1 = op2 & 0xFFFFFFFF;
-   op2 = (op2 >> 32) & 0xFFFFFFFF;
-   op3 = op4 & 0xFFFFFFFF;
-   op4 = (op4 >> 32) & 0xFFFFFFFF;
+   op1 = op2 & UINT64_C(0xFFFFFFFF);
+   op2 = (op2 >> 32) & UINT64_C(0xFFFFFFFF);
+   op3 = op4 & UINT64_C(0xFFFFFFFF);
+   op4 = (op4 >> 32) & UINT64_C(0xFFFFFFFF);
    
    temp1 = op1 * op3;
    temp2 = (temp1 >> 32) + op1 * op4;
    temp3 = op2 * op3;
    temp4 = (temp3 >> 32) + op2 * op4;
    
-   result1 = temp1 & 0xFFFFFFFF;
-   result2 = temp2 + (temp3 & 0xFFFFFFFF);
+   result1 = temp1 & UINT64_C(0xFFFFFFFF);
+   result2 = temp2 + (temp3 & UINT64_C(0xFFFFFFFF));
    result3 = (result2 >> 32) + temp4;
    result4 = (result3 >> 32);
    
    lo = result1 | (result2 << 32);
-   hi = (result3 & 0xFFFFFFFF) | (result4 << 32);
+   hi = (result3 & UINT64_C(0xFFFFFFFF)) | (result4 << 32);
    if (sign)
      {
     hi = ~hi;
@@ -216,27 +216,27 @@ DECLARE_INSTRUCTION(DMULT)
 
 DECLARE_INSTRUCTION(DMULTU)
 {
-   unsigned long long int op1, op2, op3, op4;
-   unsigned long long int result1, result2, result3, result4;
-   unsigned long long int temp1, temp2, temp3, temp4;
+   uint64_t op1, op2, op3, op4;
+   uint64_t result1, result2, result3, result4;
+   uint64_t temp1, temp2, temp3, temp4;
    
-   op1 = rrs & 0xFFFFFFFF;
-   op2 = (rrs >> 32) & 0xFFFFFFFF;
-   op3 = rrt & 0xFFFFFFFF;
-   op4 = (rrt >> 32) & 0xFFFFFFFF;
+   op1 = rrs & UINT64_C(0xFFFFFFFF);
+   op2 = (rrs >> 32) & UINT64_C(0xFFFFFFFF);
+   op3 = rrt & UINT64_C(0xFFFFFFFF);
+   op4 = (rrt >> 32) & UINT64_C(0xFFFFFFFF);
    
    temp1 = op1 * op3;
    temp2 = (temp1 >> 32) + op1 * op4;
    temp3 = op2 * op3;
    temp4 = (temp3 >> 32) + op2 * op4;
    
-   result1 = temp1 & 0xFFFFFFFF;
-   result2 = temp2 + (temp3 & 0xFFFFFFFF);
+   result1 = temp1 & UINT64_C(0xFFFFFFFF);
+   result2 = temp2 + (temp3 & UINT64_C(0xFFFFFFFF));
    result3 = (result2 >> 32) + temp4;
    result4 = (result3 >> 32);
    
    lo = result1 | (result2 << 32);
-   hi = (result3 & 0xFFFFFFFF) | (result4 << 32);
+   hi = (result3 & UINT64_C(0xFFFFFFFF)) | (result4 << 32);
    
    ADD_TO_PC(1);
 }
@@ -245,8 +245,8 @@ DECLARE_INSTRUCTION(DDIV)
 {
    if (rrt)
    {
-     lo = (long long int)rrs / (long long int)rrt;
-     hi = (long long int)rrs % (long long int)rrt;
+     lo = rrs / rrt;
+     hi = rrs % rrt;
    }
    else DebugMessage(M64MSG_ERROR, "DDIV: divide by 0");
    ADD_TO_PC(1);
@@ -256,8 +256,8 @@ DECLARE_INSTRUCTION(DDIVU)
 {
    if (rrt)
    {
-     lo = (unsigned long long int)rrs / (unsigned long long int)rrt;
-     hi = (unsigned long long int)rrs % (unsigned long long int)rrt;
+     lo = (uint64_t) rrs / (uint64_t) rrt;
+     hi = (uint64_t) rrs % (uint64_t) rrt;
    }
    else DebugMessage(M64MSG_ERROR, "DDIVU: divide by 0");
    ADD_TO_PC(1);
@@ -324,7 +324,7 @@ DECLARE_INSTRUCTION(SLT)
 
 DECLARE_INSTRUCTION(SLTU)
 {
-   if ((unsigned long long)rrs < (unsigned long long)rrt) 
+   if ((uint64_t) rrs < (uint64_t) rrt)
      rrd = 1;
    else rrd = 0;
    ADD_TO_PC(1);
@@ -372,7 +372,7 @@ DECLARE_INSTRUCTION(DSLL)
 
 DECLARE_INSTRUCTION(DSRL)
 {
-   rrd = (unsigned long long)rrt >> rsa;
+   rrd = (uint64_t) rrt >> rsa;
    ADD_TO_PC(1);
 }
 
@@ -384,18 +384,18 @@ DECLARE_INSTRUCTION(DSRA)
 
 DECLARE_INSTRUCTION(DSLL32)
 {
-   rrd = rrt << (32+rsa);
+   rrd = rrt << (32 + rsa);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DSRL32)
 {
-   rrd = (unsigned long long int)rrt >> (32+rsa);
+   rrd = (uint64_t) rrt >> (32 + rsa);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DSRA32)
 {
-   rrd = (signed long long int)rrt >> (32+rsa);
+   rrd = (int64_t) rrt >> (32 + rsa);
    ADD_TO_PC(1);
 }

--- a/src/r4300/interpreter_special.def
+++ b/src/r4300/interpreter_special.def
@@ -71,7 +71,7 @@ DECLARE_JUMP(JALR, irs32, 1, &rrd,    0, 0)
 
 DECLARE_INSTRUCTION(SYSCALL)
 {
-   g_cp0_regs[CP0_CAUSE_REG] = 8 << 2;
+   g_cp0_regs[CP0_CAUSE_REG] = UINT32_C(8) << 2;
    exception_general();
 }
 

--- a/src/r4300/interpreter_special.def
+++ b/src/r4300/interpreter_special.def
@@ -26,43 +26,37 @@ DECLARE_INSTRUCTION(NOP)
 
 DECLARE_INSTRUCTION(SLL)
 {
-   rrd32 = (uint32_t) rrt32 << rsa;
-   sign_extended(rrd);
+   rrd = SE32((uint32_t) rrt32 << rsa);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SRL)
 {
-   rrd32 = (uint32_t) rrt32 >> rsa;
-   sign_extended(rrd);
+   rrd = SE32((uint32_t) rrt32 >> rsa);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SRA)
 {
-   rrd32 = (int32_t) rrt32 >> rsa;
-   sign_extended(rrd);
+   rrd = SE32((int32_t) rrt32 >> rsa);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SLLV)
 {
-   rrd32 = (uint32_t) rrt32 << (rrs32 & 0x1F);
-   sign_extended(rrd);
+   rrd = SE32((uint32_t) rrt32 << (rrs32 & 0x1F));
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SRLV)
 {
-   rrd32 = (uint32_t) rrt32 >> (rrs32 & 0x1F);
-   sign_extended(rrd);
+   rrd = SE32((uint32_t) rrt32 >> (rrs32 & 0x1F));
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SRAV)
 {
-   rrd32 = (int32_t) rrt32 >> (rrs32 & 0x1F);
-   sign_extended(rrd);
+   rrd = SE32((int32_t) rrt32 >> (rrs32 & 0x1F));
    ADD_TO_PC(1);
 }
 
@@ -127,8 +121,7 @@ DECLARE_INSTRUCTION(MULT)
    int64_t temp;
    temp = rrs * rrt;
    hi = temp >> 32;
-   lo = temp;
-   sign_extended(lo);
+   lo = SE32(temp);
    ADD_TO_PC(1);
 }
 
@@ -137,8 +130,7 @@ DECLARE_INSTRUCTION(MULTU)
    uint64_t temp;
    temp = (uint32_t) rrs * (uint64_t) ((uint32_t) rrt);
    hi = (int64_t) temp >> 32;
-   lo = temp;
-   sign_extended(lo);
+   lo = SE32(temp);
    ADD_TO_PC(1);
 }
 
@@ -146,10 +138,8 @@ DECLARE_INSTRUCTION(DIV)
 {
    if (rrt32)
    {
-     lo = rrs32 / rrt32;
-     hi = rrs32 % rrt32;
-     sign_extended(lo);
-     sign_extended(hi);
+     lo = SE32(rrs32 / rrt32);
+     hi = SE32(rrs32 % rrt32);
    }
    else DebugMessage(M64MSG_ERROR, "DIV: divide by 0");
    ADD_TO_PC(1);
@@ -159,10 +149,8 @@ DECLARE_INSTRUCTION(DIVU)
 {
    if (rrt32)
    {
-     lo = (uint32_t) rrs32 / (uint32_t) rrt32;
-     hi = (uint32_t) rrs32 % (uint32_t) rrt32;
-     sign_extended(lo);
-     sign_extended(hi);
+     lo = SE32((uint32_t) rrs32 / (uint32_t) rrt32);
+     hi = SE32((uint32_t) rrs32 % (uint32_t) rrt32);
    }
    else DebugMessage(M64MSG_ERROR, "DIVU: divide by 0");
    ADD_TO_PC(1);
@@ -265,29 +253,25 @@ DECLARE_INSTRUCTION(DDIVU)
 
 DECLARE_INSTRUCTION(ADD)
 {
-   rrd32 = rrs32 + rrt32;
-   sign_extended(rrd);
+   rrd = SE32(rrs32 + rrt32);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ADDU)
 {
-   rrd32 = rrs32 + rrt32;
-   sign_extended(rrd);
+   rrd = SE32(rrs32 + rrt32);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SUB)
 {
-   rrd32 = rrs32 - rrt32;
-   sign_extended(rrd);
+   rrd = SE32(rrs32 - rrt32);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SUBU)
 {
-   rrd32 = rrs32 - rrt32;
-   sign_extended(rrd);
+   rrd = SE32(rrs32 - rrt32);
    ADD_TO_PC(1);
 }
 

--- a/src/r4300/interpreter_tlb.def
+++ b/src/r4300/interpreter_tlb.def
@@ -24,7 +24,7 @@
 DECLARE_INSTRUCTION(TLBR)
 {
    int index;
-   index = g_cp0_regs[CP0_INDEX_REG] & 0x1F;
+   index = g_cp0_regs[CP0_INDEX_REG] & UINT32_C(0x1F);
    g_cp0_regs[CP0_PAGEMASK_REG] = tlb_e[index].mask << 13;
    g_cp0_regs[CP0_ENTRYHI_REG] = ((tlb_e[index].vpn2 << 13) | tlb_e[index].asid);
    g_cp0_regs[CP0_ENTRYLO0_REG] = (tlb_e[index].pfn_even << 6) | (tlb_e[index].c_even << 3)
@@ -108,28 +108,28 @@ static void TLBWrite(unsigned int idx)
    tlb_unmap(&tlb_e[idx]);
 
    tlb_e[idx].g = (g_cp0_regs[CP0_ENTRYLO0_REG] & g_cp0_regs[CP0_ENTRYLO1_REG] & 1);
-   tlb_e[idx].pfn_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & 0x3FFFFFC0) >> 6;
-   tlb_e[idx].pfn_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & 0x3FFFFFC0) >> 6;
-   tlb_e[idx].c_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & 0x38) >> 3;
-   tlb_e[idx].c_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & 0x38) >> 3;
-   tlb_e[idx].d_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & 0x4) >> 2;
-   tlb_e[idx].d_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & 0x4) >> 2;
-   tlb_e[idx].v_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & 0x2) >> 1;
-   tlb_e[idx].v_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & 0x2) >> 1;
-   tlb_e[idx].asid = (g_cp0_regs[CP0_ENTRYHI_REG] & 0xFF);
-   tlb_e[idx].vpn2 = (g_cp0_regs[CP0_ENTRYHI_REG] & 0xFFFFE000) >> 13;
+   tlb_e[idx].pfn_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x3FFFFFC0)) >> 6;
+   tlb_e[idx].pfn_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & UINT32_C(0x3FFFFFC0)) >> 6;
+   tlb_e[idx].c_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x38)) >> 3;
+   tlb_e[idx].c_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & UINT32_C(0x38)) >> 3;
+   tlb_e[idx].d_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x4)) >> 2;
+   tlb_e[idx].d_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & UINT32_C(0x4)) >> 2;
+   tlb_e[idx].v_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x2)) >> 1;
+   tlb_e[idx].v_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & UINT32_C(0x2)) >> 1;
+   tlb_e[idx].asid = (g_cp0_regs[CP0_ENTRYHI_REG] & UINT32_C(0xFF));
+   tlb_e[idx].vpn2 = (g_cp0_regs[CP0_ENTRYHI_REG] & UINT32_C(0xFFFFE000)) >> 13;
    //tlb_e[idx].r = (g_cp0_regs[CP0_ENTRYHI_REG] & 0xC000000000000000LL) >> 62;
-   tlb_e[idx].mask = (g_cp0_regs[CP0_PAGEMASK_REG] & 0x1FFE000) >> 13;
+   tlb_e[idx].mask = (g_cp0_regs[CP0_PAGEMASK_REG] & UINT32_C(0x1FFE000)) >> 13;
    
    tlb_e[idx].start_even = tlb_e[idx].vpn2 << 13;
    tlb_e[idx].end_even = tlb_e[idx].start_even+
-     (tlb_e[idx].mask << 12) + 0xFFF;
+     (tlb_e[idx].mask << 12) + UINT32_C(0xFFF);
    tlb_e[idx].phys_even = tlb_e[idx].pfn_even << 12;
    
 
    tlb_e[idx].start_odd = tlb_e[idx].end_even+1;
    tlb_e[idx].end_odd = tlb_e[idx].start_odd+
-     (tlb_e[idx].mask << 12) + 0xFFF;
+     (tlb_e[idx].mask << 12) + UINT32_C(0xFFF);
    tlb_e[idx].phys_odd = tlb_e[idx].pfn_odd << 12;
    
    tlb_map(&tlb_e[idx]);
@@ -199,7 +199,7 @@ static void TLBWrite(unsigned int idx)
 
 DECLARE_INSTRUCTION(TLBWI)
 {
-   TLBWrite(g_cp0_regs[CP0_INDEX_REG]&0x3F);
+   TLBWrite(g_cp0_regs[CP0_INDEX_REG] & UINT32_C(0x3F));
    ADD_TO_PC(1);
 }
 
@@ -215,13 +215,13 @@ DECLARE_INSTRUCTION(TLBWR)
 DECLARE_INSTRUCTION(TLBP)
 {
    int i;
-   g_cp0_regs[CP0_INDEX_REG] |= 0x80000000;
+   g_cp0_regs[CP0_INDEX_REG] |= UINT32_C(0x80000000);
    for (i=0; i<32; i++)
    {
       if (((tlb_e[i].vpn2 & (~tlb_e[i].mask)) ==
-         (((g_cp0_regs[CP0_ENTRYHI_REG] & 0xFFFFE000) >> 13) & (~tlb_e[i].mask))) &&
+         (((g_cp0_regs[CP0_ENTRYHI_REG] & UINT32_C(0xFFFFE000)) >> 13) & (~tlb_e[i].mask))) &&
         ((tlb_e[i].g) ||
-         (tlb_e[i].asid == (g_cp0_regs[CP0_ENTRYHI_REG] & 0xFF))))
+         (tlb_e[i].asid == (g_cp0_regs[CP0_ENTRYHI_REG] & UINT32_C(0xFF)))))
       {
          g_cp0_regs[CP0_INDEX_REG] = i;
          break;
@@ -233,14 +233,14 @@ DECLARE_INSTRUCTION(TLBP)
 DECLARE_INSTRUCTION(ERET)
 {
    update_count();
-   if (g_cp0_regs[CP0_STATUS_REG] & 0x4)
+   if (g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x4))
    {
      DebugMessage(M64MSG_ERROR, "error in ERET");
      stop=1;
    }
    else
    {
-     g_cp0_regs[CP0_STATUS_REG] &= ~0x2;
+     g_cp0_regs[CP0_STATUS_REG] &= ~UINT32_C(0x2);
      generic_jump_to(g_cp0_regs[CP0_EPC_REG]);
    }
    llbit = 0;

--- a/src/r4300/interupt.c
+++ b/src/r4300/interupt.c
@@ -41,7 +41,7 @@
 #include "si/si_controller.h"
 #include "vi/vi_controller.h"
 
-
+#include <stdint.h>
 #include <string.h>
 
 #include <SDL.h>
@@ -479,8 +479,8 @@ static void nmi_int_handler(void)
     delay_slot = 0;
     dyna_interp = 0;
     // set next instruction address to reset vector
-    last_addr = 0xa4000040;
-    generic_jump_to(0xa4000040);
+    last_addr = UINT32_C(0xa4000040);
+    generic_jump_to(UINT32_C(0xa4000040));
 }
 
 
@@ -510,7 +510,7 @@ void gen_interupt(void)
    
     if (skip_jump)
     {
-        unsigned int dest = skip_jump;
+        uint32_t dest = skip_jump;
         skip_jump = 0;
 
         next_interupt = (q.first->data.count > g_cp0_regs[CP0_COUNT_REG]

--- a/src/r4300/interupt.c
+++ b/src/r4300/interupt.c
@@ -131,16 +131,16 @@ static int SPECIAL_done = 0;
 
 static int before_event(unsigned int evt1, unsigned int evt2, int type2)
 {
-    if(evt1 - g_cp0_regs[CP0_COUNT_REG] < 0x80000000)
+    if(evt1 - g_cp0_regs[CP0_COUNT_REG] < UINT32_C(0x80000000))
     {
-        if(evt2 - g_cp0_regs[CP0_COUNT_REG] < 0x80000000)
+        if(evt2 - g_cp0_regs[CP0_COUNT_REG] < UINT32_C(0x80000000))
         {
             if((evt1 - g_cp0_regs[CP0_COUNT_REG]) < (evt2 - g_cp0_regs[CP0_COUNT_REG])) return 1;
             else return 0;
         }
         else
         {
-            if((g_cp0_regs[CP0_COUNT_REG] - evt2) < 0x10000000)
+            if((g_cp0_regs[CP0_COUNT_REG] - evt2) < UINT32_C(0x10000000))
             {
                 switch(type2)
                 {
@@ -171,7 +171,7 @@ void add_interupt_event_count(int type, unsigned int count)
 
     special = (type == SPECIAL_INT);
    
-    if(g_cp0_regs[CP0_COUNT_REG] > 0x80000000) SPECIAL_done = 0;
+    if(g_cp0_regs[CP0_COUNT_REG] > UINT32_C(0x80000000)) SPECIAL_done = 0;
    
     if (get_event(type)) {
         DebugMessage(M64MSG_WARNING, "two events of type 0x%x in interrupt queue", type);
@@ -237,7 +237,7 @@ static void remove_interupt_event(void)
 
     next_interupt = (q.first != NULL
          && (q.first->data.count > g_cp0_regs[CP0_COUNT_REG]
-         || (g_cp0_regs[CP0_COUNT_REG] - q.first->data.count) < 0x80000000))
+         || (g_cp0_regs[CP0_COUNT_REG] - q.first->data.count) < UINT32_C(0x80000000)))
         ? q.first->data.count
         : 0;
 }
@@ -354,11 +354,11 @@ void check_interupt(void)
     struct node* event;
 
     if (g_r4300.mi.regs[MI_INTR_REG] & g_r4300.mi.regs[MI_INTR_MASK_REG])
-        g_cp0_regs[CP0_CAUSE_REG] = (g_cp0_regs[CP0_CAUSE_REG] | 0x400) & 0xFFFFFF83;
+        g_cp0_regs[CP0_CAUSE_REG] = (g_cp0_regs[CP0_CAUSE_REG] | UINT32_C(0x400)) & UINT32_C(0xFFFFFF83);
     else
-        g_cp0_regs[CP0_CAUSE_REG] &= ~0x400;
-    if ((g_cp0_regs[CP0_STATUS_REG] & 7) != 1) return;
-    if (g_cp0_regs[CP0_STATUS_REG] & g_cp0_regs[CP0_CAUSE_REG] & 0xFF00)
+        g_cp0_regs[CP0_CAUSE_REG] &= ~UINT32_C(0x400);
+    if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(7)) != 1) return;
+    if (g_cp0_regs[CP0_STATUS_REG] & g_cp0_regs[CP0_CAUSE_REG] & UINT32_C(0xFF00))
     {
         event = alloc_node(&q.pool);
 
@@ -391,8 +391,8 @@ static void wrapped_exception_general(void)
     if (r4300emu == CORE_DYNAREC) {
         g_cp0_regs[CP0_EPC_REG] = pcaddr;
         pcaddr = 0x80000180;
-        g_cp0_regs[CP0_STATUS_REG] |= 2;
-        g_cp0_regs[CP0_CAUSE_REG] &= 0x7FFFFFFF;
+        g_cp0_regs[CP0_STATUS_REG] |= UINT32_C(2);
+        g_cp0_regs[CP0_CAUSE_REG] &= UINT32_C(0x7FFFFFFF);
         pending_exception=1;
     } else {
         exception_general();
@@ -404,12 +404,12 @@ static void wrapped_exception_general(void)
 
 void raise_maskable_interrupt(uint32_t cause)
 {
-    g_cp0_regs[CP0_CAUSE_REG] = (g_cp0_regs[CP0_CAUSE_REG] | cause) & 0xffffff83;
+    g_cp0_regs[CP0_CAUSE_REG] = (g_cp0_regs[CP0_CAUSE_REG] | cause) & UINT32_C(0xffffff83);
 
-    if (!(g_cp0_regs[CP0_STATUS_REG] & g_cp0_regs[CP0_CAUSE_REG] & 0xff00))
+    if (!(g_cp0_regs[CP0_STATUS_REG] & g_cp0_regs[CP0_CAUSE_REG] & UINT32_C(0xff00)))
         return;
 
-    if ((g_cp0_regs[CP0_STATUS_REG] & 7) != 1)
+    if ((g_cp0_regs[CP0_STATUS_REG] & UINT32_C(7)) != UINT32_C(1))
         return;
 
     wrapped_exception_general();
@@ -417,7 +417,7 @@ void raise_maskable_interrupt(uint32_t cause)
 
 static void special_int_handler(void)
 {
-    if (g_cp0_regs[CP0_COUNT_REG] > 0x10000000)
+    if (g_cp0_regs[CP0_COUNT_REG] > UINT32_C(0x10000000))
         return;
 
 
@@ -433,7 +433,7 @@ static void compare_int_handler(void)
     add_interupt_event_count(COMPARE_INT, g_cp0_regs[CP0_COMPARE_REG]);
     g_cp0_regs[CP0_COUNT_REG]-=count_per_op;
 
-    raise_maskable_interrupt(0x8000);
+    raise_maskable_interrupt(UINT32_C(0x8000));
 }
 
 static void hw2_int_handler(void)
@@ -441,8 +441,8 @@ static void hw2_int_handler(void)
     // Hardware Interrupt 2 -- remove interrupt event from queue
     remove_interupt_event();
 
-    g_cp0_regs[CP0_STATUS_REG] = (g_cp0_regs[CP0_STATUS_REG] & ~0x00380000) | 0x1000;
-    g_cp0_regs[CP0_CAUSE_REG] = (g_cp0_regs[CP0_CAUSE_REG] | 0x1000) & 0xffffff83;
+    g_cp0_regs[CP0_STATUS_REG] = (g_cp0_regs[CP0_STATUS_REG] & ~UINT32_C(0x00380000)) | UINT32_C(0x1000);
+    g_cp0_regs[CP0_CAUSE_REG] = (g_cp0_regs[CP0_CAUSE_REG] | UINT32_C(0x1000)) & UINT32_C(0xffffff83);
 
     wrapped_exception_general();
 }
@@ -452,7 +452,7 @@ static void nmi_int_handler(void)
     // Non Maskable Interrupt -- remove interrupt event from queue
     remove_interupt_event();
     // setup r4300 Status flags: reset TS and SR, set BEV, ERL, and SR
-    g_cp0_regs[CP0_STATUS_REG] = (g_cp0_regs[CP0_STATUS_REG] & ~0x00380000) | 0x00500004;
+    g_cp0_regs[CP0_STATUS_REG] = (g_cp0_regs[CP0_STATUS_REG] & ~UINT32_C(0x00380000)) | UINT32_C(0x00500004);
     g_cp0_regs[CP0_CAUSE_REG]  = 0x00000000;
     // simulate the soft reset code which would run from the PIF ROM
     r4300_reset_soft();
@@ -514,7 +514,7 @@ void gen_interupt(void)
         skip_jump = 0;
 
         next_interupt = (q.first->data.count > g_cp0_regs[CP0_COUNT_REG]
-                || (g_cp0_regs[CP0_COUNT_REG] - q.first->data.count) < 0x80000000)
+                || (g_cp0_regs[CP0_COUNT_REG] - q.first->data.count) < UINT32_C(0x80000000))
             ? q.first->data.count
             : 0;
 

--- a/src/r4300/macros.h
+++ b/src/r4300/macros.h
@@ -22,9 +22,9 @@
 #ifndef M64P_R4300_MACROS_H
 #define M64P_R4300_MACROS_H
 
-#define sign_extended(a) a = (long long)((int)a)
-#define sign_extendedb(a) a = (long long)((signed char)a)
-#define sign_extendedh(a) a = (long long)((short)a)
+#define sign_extended(a) a = (int64_t) ((int32_t) a)
+#define sign_extendedb(a) a = (int64_t) ((int8_t) a)
+#define sign_extendedh(a) a = (int64_t) ((int16_t) a)
 
 #define rrt *PC->f.r.rt
 #define rrd *PC->f.r.rd
@@ -46,17 +46,17 @@
 
 // 32 bits macros
 #ifndef M64P_BIG_ENDIAN
-#define rrt32 *((int*)PC->f.r.rt)
-#define rrd32 *((int*)PC->f.r.rd)
-#define rrs32 *((int*)PC->f.r.rs)
-#define irs32 *((int*)PC->f.i.rs)
-#define irt32 *((int*)PC->f.i.rt)
+#define rrt32 *((int32_t*) PC->f.r.rt)
+#define rrd32 *((int32_t*) PC->f.r.rd)
+#define rrs32 *((int32_t*) PC->f.r.rs)
+#define irs32 *((int32_t*) PC->f.i.rs)
+#define irt32 *((int32_t*) PC->f.i.rt)
 #else
-#define rrt32 *((int*)PC->f.r.rt+1)
-#define rrd32 *((int*)PC->f.r.rd+1)
-#define rrs32 *((int*)PC->f.r.rs+1)
-#define irs32 *((int*)PC->f.i.rs+1)
-#define irt32 *((int*)PC->f.i.rt+1)
+#define rrt32 *((int32_t*) PC->f.r.rt + 1)
+#define rrd32 *((int32_t*) PC->f.r.rd + 1)
+#define rrs32 *((int32_t*) PC->f.r.rs + 1)
+#define irs32 *((int32_t*) PC->f.i.rs + 1)
+#define irt32 *((int32_t*) PC->f.i.rt + 1)
 #endif
 
 #endif /* M64P_R4300_MACROS_H */

--- a/src/r4300/macros.h
+++ b/src/r4300/macros.h
@@ -22,9 +22,9 @@
 #ifndef M64P_R4300_MACROS_H
 #define M64P_R4300_MACROS_H
 
-#define sign_extended(a) a = (int64_t) ((int32_t) a)
-#define sign_extendedb(a) a = (int64_t) ((int8_t) a)
-#define sign_extendedh(a) a = (int64_t) ((int16_t) a)
+#define SE8(a) ((int64_t) ((int8_t) (a)))
+#define SE16(a) ((int64_t) ((int16_t) (a)))
+#define SE32(a) ((int64_t) ((int32_t) (a)))
 
 #define rrt *PC->f.r.rt
 #define rrd *PC->f.r.rd

--- a/src/r4300/pure_interp.c
+++ b/src/r4300/pure_interp.c
@@ -20,6 +20,8 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 #include "api/m64p_types.h"
 #include "api/callbacks.h"
@@ -170,8 +172,6 @@ static void InterpretOpcode(void);
 #endif
 
 #include "interpreter.def"
-#include <stdio.h>
-#include <inttypes.h>
 
 void InterpretOpcode()
 {

--- a/src/r4300/pure_interp.c
+++ b/src/r4300/pure_interp.c
@@ -91,7 +91,7 @@ static void InterpretOpcode(void);
       { \
          update_count(); \
          skip = next_interupt - g_cp0_regs[CP0_COUNT_REG]; \
-         if (skip > 3) g_cp0_regs[CP0_COUNT_REG] += (skip & 0xFFFFFFFC); \
+         if (skip > 3) g_cp0_regs[CP0_COUNT_REG] += (skip & UINT32_C(0xFFFFFFFC)); \
          else name(op); \
       } \
       else name(op); \

--- a/src/r4300/pure_interp.c
+++ b/src/r4300/pure_interp.c
@@ -55,7 +55,7 @@ static void InterpretOpcode(void);
    { \
       const int take_jump = (condition); \
       const unsigned int jump_target = (destination); \
-      long long int *link_register = (link); \
+      int64_t *link_register = (link); \
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \
       { \

--- a/src/r4300/pure_interp.c
+++ b/src/r4300/pure_interp.c
@@ -59,8 +59,7 @@ static void InterpretOpcode(void);
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \
       { \
-          *link_register=interp_PC.addr + 8; \
-          sign_extended(*link_register); \
+          *link_register = SE32(interp_PC.addr + 8); \
       } \
       if (!likely || take_jump) \
       { \
@@ -125,9 +124,9 @@ static void InterpretOpcode(void);
 	 && ((addr) & UINT32_C(0x0FFFFFFF)) != UINT32_C(0x0FFFFFFC) \
 	 && *fast_mem_access((addr) + 4) == 0)
 
-#define sign_extended(a) a = (int64_t) ((int32_t) (a))
-#define sign_extendedb(a) a = (int64_t) ((int8_t) (a))
-#define sign_extendedh(a) a = (int64_t) ((int16_t) (a))
+#define SE8(a) ((int64_t) ((int8_t) (a)))
+#define SE16(a) ((int64_t) ((int16_t) (a)))
+#define SE32(a) ((int64_t) ((int32_t) (a)))
 
 /* These macros are like those in macros.h, but they parse opcode fields. */
 #define rrt reg[RT_OF(op)]

--- a/src/r4300/pure_interp.c
+++ b/src/r4300/pure_interp.c
@@ -54,7 +54,7 @@ static void InterpretOpcode(void);
    static void name(uint32_t op) \
    { \
       const int take_jump = (condition); \
-      const unsigned int jump_target = (destination); \
+      const uint32_t jump_target = (destination); \
       int64_t *link_register = (link); \
       if (cop1 && check_cop1_unusable()) return; \
       if (link_register != &reg[0]) \

--- a/src/r4300/r4300.c
+++ b/src/r4300/r4300.c
@@ -63,7 +63,7 @@ int llbit, rompause;
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
 int stop;
 int64_t reg[32], hi, lo;
-unsigned int next_interupt;
+uint32_t next_interupt;
 precomp_instr *PC;
 #endif
 long long int local_rs;
@@ -137,17 +137,17 @@ void r4300_reset_hard(void)
     FCR31=0;
 
     // set COP0 registers
-    g_cp0_regs[CP0_RANDOM_REG] = 31;
-    g_cp0_regs[CP0_STATUS_REG]= 0x34000000;
+    g_cp0_regs[CP0_RANDOM_REG] = UINT32_C(31);
+    g_cp0_regs[CP0_STATUS_REG]= UINT32_C(0x34000000);
     set_fpr_pointers(g_cp0_regs[CP0_STATUS_REG]);
-    g_cp0_regs[CP0_CONFIG_REG]= 0x6e463;
-    g_cp0_regs[CP0_PREVID_REG] = 0xb00;
-    g_cp0_regs[CP0_COUNT_REG] = 0x5000;
-    g_cp0_regs[CP0_CAUSE_REG] = 0x5C;
-    g_cp0_regs[CP0_CONTEXT_REG] = 0x7FFFF0;
-    g_cp0_regs[CP0_EPC_REG] = 0xFFFFFFFF;
-    g_cp0_regs[CP0_BADVADDR_REG] = 0xFFFFFFFF;
-    g_cp0_regs[CP0_ERROREPC_REG] = 0xFFFFFFFF;
+    g_cp0_regs[CP0_CONFIG_REG]= UINT32_C(0x6e463);
+    g_cp0_regs[CP0_PREVID_REG] = UINT32_C(0xb00);
+    g_cp0_regs[CP0_COUNT_REG] = UINT32_C(0x5000);
+    g_cp0_regs[CP0_CAUSE_REG] = UINT32_C(0x5C);
+    g_cp0_regs[CP0_CONTEXT_REG] = UINT32_C(0x7FFFF0);
+    g_cp0_regs[CP0_EPC_REG] = UINT32_C(0xFFFFFFFF);
+    g_cp0_regs[CP0_BADVADDR_REG] = UINT32_C(0xFFFFFFFF);
+    g_cp0_regs[CP0_ERROREPC_REG] = UINT32_C(0xFFFFFFFF);
    
     rounding_mode = 0x33F;
 }

--- a/src/r4300/r4300.c
+++ b/src/r4300/r4300.c
@@ -67,11 +67,14 @@ unsigned int next_interupt;
 precomp_instr *PC;
 #endif
 long long int local_rs;
-unsigned int delay_slot, skip_jump = 0, dyna_interp = 0, last_addr;
+unsigned int delay_slot;
+uint32_t skip_jump = 0;
+unsigned int dyna_interp = 0;
+uint32_t last_addr;
 
 cpu_instruction_table current_instruction_table;
 
-void generic_jump_to(unsigned int address)
+void generic_jump_to(uint32_t address)
 {
    if (r4300emu == CORE_PURE_INTERPRETER)
       PC->addr = address;
@@ -222,7 +225,7 @@ static void dynarec_setup_code(void)
 {
    // The dynarec jumps here after we call dyna_start and it prepares
    // Here we need to prepare the initial code block and jump to it
-   jump_to(0xa4000040);
+   jump_to(UINT32_C(0xa4000040));
 
    // Prevent segfault on failed jump_to
    if (!actual->block || !actual->code)
@@ -297,7 +300,7 @@ void r4300_execute(void)
         DebugMessage(M64MSG_INFO, "Starting R4300 emulator: Cached Interpreter");
         r4300emu = CORE_INTERPRETER;
         init_blocks();
-        jump_to(0xa4000040);
+        jump_to(UINT32_C(0xa4000040));
 
         /* Prevent segfault on failed jump_to */
         if (!actual->block)

--- a/src/r4300/r4300.c
+++ b/src/r4300/r4300.c
@@ -19,6 +19,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -61,7 +62,7 @@ unsigned int count_per_op = COUNT_PER_OP_DEFAULT;
 int llbit, rompause;
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
 int stop;
-long long int reg[32], hi, lo;
+int64_t reg[32], hi, lo;
 unsigned int next_interupt;
 precomp_instr *PC;
 #endif
@@ -209,9 +210,9 @@ void r4300_reset_soft(void)
     g_sp.mem[0x101c/4] = 0x3c0bb000;
 
     /* required by CIC x105 */
-    reg[11] = 0xffffffffa4000040ULL; /* t3 */
-    reg[29] = 0xffffffffa4001ff0ULL; /* sp */
-    reg[31] = 0xffffffffa4001550ULL; /* ra */
+    reg[11] = INT64_C(0xffffffffa4000040); /* t3 */
+    reg[29] = INT64_C(0xffffffffa4001ff0); /* sp */
+    reg[31] = INT64_C(0xffffffffa4001550); /* ra */
 
     /* ready to execute IPL3 */
 }

--- a/src/r4300/r4300.c
+++ b/src/r4300/r4300.c
@@ -133,7 +133,7 @@ void r4300_reset_hard(void)
     llbit=0;
     hi=0;
     lo=0;
-    FCR0=0x511;
+    FCR0 = UINT32_C(0x511);
     FCR31=0;
 
     // set COP0 registers

--- a/src/r4300/r4300.h
+++ b/src/r4300/r4300.h
@@ -22,13 +22,15 @@
 #ifndef M64P_R4300_R4300_H
 #define M64P_R4300_R4300_H
 
+#include <stdint.h>
+
 #include "ops.h"
 #include "recomp.h"
 
 extern precomp_instr *PC;
 
 extern int stop, llbit, rompause;
-extern long long int reg[32], hi, lo;
+extern int64_t reg[32], hi, lo;
 extern long long int local_rs;
 extern unsigned int delay_slot, skip_jump, dyna_interp;
 extern unsigned int r4300emu;

--- a/src/r4300/r4300.h
+++ b/src/r4300/r4300.h
@@ -36,7 +36,7 @@ extern unsigned int delay_slot;
 extern uint32_t skip_jump;
 extern unsigned int dyna_interp;
 extern unsigned int r4300emu;
-extern unsigned int next_interupt;
+extern uint32_t next_interupt;
 extern uint32_t last_addr;
 #define COUNT_PER_OP_DEFAULT 2
 extern unsigned int count_per_op;

--- a/src/r4300/r4300.h
+++ b/src/r4300/r4300.h
@@ -32,10 +32,12 @@ extern precomp_instr *PC;
 extern int stop, llbit, rompause;
 extern int64_t reg[32], hi, lo;
 extern long long int local_rs;
-extern unsigned int delay_slot, skip_jump, dyna_interp;
+extern unsigned int delay_slot;
+extern uint32_t skip_jump;
+extern unsigned int dyna_interp;
 extern unsigned int r4300emu;
 extern unsigned int next_interupt;
-extern unsigned int last_addr;
+extern uint32_t last_addr;
 #define COUNT_PER_OP_DEFAULT 2
 extern unsigned int count_per_op;
 extern cpu_instruction_table current_instruction_table;
@@ -46,7 +48,7 @@ void r4300_execute(void);
 
 /* Jump to the given address. This works for all r4300 emulator, but is slower.
  * Use this for common code which can be executed from any r4300 emulator. */ 
-void generic_jump_to(unsigned int address);
+void generic_jump_to(uint32_t address);
 
 // r4300 emulators
 #define CORE_PURE_INTERPRETER 0

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -2285,7 +2285,7 @@ void init_block(precomp_block *block)
    * yet as the game should have already set up the code correctly.
    */
   invalid_code[block->start>>12] = 0;
-  if (block->end < 0x80000000 || block->start >= 0xc0000000)
+  if (block->end < UINT32_C(0x80000000) || block->start >= UINT32_C(0xc0000000))
   { 
     unsigned int paddr;
     
@@ -2298,8 +2298,8 @@ void init_block(precomp_block *block)
       blocks[paddr>>12]->block = NULL;
       blocks[paddr>>12]->jumps_table = NULL;
       blocks[paddr>>12]->riprel_table = NULL;
-      blocks[paddr>>12]->start = paddr & ~0xFFF;
-      blocks[paddr>>12]->end = (paddr & ~0xFFF) + 0x1000;
+      blocks[paddr>>12]->start = paddr & ~UINT32_C(0xFFF);
+      blocks[paddr>>12]->end = (paddr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
     }
     init_block(blocks[paddr>>12]);
     
@@ -2312,40 +2312,40 @@ void init_block(precomp_block *block)
       blocks[paddr>>12]->block = NULL;
       blocks[paddr>>12]->jumps_table = NULL;
       blocks[paddr>>12]->riprel_table = NULL;
-      blocks[paddr>>12]->start = paddr & ~0xFFF;
-      blocks[paddr>>12]->end = (paddr & ~0xFFF) + 0x1000;
+      blocks[paddr>>12]->start = paddr & ~UINT32_C(0xFFF);
+      blocks[paddr>>12]->end = (paddr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
     }
     init_block(blocks[paddr>>12]);
   }
   else
   {
-    if (block->start >= 0x80000000 && block->end < 0xa0000000 && invalid_code[(block->start+0x20000000)>>12])
+    if (block->start >= UINT32_C(0x80000000) && block->end < UINT32_C(0xa0000000) && invalid_code[(block->start+UINT32_C(0x20000000))>>12])
     {
-      if (!blocks[(block->start+0x20000000)>>12])
+      if (!blocks[(block->start+UINT32_C(0x20000000))>>12])
       {
-        blocks[(block->start+0x20000000)>>12] = (precomp_block *) malloc(sizeof(precomp_block));
-        blocks[(block->start+0x20000000)>>12]->code = NULL;
-        blocks[(block->start+0x20000000)>>12]->block = NULL;
-        blocks[(block->start+0x20000000)>>12]->jumps_table = NULL;
-        blocks[(block->start+0x20000000)>>12]->riprel_table = NULL;
-        blocks[(block->start+0x20000000)>>12]->start = (block->start+0x20000000) & ~0xFFF;
-        blocks[(block->start+0x20000000)>>12]->end = ((block->start+0x20000000) & ~0xFFF) + 0x1000;
+        blocks[(block->start+UINT32_C(0x20000000))>>12] = (precomp_block *) malloc(sizeof(precomp_block));
+        blocks[(block->start+UINT32_C(0x20000000))>>12]->code = NULL;
+        blocks[(block->start+UINT32_C(0x20000000))>>12]->block = NULL;
+        blocks[(block->start+UINT32_C(0x20000000))>>12]->jumps_table = NULL;
+        blocks[(block->start+UINT32_C(0x20000000))>>12]->riprel_table = NULL;
+        blocks[(block->start+UINT32_C(0x20000000))>>12]->start = (block->start+UINT32_C(0x20000000)) & ~UINT32_C(0xFFF);
+        blocks[(block->start+UINT32_C(0x20000000))>>12]->end = ((block->start+UINT32_C(0x20000000)) & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
       }
-      init_block(blocks[(block->start+0x20000000)>>12]);
+      init_block(blocks[(block->start+UINT32_C(0x20000000))>>12]);
     }
-    if (block->start >= 0xa0000000 && block->end < 0xc0000000 && invalid_code[(block->start-0x20000000)>>12])
+    if (block->start >= UINT32_C(0xa0000000) && block->end < UINT32_C(0xc0000000) && invalid_code[(block->start-UINT32_C(0x20000000))>>12])
     {
-      if (!blocks[(block->start-0x20000000)>>12])
+      if (!blocks[(block->start-UINT32_C(0x20000000))>>12])
       {
-        blocks[(block->start-0x20000000)>>12] = (precomp_block *) malloc(sizeof(precomp_block));
-        blocks[(block->start-0x20000000)>>12]->code = NULL;
-        blocks[(block->start-0x20000000)>>12]->block = NULL;
-        blocks[(block->start-0x20000000)>>12]->jumps_table = NULL;
-        blocks[(block->start-0x20000000)>>12]->riprel_table = NULL;
-        blocks[(block->start-0x20000000)>>12]->start = (block->start-0x20000000) & ~0xFFF;
-        blocks[(block->start-0x20000000)>>12]->end = ((block->start-0x20000000) & ~0xFFF) + 0x1000;
+        blocks[(block->start-UINT32_C(0x20000000))>>12] = (precomp_block *) malloc(sizeof(precomp_block));
+        blocks[(block->start-UINT32_C(0x20000000))>>12]->code = NULL;
+        blocks[(block->start-UINT32_C(0x20000000))>>12]->block = NULL;
+        blocks[(block->start-UINT32_C(0x20000000))>>12]->jumps_table = NULL;
+        blocks[(block->start-UINT32_C(0x20000000))>>12]->riprel_table = NULL;
+        blocks[(block->start-UINT32_C(0x20000000))>>12]->start = (block->start-UINT32_C(0x20000000)) & ~UINT32_C(0xFFF);
+        blocks[(block->start-UINT32_C(0x20000000))>>12]->end = ((block->start-UINT32_C(0x20000000)) & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
       }
-      init_block(blocks[(block->start-0x20000000)>>12]);
+      init_block(blocks[(block->start-UINT32_C(0x20000000))>>12]);
     }
   }
   timed_section_end(TIMED_SECTION_COMPILER);
@@ -2395,12 +2395,12 @@ void recompile_block(int *source, precomp_block *block, unsigned int func)
 
    for (i = (func & 0xFFF) / 4; finished != 2; i++)
      {
-    if(block->start < 0x80000000 || block->start >= 0xc0000000)
+    if(block->start < UINT32_C(0x80000000) || UINT32_C(block->start >= 0xc0000000))
       {
-          unsigned int address2 =
+          uint32_t address2 =
            virtual_to_physical_address(block->start + i*4, 0);
-         if(blocks[address2>>12]->block[(address2&0xFFF)/4].ops == current_instruction_table.NOTCOMPILED)
-           blocks[address2>>12]->block[(address2&0xFFF)/4].ops = current_instruction_table.NOTCOMPILED2;
+         if(blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops == current_instruction_table.NOTCOMPILED)
+           blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops = current_instruction_table.NOTCOMPILED2;
       }
     
     SRC = source + i;
@@ -2437,16 +2437,16 @@ void recompile_block(int *source, precomp_block *block, unsigned int func)
       }
     
     if (i >= length-2+(length>>2)) finished = 2;
-    if (i >= (length-1) && (block->start == 0xa4000000 ||
-                block->start >= 0xc0000000 ||
-                block->end   <  0x80000000)) finished = 2;
+    if (i >= (length-1) && (block->start == UINT32_C(0xa4000000) ||
+                block->start >= UINT32_C(0xc0000000) ||
+                block->end   <  UINT32_C(0x80000000))) finished = 2;
     if (dst->ops == current_instruction_table.ERET || finished == 1) finished = 2;
     if (/*i >= length &&*/ 
         (dst->ops == current_instruction_table.J ||
          dst->ops == current_instruction_table.J_OUT ||
          dst->ops == current_instruction_table.JR) &&
-        !(i >= (length-1) && (block->start >= 0xc0000000 ||
-                  block->end   <  0x80000000)))
+        !(i >= (length-1) && (block->start >= UINT32_C(0xc0000000) ||
+                  block->end   <  UINT32_C(0x80000000))))
       finished = 1;
      }
 

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -535,7 +535,7 @@ static void (*recomp_special[64])(void) =
 
 static void RBLTZ(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BLTZ;
    recomp_func = genbltz;
    recompile_standard_i_type();
@@ -557,7 +557,7 @@ static void RBLTZ(void)
 
 static void RBGEZ(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BGEZ;
    recomp_func = genbgez;
    recompile_standard_i_type();
@@ -579,7 +579,7 @@ static void RBGEZ(void)
 
 static void RBLTZL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BLTZL;
    recomp_func = genbltzl;
    recompile_standard_i_type();
@@ -601,7 +601,7 @@ static void RBLTZL(void)
 
 static void RBGEZL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BGEZL;
    recomp_func = genbgezl;
    recompile_standard_i_type();
@@ -659,7 +659,7 @@ static void RTNEI(void)
 
 static void RBLTZAL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BLTZAL;
    recomp_func = genbltzal;
    recompile_standard_i_type();
@@ -681,7 +681,7 @@ static void RBLTZAL(void)
 
 static void RBGEZAL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BGEZAL;
    recomp_func = genbgezal;
    recompile_standard_i_type();
@@ -703,7 +703,7 @@ static void RBGEZAL(void)
 
 static void RBLTZALL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BLTZALL;
    recomp_func = genbltzall;
    recompile_standard_i_type();
@@ -725,7 +725,7 @@ static void RBLTZALL(void)
 
 static void RBGEZALL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BGEZALL;
    recomp_func = genbgezall;
    recompile_standard_i_type();
@@ -840,7 +840,7 @@ static void (*recomp_cop0[32])(void) =
 
 static void RBC1F(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BC1F;
    recomp_func = genbc1f;
    recompile_standard_i_type();
@@ -862,7 +862,7 @@ static void RBC1F(void)
 
 static void RBC1T(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BC1T;
    recomp_func = genbc1t;
    recompile_standard_i_type();
@@ -884,7 +884,7 @@ static void RBC1T(void)
 
 static void RBC1FL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BC1FL;
    recomp_func = genbc1fl;
    recompile_standard_i_type();
@@ -906,7 +906,7 @@ static void RBC1FL(void)
 
 static void RBC1TL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BC1TL;
    recomp_func = genbc1tl;
    recompile_standard_i_type();
@@ -1618,7 +1618,7 @@ static void RREGIMM(void)
 
 static void RJ(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.J;
    recomp_func = genj;
    recompile_standard_j_type();
@@ -1640,7 +1640,7 @@ static void RJ(void)
 
 static void RJAL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.JAL;
    recomp_func = genjal;
    recompile_standard_j_type();
@@ -1662,7 +1662,7 @@ static void RJAL(void)
 
 static void RBEQ(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BEQ;
    recomp_func = genbeq;
    recompile_standard_i_type();
@@ -1684,7 +1684,7 @@ static void RBEQ(void)
 
 static void RBNE(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BNE;
    recomp_func = genbne;
    recompile_standard_i_type();
@@ -1706,7 +1706,7 @@ static void RBNE(void)
 
 static void RBLEZ(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BLEZ;
    recomp_func = genblez;
    recompile_standard_i_type();
@@ -1728,7 +1728,7 @@ static void RBLEZ(void)
 
 static void RBGTZ(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BGTZ;
    recomp_func = genbgtz;
    recompile_standard_i_type();
@@ -1824,7 +1824,7 @@ static void RCOP1(void)
 
 static void RBEQL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BEQL;
    recomp_func = genbeql;
    recompile_standard_i_type();
@@ -1846,7 +1846,7 @@ static void RBEQL(void)
 
 static void RBNEL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BNEL;
    recomp_func = genbnel;
    recompile_standard_i_type();
@@ -1868,7 +1868,7 @@ static void RBNEL(void)
 
 static void RBLEZL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BLEZL;
    recomp_func = genblezl;
    recompile_standard_i_type();
@@ -1890,7 +1890,7 @@ static void RBLEZL(void)
 
 static void RBGTZL(void)
 {
-   unsigned int target;
+   uint32_t target;
    dst->ops = current_instruction_table.BGTZL;
    recomp_func = genbgtzl;
    recompile_standard_i_type();

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -19,8 +19,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 #if defined(__GNUC__)
 #include <unistd.h>
@@ -2166,7 +2169,7 @@ void init_block(precomp_block *block)
   static int init_length;
   timed_section_start(TIMED_SECTION_COMPILER);
 #ifdef CORE_DBG
-  DebugMessage(M64MSG_INFO, "init block %x - %x", (int) block->start, (int) block->end);
+  DebugMessage(M64MSG_INFO, "init block %" PRIX32 " - %" PRIX32, block->start, block->end);
 #endif
 
   length = get_block_length(block);
@@ -2496,7 +2499,7 @@ void recompile_block(const uint32_t *source, precomp_block *block, uint32_t func
     free_assembler(&block->jumps_table, &block->jumps_number, &block->riprel_table, &block->riprel_number);
      }
 #ifdef CORE_DBG
-   DebugMessage(M64MSG_INFO, "block recompiled (%x-%x)", (int)func, (int)(block->start+i*4));
+   DebugMessage(M64MSG_INFO, "block recompiled (%" PRIX32 "-%" PRIX32 ")", func, block->start+i*4);
 #endif
 #if defined(PROFILE_R4300)
    fclose(pfProfile);

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -51,7 +51,7 @@ int code_length; // current real recompiled code length
 int max_code_length; // current recompiled code's buffer length
 unsigned char **inst_pointer; // output buffer for recompiled code
 precomp_block *dst_block; // the current block that we are recompiling
-int src; // the current recompiled instruction
+uint32_t src; // the current recompiled instruction
 int fast_memory;
 int no_compiled_jump = 0; /* use cached interpreter instead of recompiler for jumps */
 
@@ -62,7 +62,7 @@ static void (*recomp_func)(void); // pointer to the dynarec's generator
 FILE *pfProfile;
 #endif
 
-static int *SRC; // currently recompiled instruction in the input stream
+static const uint32_t *SRC; // currently recompiled instruction in the input stream
 static int check_nop; // next instruction is nop ?
 static int delay_slot_compiled = 0;
 
@@ -2370,9 +2370,10 @@ void free_block(precomp_block *block)
 /**********************************************************************
  ********************* recompile a block of code **********************
  **********************************************************************/
-void recompile_block(int *source, precomp_block *block, unsigned int func)
+void recompile_block(const uint32_t *source, precomp_block *block, uint32_t func)
 {
-   int i, length, finished=0;
+   uint32_t i;
+   int length, finished=0;
    timed_section_start(TIMED_SECTION_COMPILER);
    length = (block->end-block->start)/4;
    dst_block = block;

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -95,7 +95,7 @@ static void recompile_standard_i_type(void)
 
 static void recompile_standard_j_type(void)
 {
-   dst->f.j.inst_index = src & 0x3FFFFFF;
+   dst->f.j.inst_index = src & UINT32_C(0x3FFFFFF);
 }
 
 static void recompile_standard_r_type(void)
@@ -1622,7 +1622,7 @@ static void RJ(void)
    dst->ops = current_instruction_table.J;
    recomp_func = genj;
    recompile_standard_j_type();
-   target = (dst->f.j.inst_index<<2) | (dst->addr & 0xF0000000);
+   target = (dst->f.j.inst_index<<2) | (dst->addr & UINT32_C(0xF0000000));
    if (target == dst->addr)
    {
       if (check_nop)
@@ -1644,7 +1644,7 @@ static void RJAL(void)
    dst->ops = current_instruction_table.JAL;
    recomp_func = genjal;
    recompile_standard_j_type();
-   target = (dst->f.j.inst_index<<2) | (dst->addr & 0xF0000000);
+   target = (dst->f.j.inst_index<<2) | (dst->addr & UINT32_C(0xF0000000));
    if (target == dst->addr)
    {
       if (check_nop)

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -808,7 +808,7 @@ static void RMFC0(void)
    dst->ops = current_instruction_table.MFC0;
    recomp_func = genmfc0;
    recompile_standard_r_type();
-   dst->f.r.rd = (long long*)(g_cp0_regs + ((src >> 11) & 0x1F));
+   dst->f.r.rd = (int64_t*) (g_cp0_regs + ((src >> 11) & 0x1F));
    dst->f.r.nrd = (src >> 11) & 0x1F;
    if (dst->f.r.rt == reg) RNOP();
 }

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -90,7 +90,7 @@ static void recompile_standard_i_type(void)
 {
    dst->f.i.rs = reg + ((src >> 21) & 0x1F);
    dst->f.i.rt = reg + ((src >> 16) & 0x1F);
-   dst->f.i.immediate = src & 0xFFFF;
+   dst->f.i.immediate = (int16_t) src;
 }
 
 static void recompile_standard_j_type(void)

--- a/src/r4300/recomp.h
+++ b/src/r4300/recomp.h
@@ -23,6 +23,7 @@
 #define M64P_R4300_RECOMP_H
 
 #include <stddef.h>
+#include <stdint.h>
 #if defined(__x86_64__)
   #include "x86_64/assemble_struct.h"
 #else
@@ -36,8 +37,8 @@ typedef struct _precomp_instr
      {
     struct
       {
-         long long int *rs;
-         long long int *rt;
+         int64_t *rs;
+         int64_t *rt;
          short immediate;
       } i;
     struct
@@ -46,9 +47,9 @@ typedef struct _precomp_instr
       } j;
     struct
       {
-         long long int *rs;
-         long long int *rt;
-         long long int *rd;
+         int64_t *rs;
+         int64_t *rt;
+         int64_t *rd;
          unsigned char sa;
          unsigned char nrd;
       } r;

--- a/src/r4300/recomp.h
+++ b/src/r4300/recomp.h
@@ -87,7 +87,7 @@ typedef struct _precomp_block
    unsigned int adler32;
 } precomp_block;
 
-void recompile_block(int *source, precomp_block *block, unsigned int func);
+void recompile_block(const uint32_t *source, precomp_block *block, uint32_t func);
 void init_block(precomp_block *block);
 void free_block(precomp_block *block);
 void recompile_opcode(void);

--- a/src/r4300/recomp.h
+++ b/src/r4300/recomp.h
@@ -66,7 +66,7 @@ typedef struct _precomp_instr
          unsigned char fd;
       } cf;
      } f;
-   unsigned int addr; /* word-aligned instruction address in r4300 address space */
+   uint32_t addr; /* word-aligned instruction address in r4300 address space */
    unsigned int local_addr; /* byte offset to start of corresponding x86_64 instructions, from start of code block */
    reg_cache_struct reg_cache_infos;
 } precomp_instr;
@@ -74,8 +74,8 @@ typedef struct _precomp_instr
 typedef struct _precomp_block
 {
    precomp_instr *block;
-   unsigned int start;
-   unsigned int end;
+   uint32_t start;
+   uint32_t end;
    unsigned char *code;
    unsigned int code_length;
    unsigned int max_code_length;

--- a/src/r4300/recomp.h
+++ b/src/r4300/recomp.h
@@ -39,7 +39,7 @@ typedef struct _precomp_instr
       {
          int64_t *rs;
          int64_t *rt;
-         short immediate;
+         int16_t immediate;
       } i;
     struct
       {

--- a/src/r4300/recomp.h
+++ b/src/r4300/recomp.h
@@ -43,7 +43,7 @@ typedef struct _precomp_instr
       } i;
     struct
       {
-         unsigned int inst_index;
+         uint32_t inst_index;
       } j;
     struct
       {

--- a/src/r4300/recomph.h
+++ b/src/r4300/recomph.h
@@ -29,7 +29,7 @@ extern int max_code_length;
 extern unsigned char **inst_pointer;
 extern precomp_block* dst_block;
 extern int fast_memory;
-extern int src;   /* opcode of r4300 instruction being recompiled */
+extern uint32_t src;   /* opcode of r4300 instruction being recompiled */
 
 #if defined(PROFILE_R4300)
   #include <stdio.h>

--- a/src/r4300/reset.c
+++ b/src/r4300/reset.c
@@ -22,6 +22,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
+
 #include "r4300/reset.h"
 #include "r4300/r4300.h"
 #include "r4300/interupt.h"
@@ -35,7 +37,7 @@ void reset_hard(void)
     init_memory();
     r4300_reset_hard();
     r4300_reset_soft();
-    last_addr = 0xa4000040;
+    last_addr = UINT32_C(0xa4000040);
     next_interupt = 624999;
     init_interupt();
     if(r4300emu != CORE_PURE_INTERPRETER)

--- a/src/r4300/tlb.c
+++ b/src/r4300/tlb.c
@@ -63,10 +63,10 @@ void tlb_map(tlb *entry)
             entry->phys_even < 0x20000000)
         {
             for (i=entry->start_even;i<entry->end_even;i+=0x1000)
-                tlb_LUT_r[i>>12] = 0x80000000 | (entry->phys_even + (i - entry->start_even) + 0xFFF);
+                tlb_LUT_r[i>>12] = UINT32_C(0x80000000) | (entry->phys_even + (i - entry->start_even) + 0xFFF);
             if (entry->d_even)
                 for (i=entry->start_even;i<entry->end_even;i+=0x1000)
-                    tlb_LUT_w[i>>12] = 0x80000000 | (entry->phys_even + (i - entry->start_even) + 0xFFF);
+                    tlb_LUT_w[i>>12] = UINT32_C(0x80000000) | (entry->phys_even + (i - entry->start_even) + 0xFFF);
         }
     }
 
@@ -77,17 +77,17 @@ void tlb_map(tlb *entry)
             entry->phys_odd < 0x20000000)
         {
             for (i=entry->start_odd;i<entry->end_odd;i+=0x1000)
-                tlb_LUT_r[i>>12] = 0x80000000 | (entry->phys_odd + (i - entry->start_odd) + 0xFFF);
+                tlb_LUT_r[i>>12] = UINT32_C(0x80000000) | (entry->phys_odd + (i - entry->start_odd) + 0xFFF);
             if (entry->d_odd)
                 for (i=entry->start_odd;i<entry->end_odd;i+=0x1000)
-                    tlb_LUT_w[i>>12] = 0x80000000 | (entry->phys_odd + (i - entry->start_odd) + 0xFFF);
+                    tlb_LUT_w[i>>12] = UINT32_C(0x80000000) | (entry->phys_odd + (i - entry->start_odd) + 0xFFF);
         }
     }
 }
 
-unsigned int virtual_to_physical_address(unsigned int addresse, int w)
+uint32_t virtual_to_physical_address(uint32_t addresse, int w)
 {
-    if (addresse >= 0x7f000000 && addresse < 0x80000000 && isGoldeneyeRom)
+    if (addresse >= UINT32_C(0x7f000000) && addresse < UINT32_C(0x80000000) && isGoldeneyeRom)
     {
         /**************************************************
          GoldenEye 007 hack allows for use of TLB.
@@ -97,31 +97,31 @@ unsigned int virtual_to_physical_address(unsigned int addresse, int w)
         {
         case 0x45:
             // U
-            return 0xb0034b30 + (addresse & 0xFFFFFF);
+            return UINT32_C(0xb0034b30) + (addresse & UINT32_C(0xFFFFFF));
             break;
         case 0x4A:
             // J
-            return 0xb0034b70 + (addresse & 0xFFFFFF);
+            return UINT32_C(0xb0034b70) + (addresse & UINT32_C(0xFFFFFF));
             break;
         case 0x50:
             // E
-            return 0xb00329f0 + (addresse & 0xFFFFFF);
+            return UINT32_C(0xb00329f0) + (addresse & UINT32_C(0xFFFFFF));
             break;
         default:
             // UNKNOWN COUNTRY CODE FOR GOLDENEYE USING AMERICAN VERSION HACK
-            return 0xb0034b30 + (addresse & 0xFFFFFF);
+            return UINT32_C(0xb0034b30) + (addresse & UINT32_C(0xFFFFFF));
             break;
         }
     }
     if (w == 1)
     {
         if (tlb_LUT_w[addresse>>12])
-            return (tlb_LUT_w[addresse>>12]&0xFFFFF000)|(addresse&0xFFF);
+            return (tlb_LUT_w[addresse>>12] & UINT32_C(0xFFFFF000)) | (addresse & UINT32_C(0xFFF));
     }
     else
     {
         if (tlb_LUT_r[addresse>>12])
-            return (tlb_LUT_r[addresse>>12]&0xFFFFF000)|(addresse&0xFFF);
+            return (tlb_LUT_r[addresse>>12] & UINT32_C(0xFFFFF000)) | (addresse & UINT32_C(0xFFF));
     }
     //printf("tlb exception !!! @ %x, %x, add:%x\n", addresse, w, PC->addr);
     //getchar();

--- a/src/r4300/tlb.c
+++ b/src/r4300/tlb.c
@@ -93,7 +93,7 @@ uint32_t virtual_to_physical_address(uint32_t addresse, int w)
          GoldenEye 007 hack allows for use of TLB.
          Recoded by okaygo to support all US, J, and E ROMS.
         **************************************************/
-        switch (ROM_HEADER.Country_code & 0xFF)
+        switch (ROM_HEADER.Country_code & UINT16_C(0xFF))
         {
         case 0x45:
             // U

--- a/src/r4300/tlb.h
+++ b/src/r4300/tlb.h
@@ -22,6 +22,8 @@
 #ifndef M64P_R4300_TLB_H
 #define M64P_R4300_TLB_H
 
+#include <stdint.h>
+
 typedef struct _tlb
 {
    short mask;
@@ -48,11 +50,11 @@ typedef struct _tlb
 } tlb;
 
 extern tlb tlb_e[32];
-extern unsigned int tlb_LUT_r[0x100000];
-extern unsigned int tlb_LUT_w[0x100000];
+extern uint32_t tlb_LUT_r[0x100000];
+extern uint32_t tlb_LUT_w[0x100000];
 
 void tlb_unmap(tlb *entry);
 void tlb_map(tlb *entry);
-unsigned int virtual_to_physical_address(unsigned int addresse, int w);
+uint32_t virtual_to_physical_address(uint32_t addresse, int w);
 
 #endif /* M64P_R4300_TLB_H */

--- a/src/r4300/x86/assemble.h
+++ b/src/r4300/x86/assemble.h
@@ -26,9 +26,10 @@
 #include "api/callbacks.h"
 #include "osal/preproc.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 
-extern long long int reg[32];
+extern int64_t reg[32];
 
 #define EAX 0
 #define ECX 1

--- a/src/r4300/x86_64/assemble.h
+++ b/src/r4300/x86_64/assemble.h
@@ -27,9 +27,10 @@
 #include "r4300/recomph.h"
 #include "api/callbacks.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 
-extern long long int reg[32];
+extern int64_t reg[32];
 
 #define RAX 0
 #define RCX 1

--- a/src/si/cic.c
+++ b/src/si/cic.c
@@ -27,12 +27,14 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 
 void init_cic_using_ipl3(struct cic* cic, const void* ipl3)
 {
     size_t i;
-    unsigned long long crc = 0;
+    uint64_t crc = 0;
 
     static const struct cic cics[] =
     {
@@ -49,13 +51,13 @@ void init_cic_using_ipl3(struct cic* cic, const void* ipl3)
     switch(crc)
     {
         default:
-            DebugMessage(M64MSG_WARNING, "Unknown CIC type (%08x)! using CIC 6102.", crc);
-        case 0x000000D057C85244LL: i = 1; break; /* CIC_X102 */
-        case 0x000000D0027FDF31LL:               /* CIC_X101 */
-        case 0x000000CFFB631223LL: i = 0; break; /* CIC_X101 */
-        case 0x000000D6497E414BLL: i = 2; break; /* CIC_X103 */
-        case 0x0000011A49F60E96LL: i = 3; break; /* CIC_X105 */
-        case 0x000000D6D5BE5580LL: i = 4; break; /* CIC_X106 */
+            DebugMessage(M64MSG_WARNING, "Unknown CIC type (%016" PRIX64 ")! using CIC 6102.", crc);
+        case UINT64_C(0x000000D057C85244): i = 1; break; /* CIC_X102 */
+        case UINT64_C(0x000000D0027FDF31):               /* CIC_X101 */
+        case UINT64_C(0x000000CFFB631223): i = 0; break; /* CIC_X101 */
+        case UINT64_C(0x000000D6497E414B): i = 2; break; /* CIC_X103 */
+        case UINT64_C(0x0000011A49F60E96): i = 3; break; /* CIC_X105 */
+        case UINT64_C(0x000000D6D5BE5580): i = 4; break; /* CIC_X106 */
     }
 
     memcpy(cic, &cics[i], sizeof(*cic));

--- a/src/si/eeprom.c
+++ b/src/si/eeprom.c
@@ -25,6 +25,9 @@
 #include "api/callbacks.h"
 
 #include <string.h>
+#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 
 void eeprom_save(struct eeprom* eeprom)
@@ -71,7 +74,7 @@ void eeprom_read_command(struct eeprom* eeprom, uint8_t* cmd)
     }
     else
     {
-        DebugMessage(M64MSG_WARNING, "Invalid access to eeprom address=%04x", address);
+        DebugMessage(M64MSG_WARNING, "Invalid access to eeprom address=%04" PRIX16, address);
     }
 }
 
@@ -88,7 +91,7 @@ void eeprom_write_command(struct eeprom* eeprom, uint8_t* cmd)
     }
     else
     {
-        DebugMessage(M64MSG_WARNING, "Invalid access to eeprom address=%04x", address);
+        DebugMessage(M64MSG_WARNING, "Invalid access to eeprom address=%04" PRIX16, address);
     }
 }
 

--- a/src/si/pif.c
+++ b/src/si/pif.c
@@ -31,6 +31,9 @@
 #include "r4300/interupt.h"
 
 #include <string.h>
+#include <stdint.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 //#define DEBUG_PIF
 #ifdef DEBUG_PIF
@@ -38,7 +41,7 @@ void print_pif(struct pif* pif)
 {
     int i;
     for (i=0; i<(64/8); i++)
-        DebugMessage(M64MSG_INFO, "%x %x %x %x | %x %x %x %x",
+        DebugMessage(M64MSG_INFO, "%02" PRIX8 " %02" PRIX8 " %02" PRIX8 " %02" PRIX8 " | %02" PRIX8 " %02" PRIX8 " %02" PRIX8 " %02" PRIX8,
                      pif->ram[i*8+0], pif->ram[i*8+1],pif->ram[i*8+2], pif->ram[i*8+3],
                      pif->ram[i*8+4], pif->ram[i*8+5],pif->ram[i*8+6], pif->ram[i*8+7]);
 }
@@ -55,7 +58,7 @@ static void process_cart_command(struct pif* pif, uint8_t* cmd)
     case PIF_CMD_AF_RTC_READ: af_rtc_read_command(&pif->af_rtc, cmd); break;
     case PIF_CMD_AF_RTC_WRITE: af_rtc_write_command(&pif->af_rtc, cmd); break;
     default:
-        DebugMessage(M64MSG_ERROR, "unknown PIF command: %02x", cmd[2]);
+        DebugMessage(M64MSG_ERROR, "unknown PIF command: %02" PRIX8, cmd[2]);
     }
 }
 
@@ -71,7 +74,7 @@ int read_pif_ram(void* opaque, uint32_t address, uint32_t* value)
 
     if (addr >= PIF_RAM_SIZE)
     {
-        DebugMessage(M64MSG_ERROR, "Invalid PIF address: %08x", address);
+        DebugMessage(M64MSG_ERROR, "Invalid PIF address: %08" PRIX32, address);
         *value = 0;
         return -1;
     }
@@ -89,7 +92,7 @@ int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 
     if (addr >= PIF_RAM_SIZE)
     {
-        DebugMessage(M64MSG_ERROR, "Invalid PIF address: %08x", address);
+        DebugMessage(M64MSG_ERROR, "Invalid PIF address: %08" PRIX32, address);
         return -1;
     }
 
@@ -152,7 +155,7 @@ void update_pif_write(struct si_controller* si)
             pif->ram[0x3F] = 0;
             break;
         default:
-            DebugMessage(M64MSG_ERROR, "error in update_pif_write(): %x", pif->ram[0x3F]);
+            DebugMessage(M64MSG_ERROR, "error in update_pif_write(): %" PRIX8, pif->ram[0x3F]);
         }
         return;
     }


### PR DESCRIPTION
The Nintendo 64 uses various data with exact bit counts (8-bit, 16-bit, 32-bit, 64-bit). `char`, `unsigned char`, `short`, `unsigned short`, `int`, `unsigned int`, `long`, `unsigned long`, `long long` and `unsigned long long` may be the required number of bits, but this is not guaranteed. This patch series uses `<stdint.h>` to provide types with exact bit counts for variables holding various types of Nintendo 64 data instead of the types above:

* integer registers and Coprocessors 0 and 1 registers (`int64_t`, `int32_t`);
* addresses (`uint32_t`);
* MIPS III opcodes (`uint32_t`) and instruction fields (`int16_t`, `uint32_t`);
* memory accesses (`uint8_t`, `uint16_t`, `uint32_t`, `uint64_t`);
* saved states;
* the byte-swap utility functions (`uint16_t`, `uint32_t`, `uint64_t`);
* the ROM header (`uint8_t`, `uint16_t`, `uint32_t`).

This follows in the footsteps of recent code @bsmiles32 has worked on, which has been using these types. It should not modify mupen64plus's behavior on platforms where the size of an `int`-based type matches the new intN_t type for it, only further cement the bit widths for those variables that need them.

To print out these intN_t quantities, I have made a fixup commit to use `PRIX8`, `PRIX16` and `PRIX32` from `<inttypes.h>` where appropriate.

This patch series starts creating 32-bit and 64-bit constants with **`INT32_C()`** and **`INT64_C()`**. Not every constant is like that now, but the macros append the proper suffix for constants with exact bit counts on the architecture being compiled for. I mainly used the macros for bitwise operations and to initialise the values of registers with exact bit counts, except the value `0`.

The Hacktarux JIT/x86, Hacktarux JIT/amd64 and New Dynarec/ARM are not modified, due to `unsigned int` and `unsigned long long` having the appropriate widths for their platforms already. There may be a problem with 32-bit-on-amd64 builds, due to the size of pointers differing from the size of ints and longs; this could be fixed up by the use of `uintptr_t`. This is left unhandled in my intN_t branch.

I'd like some feedback particularly related to build successes or failures on Windows, 32-bit-on-amd64 and ARM, and the use of `INTn_C()`. If things break, I'll try my best to remake the patches.