### PR TITLE
Reduce platform-specific ifdefs.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -41,7 +41,6 @@ ifeq ("$(UNAME)","FreeBSD")
 endif
 ifeq ("$(UNAME)","OpenBSD")
   OS = FREEBSD
-  CFLAGS += -DIOAPI_NO_64
   $(warning OS type "$(UNAME)" not officially supported.')
 endif
 ifneq ("$(filter GNU/kFreeBSD kfreebsd,$(UNAME))","")

--- a/src/main/zip/ioapi.c
+++ b/src/main/zip/ioapi.c
@@ -14,17 +14,6 @@
         #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#if defined(__APPLE__) || defined(IOAPI_NO_64)
-// In darwin and perhaps other BSD variants off_t is a 64 bit value, hence no need for specific 64 bit functions
-#define FOPEN_FUNC(filename, mode) fopen(filename, mode)
-#define FTELLO_FUNC(stream) ftello(stream)
-#define FSEEKO_FUNC(stream, offset, origin) fseeko(stream, offset, origin)
-#else
-#define FOPEN_FUNC(filename, mode) fopen64(filename, mode)
-#define FTELLO_FUNC(stream) ftello64(stream)
-#define FSEEKO_FUNC(stream, offset, origin) fseeko64(stream, offset, origin)
-#endif
-
 
 #include "ioapi.h"
 
@@ -124,7 +113,7 @@ static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, 
         mode_fopen = "wb";
 
     if ((filename!=NULL) && (mode_fopen != NULL))
-        file = FOPEN_FUNC((const char*)filename, mode_fopen);
+        file = fopen((const char*)filename, mode_fopen);
     return file;
 }
 
@@ -154,7 +143,7 @@ static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 static ZPOS64_T ZCALLBACK ftell64_file_func (voidpf opaque, voidpf stream)
 {
     ZPOS64_T ret;
-    ret = FTELLO_FUNC((FILE *)stream);
+    ret = ftello((FILE *)stream);
     return ret;
 }
 
@@ -200,7 +189,7 @@ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T
     }
     ret = 0;
 
-    if(FSEEKO_FUNC((FILE *)stream, offset, fseek_origin) != 0)
+    if(fseeko((FILE *)stream, offset, fseek_origin) != 0)
                         ret = -1;
 
     return ret;

--- a/src/main/zip/ioapi.h
+++ b/src/main/zip/ioapi.h
@@ -23,18 +23,8 @@
 
 #if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
 
-  // Linux needs this to support file operation on files larger then 4+GB
-  // But might need better if/def to select just the platforms that needs them.
+  // glibc needs this to support file operation on files larger then 4+GB
 
-        #ifndef __USE_FILE_OFFSET64
-                #define __USE_FILE_OFFSET64
-        #endif
-        #ifndef __USE_LARGEFILE64
-                #define __USE_LARGEFILE64
-        #endif
-        #ifndef _LARGEFILE64_SOURCE
-                #define _LARGEFILE64_SOURCE
-        #endif
         #ifndef _FILE_OFFSET_BIT
                 #define _FILE_OFFSET_BIT 64
         #endif
@@ -49,26 +39,14 @@
 #define OF _Z_OF
 #endif
 
-#if defined(USE_FILE32API)
-#define fopen64 fopen
-#define ftello64 ftell
-#define fseeko64 fseek
-#else
-#ifdef __FreeBSD__
-#define fopen64 fopen
-#define ftello64 ftello
-#define fseeko64 fseeko
-#endif
 #ifdef _MSC_VER
- #define fopen64 fopen
  #if (_MSC_VER >= 1400) && (!(defined(NO_MSCVER_FILE64_FUNC)))
-  #define ftello64 _ftelli64
-  #define fseeko64 _fseeki64
+  #define ftello _ftelli64
+  #define fseeko _fseeki64
  #else // old MSC
-  #define ftello64 ftell
-  #define fseeko64 fseek
+  #define ftello ftell
+  #define fseeko fseek
  #endif
-#endif
 #endif
 
 /*


### PR DESCRIPTION
The zip code uses 64-bit fopen(), etc by calling fopen64() and (on
platforms that don't have it) #define-ing fopen fopen64.

But this is redundant. glibc is just about the only libc out there that
needs a separate fopen64(), etc—most C libraries, including other Linux
C libraries, simply use a 64-bit off_t. glibc can do this too, by
compiling programs with _FILE_OFFSET_BITS=64. And the zip code does this.