### PR TITLE
More decoupling

### DIFF
--- a/src/debugger/dbg_memory.c
+++ b/src/debugger/dbg_memory.c
@@ -61,8 +61,7 @@ static void *opaddr_recompiled[564];
 static disassemble_info dis_info;
 
 #define CHECK_MEM(address) \
-   if (!invalid_code[(address) >> 12] && blocks[(address) >> 12]->block[((address) & 0xFFF) / 4].ops != current_instruction_table.NOTCOMPILED) \
-     invalid_code[(address) >> 12] = 1;
+   invalidate_r4300_cached_code(address, 4);
 
 static void process_opcode_out(void *strm, const char *fmt, ...){
   va_list ap;

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -192,6 +192,7 @@ static int savestates_load_m64p(char *filepath)
     gzFile f;
     int version;
     int i;
+    uint32_t FCR31;
 
     size_t savestateSize;
     unsigned char *savestateData, *curr;
@@ -410,7 +411,9 @@ static int savestates_load_m64p(char *filepath)
     if ((cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0)  // 32-bit FPR mode requires data shuffling because 64-bit layout is always stored in savestate file
         shuffle_fpr_data(UINT32_C(0x04000000), 0);
     *r4300_cp1_fcr0()  = GETDATA(curr, uint32_t);
-    *r4300_cp1_fcr31() = GETDATA(curr, uint32_t);
+    FCR31 = GETDATA(curr, uint32_t);
+    *r4300_cp1_fcr31() = FCR31;
+    update_x86_rounding_mode(FCR31);
 
     for (i = 0; i < 32; i++)
     {
@@ -463,6 +466,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     char buffer[1024];
     unsigned int vi_timer, SaveRDRAMSize;
     int i;
+    uint32_t FCR31;
 
     unsigned char header[8];
     unsigned char RomHeader[0x40];
@@ -550,7 +554,9 @@ static int savestates_load_pj64(char *filepath, void *handle,
     // FPCR
     *r4300_cp1_fcr0() = GETDATA(curr, uint32_t);
     curr += 30 * 4; // FCR1...FCR30 not supported
-    *r4300_cp1_fcr31() = GETDATA(curr, uint32_t);
+    FCR31 = GETDATA(curr, uint32_t);
+    *r4300_cp1_fcr31() = FCR31;
+    update_x86_rounding_mode(FCR31);
 
     // hi / lo
     *r4300_mult_hi() = GETDATA(curr, int64_t);

--- a/src/r4300/cp1.c
+++ b/src/r4300/cp1.c
@@ -36,7 +36,12 @@ extern uint32_t FCR0, FCR31;
 #endif
 int64_t reg_cop1_fgr_64[32];
 
-int rounding_mode = 0x33F;
+/* This is the x86 version of the rounding mode contained in FCR31.
+ * It should not really be here. Its size should also really be uint16_t,
+ * because FLDCW (Floating-point LoaD Control Word) loads 16-bit control
+ * words. However, x86/gcop1.c and x86-64/gcop1.c update this variable
+ * using 32-bit stores. */
+uint32_t rounding_mode = UINT32_C(0x33F);
 
 
 int64_t* r4300_cp1_regs(void)
@@ -147,5 +152,27 @@ void set_fpr_pointers(uint32_t newStatus)
             reg_cop1_double[i] = (double*) &reg_cop1_fgr_64[i>>1];
             reg_cop1_simple[i] = ((float*) &reg_cop1_fgr_64[i>>1]) + ((i & 1) ^ isBigEndian);
         }
+    }
+}
+
+/* XXX: This shouldn't really be here, but rounding_mode is used by the
+ * Hacktarux JIT and updated by CTC1 and saved states. Figure out a better
+ * place for this. */
+void update_x86_rounding_mode(uint32_t FCR31)
+{
+    switch (FCR31 & 3)
+    {
+    case 0: /* Round to nearest, or to even if equidistant */
+        rounding_mode = UINT32_C(0x33F);
+        break;
+    case 1: /* Truncate (toward 0) */
+        rounding_mode = UINT32_C(0xF3F);
+        break;
+    case 2: /* Round up (toward +Inf) */
+        rounding_mode = UINT32_C(0xB3F);
+        break;
+    case 3: /* Round down (toward -Inf) */
+        rounding_mode = UINT32_C(0x73F);
+        break;
     }
 }

--- a/src/r4300/cp1.c
+++ b/src/r4300/cp1.c
@@ -36,8 +36,7 @@ extern uint32_t FCR0, FCR31;
 #endif
 int64_t reg_cop1_fgr_64[32];
 
-int rounding_mode = 0x33F, trunc_mode = 0xF3F, round_mode = 0x33F,
-    ceil_mode = 0xB3F, floor_mode = 0x73F;
+int rounding_mode = 0x33F;
 
 
 int64_t* r4300_cp1_regs(void)

--- a/src/r4300/cp1.h
+++ b/src/r4300/cp1.h
@@ -34,5 +34,7 @@ uint32_t* r4300_cp1_fcr31(void);
 void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus);
 void set_fpr_pointers(uint32_t newStatus);
 
+void update_x86_rounding_mode(uint32_t FCR31);
+
 #endif /* M64P_R4300_CP1_H */
 

--- a/src/r4300/cp1_private.h
+++ b/src/r4300/cp1_private.h
@@ -30,7 +30,7 @@ extern float *reg_cop1_simple[32];
 extern double *reg_cop1_double[32];
 extern uint32_t FCR0, FCR31;
 extern int64_t reg_cop1_fgr_64[32];
-extern int rounding_mode, trunc_mode, round_mode, ceil_mode, floor_mode;
+extern int rounding_mode;
 
 #endif /* M64P_R4300_CP1_PRIVATE_H */
 

--- a/src/r4300/cp1_private.h
+++ b/src/r4300/cp1_private.h
@@ -30,7 +30,7 @@ extern float *reg_cop1_simple[32];
 extern double *reg_cop1_double[32];
 extern uint32_t FCR0, FCR31;
 extern int64_t reg_cop1_fgr_64[32];
-extern int rounding_mode;
+extern uint32_t rounding_mode;
 
 #endif /* M64P_R4300_CP1_PRIVATE_H */
 

--- a/src/r4300/fpu.h
+++ b/src/r4300/fpu.h
@@ -53,17 +53,17 @@
 
 M64P_FPU_INLINE void set_rounding(void)
 {
-  switch(rounding_mode) {
-  case 0x33F:
+  switch(FCR31 & 3) {
+  case 0: /* Round to nearest, or to even if equidistant */
     fesetround(FE_TONEAREST);
     break;
-  case 0xF3F:
+  case 1: /* Truncate (toward 0) */
     fesetround(FE_TOWARDZERO);
     break;
-  case 0xB3F:
+  case 2: /* Round up (toward +Inf) */
     fesetround(FE_UPWARD);
     break;
-  case 0x73F:
+  case 3: /* Round down (toward -Inf) */
     fesetround(FE_DOWNWARD);
     break;
   }

--- a/src/r4300/interpreter_cop1.def
+++ b/src/r4300/interpreter_cop1.def
@@ -72,21 +72,9 @@ DECLARE_INSTRUCTION(CTC1)
 {
    if (check_cop1_unusable()) return;
    if (rfs==31)
-      FCR31 = rrt32;
-   switch((FCR31 & 3))
    {
-   case 0:
-      rounding_mode = 0x33F; // Round to nearest, or to even if equidistant
-      break;
-    case 1:
-      rounding_mode = 0xF3F; // Truncate (toward 0)
-      break;
-    case 2:
-      rounding_mode = 0xB3F; // Round up (toward +infinity) 
-      break;
-    case 3:
-      rounding_mode = 0x73F; // Round down (toward -infinity) 
-      break;
+      FCR31 = rrt32;
+      update_x86_rounding_mode(rrt32);
    }
    //if ((FCR31 >> 7) & 0x1F) printf("FPU Exception enabled : %x\n",
    //                 (int)((FCR31 >> 7) & 0x1F));

--- a/src/r4300/interpreter_r4300.def
+++ b/src/r4300/interpreter_r4300.def
@@ -491,7 +491,7 @@ DECLARE_INSTRUCTION(LWC1)
    rdword = &temp;
    read_word_in_memory();
    if (address)
-     *((int*)reg_cop1_simple[lslfft]) = (int) *rdword;
+     *((uint32_t*) reg_cop1_simple[lslfft]) = (uint32_t) *rdword;
 }
 
 DECLARE_INSTRUCTION(LDC1)
@@ -542,7 +542,7 @@ DECLARE_INSTRUCTION(SWC1)
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
    address = lslfaddr;
-   cpu_word = *((int*)reg_cop1_simple[lslfft]);
+   cpu_word = *((uint32_t*) reg_cop1_simple[lslfft]);
    write_word_in_memory();
    CHECK_MEMORY();
 }
@@ -554,7 +554,7 @@ DECLARE_INSTRUCTION(SDC1)
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
    address = lslfaddr;
-   cpu_dword = *((unsigned long long*)reg_cop1_double[lslfft]);
+   cpu_dword = *((uint64_t*) reg_cop1_double[lslfft]);
    write_dword_in_memory();
    CHECK_MEMORY();
 }

--- a/src/r4300/new_dynarec/x86/assem_x86.c
+++ b/src/r4300/new_dynarec/x86/assem_x86.c
@@ -3719,10 +3719,10 @@ static void fconv_assemble_x86(int i,struct regstat *i_regs)
   }
   if((source[i]&0x3f)<0x10) {
     emit_fnstcw_stack();
-    if((source[i]&3)==0) emit_fldcw((int)&round_mode); //DebugMessage(M64MSG_VERBOSE, "round");
-    if((source[i]&3)==1) emit_fldcw((int)&trunc_mode); //DebugMessage(M64MSG_VERBOSE, "trunc");
-    if((source[i]&3)==2) emit_fldcw((int)&ceil_mode); //DebugMessage(M64MSG_VERBOSE, "ceil");
-    if((source[i]&3)==3) emit_fldcw((int)&floor_mode); //DebugMessage(M64MSG_VERBOSE, "floor");
+    if((source[i]&3)==0) emit_fldcw((int)&rounding_modes[0]); //DebugMessage(M64MSG_VERBOSE, "round");
+    if((source[i]&3)==1) emit_fldcw((int)&rounding_modes[1]); //DebugMessage(M64MSG_VERBOSE, "trunc");
+    if((source[i]&3)==2) emit_fldcw((int)&rounding_modes[2]); //DebugMessage(M64MSG_VERBOSE, "ceil");
+    if((source[i]&3)==3) emit_fldcw((int)&rounding_modes[3]); //DebugMessage(M64MSG_VERBOSE, "floor");
   }
   if((source[i]&0x3f)==0x24||(source[i]&0x3c)==0x0c) { // cvt_w_*
     if(opcode2[i]!=0x10||((source[i]>>11)&0x1f)!=((source[i]>>6)&0x1f))

--- a/src/r4300/r4300.c
+++ b/src/r4300/r4300.c
@@ -150,7 +150,7 @@ void r4300_reset_hard(void)
     g_cp0_regs[CP0_BADVADDR_REG] = UINT32_C(0xFFFFFFFF);
     g_cp0_regs[CP0_ERROREPC_REG] = UINT32_C(0xFFFFFFFF);
    
-    rounding_mode = 0x33F;
+    update_x86_rounding_mode(FCR31);
 }
 
 

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -2290,9 +2290,7 @@ void init_block(precomp_block *block)
   invalid_code[block->start>>12] = 0;
   if (block->end < UINT32_C(0x80000000) || block->start >= UINT32_C(0xc0000000))
   { 
-    unsigned int paddr;
-    
-    paddr = virtual_to_physical_address(block->start, 2);
+    uint32_t paddr = virtual_to_physical_address(block->start, 2);
     invalid_code[paddr>>12] = 0;
     if (!blocks[paddr>>12])
     {
@@ -2322,33 +2320,21 @@ void init_block(precomp_block *block)
   }
   else
   {
-    if (block->start >= UINT32_C(0x80000000) && block->end < UINT32_C(0xa0000000) && invalid_code[(block->start+UINT32_C(0x20000000))>>12])
+    uint32_t alt_addr = block->start ^ UINT32_C(0x20000000);
+
+    if (invalid_code[alt_addr>>12])
     {
-      if (!blocks[(block->start+UINT32_C(0x20000000))>>12])
+      if (!blocks[alt_addr>>12])
       {
-        blocks[(block->start+UINT32_C(0x20000000))>>12] = (precomp_block *) malloc(sizeof(precomp_block));
-        blocks[(block->start+UINT32_C(0x20000000))>>12]->code = NULL;
-        blocks[(block->start+UINT32_C(0x20000000))>>12]->block = NULL;
-        blocks[(block->start+UINT32_C(0x20000000))>>12]->jumps_table = NULL;
-        blocks[(block->start+UINT32_C(0x20000000))>>12]->riprel_table = NULL;
-        blocks[(block->start+UINT32_C(0x20000000))>>12]->start = (block->start+UINT32_C(0x20000000)) & ~UINT32_C(0xFFF);
-        blocks[(block->start+UINT32_C(0x20000000))>>12]->end = ((block->start+UINT32_C(0x20000000)) & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
+        blocks[alt_addr>>12] = (precomp_block *) malloc(sizeof(precomp_block));
+        blocks[alt_addr>>12]->code = NULL;
+        blocks[alt_addr>>12]->block = NULL;
+        blocks[alt_addr>>12]->jumps_table = NULL;
+        blocks[alt_addr>>12]->riprel_table = NULL;
+        blocks[alt_addr>>12]->start = alt_addr & ~UINT32_C(0xFFF);
+        blocks[alt_addr>>12]->end = (alt_addr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
       }
-      init_block(blocks[(block->start+UINT32_C(0x20000000))>>12]);
-    }
-    if (block->start >= UINT32_C(0xa0000000) && block->end < UINT32_C(0xc0000000) && invalid_code[(block->start-UINT32_C(0x20000000))>>12])
-    {
-      if (!blocks[(block->start-UINT32_C(0x20000000))>>12])
-      {
-        blocks[(block->start-UINT32_C(0x20000000))>>12] = (precomp_block *) malloc(sizeof(precomp_block));
-        blocks[(block->start-UINT32_C(0x20000000))>>12]->code = NULL;
-        blocks[(block->start-UINT32_C(0x20000000))>>12]->block = NULL;
-        blocks[(block->start-UINT32_C(0x20000000))>>12]->jumps_table = NULL;
-        blocks[(block->start-UINT32_C(0x20000000))>>12]->riprel_table = NULL;
-        blocks[(block->start-UINT32_C(0x20000000))>>12]->start = (block->start-UINT32_C(0x20000000)) & ~UINT32_C(0xFFF);
-        blocks[(block->start-UINT32_C(0x20000000))>>12]->end = ((block->start-UINT32_C(0x20000000)) & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
-      }
-      init_block(blocks[(block->start-UINT32_C(0x20000000))>>12]);
+      init_block(blocks[alt_addr>>12]);
     }
   }
   timed_section_end(TIMED_SECTION_COMPILER);

--- a/src/r4300/x86/assemble.h
+++ b/src/r4300/x86/assemble.h
@@ -60,6 +60,8 @@ extern int64_t reg[32];
 
 extern int branch_taken;
 
+extern const uint16_t trunc_mode, round_mode, ceil_mode, floor_mode;
+
 void jump_start_rel8(void);
 void jump_end_rel8(void);
 void jump_start_rel32(void);

--- a/src/r4300/x86/gcop1.c
+++ b/src/r4300/x86/gcop1.c
@@ -19,6 +19,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
 #include <stdio.h>
 
 #include "assemble.h"
@@ -32,6 +33,13 @@
 #include "r4300/cp1_private.h"
 
 #include "memory/memory.h"
+
+/* These are constants with addresses so that FLDCW can read them.
+ * They are declared 'extern' so that other files can do the same. */
+const uint16_t trunc_mode = 0xF3F;
+const uint16_t round_mode = 0x33F;
+const uint16_t ceil_mode = 0xB3F;
+const uint16_t floor_mode = 0x73F;
 
 void genmfc1(void)
 {

--- a/src/r4300/x86_64/assemble.h
+++ b/src/r4300/x86_64/assemble.h
@@ -70,6 +70,8 @@ extern int64_t reg[32];
 
 extern int branch_taken;
 
+extern const uint16_t trunc_mode, round_mode, ceil_mode, floor_mode;
+
 void jump_start_rel8(void);
 void jump_end_rel8(void);
 void jump_start_rel32(void);

--- a/src/r4300/x86_64/gcop1.c
+++ b/src/r4300/x86_64/gcop1.c
@@ -20,6 +20,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include <stdint.h>
 #include <stdio.h>
 
 #include "assemble.h"
@@ -37,6 +38,13 @@
 #if defined(COUNT_INSTR)
 #include "r4300/instr_counters.h"
 #endif
+
+/* These are constants with addresses so that FLDCW can read them.
+ * They are declared 'extern' so that other files can do the same. */
+const uint16_t trunc_mode = 0xF3F;
+const uint16_t round_mode = 0x33F;
+const uint16_t ceil_mode = 0xB3F;
+const uint16_t floor_mode = 0x73F;
 
 void genmfc1(void)
 {


### PR DESCRIPTION
These commits are intended to follow up those in #69 and #83 with more decoupling. Each commit has a message that describes it.

I would like some comments on the two following things I saw while making the changes:

1. In [`r4300_reset_hard` of `r4300.c` as of commit ff1b04f](https://github.com/mupen64plus/mupen64plus-core/blob/ff1b04f43e97ee8d2d4203656a1f08aec4768f6b/src/r4300/r4300.c#L95-L154), I've made it so `rounding_mode` was updated by a new function, `update_x86_rounding_mode`. But I saw that the rest of the function is directly accessing variables of the R4300 implementation despite work done in #83 to prevent this. And, what's more, it even accesses the TLB variables directly. **Should I replace the direct accesses in that function as part of this PR? Should there be TLB pointer functions, like `r4300_tlb_entries()`?**

2. In commit d4282c4511037df835e8740f48f1aeecb7b783dc, I've made it so that writes of `1` to `invalid_code` after 32-bit writes to N64 memory in the Debugger were done by `invalidate_r4300_cached_code` instead. But I saw that the debugger heavily uses the `blocks` and `invalid_code` variables directly, which belong to the Cached Interpreter and Hacktarux JIT. **Should `blocks` and `invalid_code` be torn down in some way?**

I would like to page @bsmiles32 specifically as he has been involved with #83, but also @richard42, @TwinAphex and @Narann, who have been involved with the core.