### PR TITLE
Remove unnecessary OpenBSD warning.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -42,7 +42,6 @@ endif
 ifeq ("$(UNAME)","OpenBSD")
   OS = FREEBSD
   CFLAGS += -DIOAPI_NO_64
-  $(warning OS type "$(UNAME)" not officially supported.')
 endif
 ifneq ("$(filter GNU/kFreeBSD kfreebsd,$(UNAME))","")
   OS = LINUX


### PR DESCRIPTION
OpenBSD has consistently had up‐to‐date packages for over three years and four mupen releases now. I’ve actively maintained it the whole time and provided several pull requests which have been merged. I think at this point the warning is no longer necessary.