### PR TITLE
Fix skip to next block logic in code invalidation.

### DIFF
--- a/src/r4300/cached_interp.c
+++ b/src/r4300/cached_interp.c
@@ -613,12 +613,14 @@ void invalidate_cached_code_hacktarux(uint32_t address, size_t size)
                 {
                     invalid_code[i] = 1;
                     /* go directly to next i */
+                    addr &= ~0xfff;
                     addr |= 0xffc;
                 }
             }
             else
             {
                 /* go directly to next i */
+                addr &= ~0xfff;
                 addr |= 0xffc;
             }
         }


### PR DESCRIPTION
I forgot to clear the bits before setting their new value in commit
30b97ee. That could cause problems with non word aligned addresses.