### PR TITLE
Remove Zelda OoT Subscreen Delay Fix from mupen64plus.ini

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -6852,8 +6852,6 @@ SaveType=Flash RAM
 Status=4
 Rumble=Yes
 Players=1
-; Subscreen Delay Fix
-Cheat0=801DB78B 0002
 ; End Credits Fix
 Cheat1=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
 
@@ -6864,8 +6862,6 @@ SaveType=Flash RAM
 Status=4
 Rumble=Yes
 Players=1
-; Subscreen Delay Fix
-Cheat0=801DB78B 0002
 ; End Credits Fix
 Cheat1=D109A834 0320,8109A834 0000,D109A836 F809,8109A836 0000
 
@@ -6876,8 +6872,6 @@ SaveType=Flash RAM
 Status=4
 Rumble=Yes
 Players=1
-; Subscreen Delay Fix
-Cheat0=801DB78B 0002
 ; End Credits Fix
 Cheat1=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
 
@@ -7009,8 +7003,6 @@ SaveType=SRAM
 Status=4
 Rumble=Yes
 Players=1
-; Subscreen Delay Fix
-Cheat0=801DA5CB 0002
 
 [A04EBD753276C52E95E25AF7683DA32D]
 GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell]
@@ -7034,15 +7026,11 @@ SaveType=SRAM
 Status=4
 Rumble=Yes
 Players=1
-; Subscreen Delay Fix
-Cheat0=801DA78B 0002
 
 [2258052847BDD056C8406A9EF6427F13]
 GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!]
 CRC=693BA2AE B7F14E9F
 RefMD5=1BF5F42B98C3E97948F01155F12E2D88
-; Subscreen Delay Fix
-Cheat0=801DAE8B 0002
 
 [E040DE91A74B61E3201DB0E2323F768A]
 GoodName=Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!]
@@ -7051,8 +7039,6 @@ Status=4
 Players=1
 SaveType=SRAM
 Rumble=Yes
-; Subscreen Delay Fix
-Cheat0=801D860B 0002
 
 [2B60EF777F759B4F0E19DDF3CB84D9AB]
 GoodName=Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [b1]
@@ -7076,8 +7062,6 @@ Status=4
 Players=1
 SaveType=SRAM
 Rumble=Yes
-; Subscreen Delay Fix
-Cheat0=801D864B 0002
 
 [5BD1FE107BF8106B2AB6650ABECD54D6]
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.0) [!]
@@ -7086,8 +7070,6 @@ Status=4
 SaveType=SRAM
 Players=1
 Rumble=Yes
-; Subscreen Delay Fix
-Cheat0=801DA5CB 0002
 
 [A43A350385FA814EC9793B7ACD9E18F4]
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.0) (Room121 Hack)
@@ -7260,8 +7242,6 @@ Status=4
 SaveType=SRAM
 Players=1
 Rumble=Yes
-; Subscreen Delay Fix
-Cheat0=801DA78B 0002
 
 [92C842FC8CF706FF290044D40A64D346]
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Ita100]
@@ -7308,8 +7288,6 @@ GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!]
 CRC=693BA2AE B7F14E9F
 Players=1
 SaveType=SRAM
-; Subscreen Delay Fix
-Cheat0=801DAE8B 0002
 
 [CD09029EDCFB7C097AC01986A0F83D3F]
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (GC) [!]
@@ -7318,8 +7296,6 @@ Status=4
 Players=1
 SaveType=SRAM
 Rumble=Yes
-; Subscreen Delay Fix
-Cheat0=801DB78B 0002
 ; End Credits Fix
 Cheat1=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
 
@@ -7330,8 +7306,6 @@ Status=4
 Players=1
 SaveType=SRAM
 Rumble=Yes
-; Subscreen Delay Fix
-Cheat0=801D8F8B 0002
 ; End Credits Fix
 Cheat1=D109A8E4 0320,8109A8E4 0000,D109A8E6 F809,8109A8E6 0000
 
@@ -7347,8 +7321,6 @@ Status=4
 Players=1
 SaveType=SRAM
 Rumble=Yes
-; Subscreen Delay Fix
-Cheat0=801D8F4B 0002
 ; End Credits Fix
 Cheat1=D109A8C4 0320,8109A8C4 0000,D109A8C6 F809,8109A8C6 0000
 
@@ -7379,8 +7351,6 @@ Status=4
 Players=1
 SaveType=SRAM
 Rumble=Yes
-; Subscreen Delay Fix
-Cheat0=801DB74B 0002
 ; End Credits Fix
 Cheat1=D109A7F4 0320,8109A7F4 0000,D109A7F6 F809,8109A7F6 0000
 


### PR DESCRIPTION
The Subscreen Delay Fix for zelda OoT is now in conflict with GLideN64 own subscreen fix.
gonetz/GLideN64#589
