### PR TITLE
Revert "Check if the size calculation for config file failed"

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -492,10 +492,6 @@ m64p_error ConfigInit(const char *ConfigDirOverride, const char *DataDirOverride
         fclose(fPtr);
         return M64ERR_FILES;
     }
-    if (filelen < 0) {
-        fclose(fPtr);
-        return M64ERR_FILES;
-    }
 
     configtext = (char *) malloc(filelen + 1);
     if (configtext == NULL)

--- a/src/r4300/interpreter_cop0.def
+++ b/src/r4300/interpreter_cop0.def
@@ -29,6 +29,7 @@ DECLARE_INSTRUCTION(MFC0)
         break;
       case CP0_COUNT_REG:
         update_count();
+        /* fall through */
       default:
         rrt = SE32(g_cp0_regs[rfs]);
    }

--- a/src/r4300/interpreter_cop0.def
+++ b/src/r4300/interpreter_cop0.def
@@ -26,6 +26,7 @@ DECLARE_INSTRUCTION(MFC0)
       case CP0_RANDOM_REG:
         DebugMessage(M64MSG_ERROR, "MFC0 instruction reading un-implemented Random register");
         stop=1;
+        break;
       case CP0_COUNT_REG:
         update_count();
       default:

--- a/src/si/cic.c
+++ b/src/si/cic.c
@@ -52,6 +52,7 @@ void init_cic_using_ipl3(struct cic* cic, const void* ipl3)
     {
         default:
             DebugMessage(M64MSG_WARNING, "Unknown CIC type (%016" PRIX64 ")! using CIC 6102.", crc);
+            /* fall through */
         case UINT64_C(0x000000D057C85244): i = 1; break; /* CIC_X102 */
         case UINT64_C(0x000000D0027FDF31):               /* CIC_X101 */
         case UINT64_C(0x000000CFFB631223): i = 0; break; /* CIC_X101 */


### PR DESCRIPTION
This fix for CID 38108 was actually introducing dead code and not fixing the
actual problem. The check for the ftell_result == -1 was already some lines
before.

The CID report was also not about the ftell return value. Sorry about that.

This reverts commit 6c10db91a5f1a13431b9aefabbbc0918ee5ca4b7.