### PR TITLE
Use only portable byteswapping code. Don't bother with intrinsics.

### DIFF
--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -48,9 +48,6 @@ extern void (*writememh[0x10000])(void);
 extern void (*writememd[0x10000])(void);
 
 #ifndef M64P_BIG_ENDIAN
-#if defined(__GNUC__) && (__GNUC__ > 4  || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))
-#define sl(x) __builtin_bswap32(x)
-#else
 #define sl(mot) \
 ( \
 ((mot & 0x000000FF) << 24) | \
@@ -58,7 +55,6 @@ extern void (*writememd[0x10000])(void);
 ((mot & 0x00FF0000) >>  8) | \
 ((mot & 0xFF000000) >> 24) \
 )
-#endif
 #define S8 3
 #define S16 2
 #define Sh16 1


### PR DESCRIPTION
The method used for determining if the intrinsics should be used does
not work properly on some versions of GCC. We had the same problem in
util.h, and decided to use portable code, adding the following comment:

"GCC has also byte swap intrinsics (__builtin_bswap32, etc.), but they
were added in relatively recent versions. In addition, GCC can detect
the byte swap code and optimize it with a high enough optimization
level."

Without this fix, mupen64plus fails at runtime on OpenBSD:

    mupen64plus:/usr/local/lib/libmupen64plus.so.2.3: undefined symbol 'm64p_swap32'