### PR TITLE
Use one struct for R4300 registers on all architectures

### DIFF
--- a/src/memory/memory.c
+++ b/src/memory/memory.c
@@ -48,22 +48,6 @@
 
 extern int fast_memory;
 
-#if NEW_DYNAREC != NEW_DYNAREC_ARM
-// address : address of the read/write operation being done
-uint32_t address = 0;
-#endif
-
-// values that are being written are stored in these variables
-#if NEW_DYNAREC != NEW_DYNAREC_ARM
-uint32_t cpu_word;
-uint8_t cpu_byte;
-uint16_t cpu_hword;
-uint64_t cpu_dword;
-#endif
-
-// addresse where the read value will be stored
-uint64_t* rdword;
-
 // hash tables of read functions
 void (*readmem[0x10000])(void);
 void (*readmemb[0x10000])(void);
@@ -164,22 +148,22 @@ static int writed(writefn write_word, void* opaque, uint32_t address, uint64_t v
 
 static void read_nothing(void)
 {
-    *rdword = 0;
+    *(g_state.read_dest) = 0;
 }
 
 static void read_nothingb(void)
 {
-    *rdword = 0;
+    *(g_state.read_dest) = 0;
 }
 
 static void read_nothingh(void)
 {
-    *rdword = 0;
+    *(g_state.read_dest) = 0;
 }
 
 static void read_nothingd(void)
 {
-    *rdword = 0;
+    *(g_state.read_dest) = 0;
 }
 
 static void write_nothing(void)
@@ -200,743 +184,743 @@ static void write_nothingd(void)
 
 static void read_nomem(void)
 {
-    address = virtual_to_physical_address(address,0);
-    if (address == 0x00000000) return;
+    g_state.access_addr = virtual_to_physical_address(g_state.access_addr, 0);
+    if (g_state.access_addr == 0x00000000) return;
     read_word_in_memory();
 }
 
 static void read_nomemb(void)
 {
-    address = virtual_to_physical_address(address,0);
-    if (address == 0x00000000) return;
+    g_state.access_addr = virtual_to_physical_address(g_state.access_addr, 0);
+    if (g_state.access_addr == 0x00000000) return;
     read_byte_in_memory();
 }
 
 static void read_nomemh(void)
 {
-    address = virtual_to_physical_address(address,0);
-    if (address == 0x00000000) return;
+    g_state.access_addr = virtual_to_physical_address(g_state.access_addr, 0);
+    if (g_state.access_addr == 0x00000000) return;
     read_hword_in_memory();
 }
 
 static void read_nomemd(void)
 {
-    address = virtual_to_physical_address(address,0);
-    if (address == 0x00000000) return;
+    g_state.access_addr = virtual_to_physical_address(g_state.access_addr, 0);
+    if (g_state.access_addr == 0x00000000) return;
     read_dword_in_memory();
 }
 
 static void write_nomem(void)
 {
-    invalidate_r4300_cached_code(address, 4);
-    address = virtual_to_physical_address(address,1);
-    if (address == 0x00000000) return;
+    invalidate_r4300_cached_code(g_state.access_addr, 4);
+    g_state.access_addr = virtual_to_physical_address(g_state.access_addr, 1);
+    if (g_state.access_addr == 0x00000000) return;
     write_word_in_memory();
 }
 
 static void write_nomemb(void)
 {
-    invalidate_r4300_cached_code(address, 1);
-    address = virtual_to_physical_address(address,1);
-    if (address == 0x00000000) return;
+    invalidate_r4300_cached_code(g_state.access_addr, 1);
+    g_state.access_addr = virtual_to_physical_address(g_state.access_addr, 1);
+    if (g_state.access_addr == 0x00000000) return;
     write_byte_in_memory();
 }
 
 static void write_nomemh(void)
 {
-    invalidate_r4300_cached_code(address, 2);
-    address = virtual_to_physical_address(address,1);
-    if (address == 0x00000000) return;
+    invalidate_r4300_cached_code(g_state.access_addr, 2);
+    g_state.access_addr = virtual_to_physical_address(g_state.access_addr, 1);
+    if (g_state.access_addr == 0x00000000) return;
     write_hword_in_memory();
 }
 
 static void write_nomemd(void)
 {
-    invalidate_r4300_cached_code(address, 8);
-    address = virtual_to_physical_address(address,1);
-    if (address == 0x00000000) return;
+    invalidate_r4300_cached_code(g_state.access_addr, 8);
+    g_state.access_addr = virtual_to_physical_address(g_state.access_addr, 1);
+    if (g_state.access_addr == 0x00000000) return;
     write_dword_in_memory();
 }
 
 
 void read_rdram(void)
 {
-    readw(read_rdram_dram, &g_ri, address, rdword);
+    readw(read_rdram_dram, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 void read_rdramb(void)
 {
-    readb(read_rdram_dram, &g_ri, address, rdword);
+    readb(read_rdram_dram, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 void read_rdramh(void)
 {
-    readh(read_rdram_dram, &g_ri, address, rdword);
+    readh(read_rdram_dram, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 void read_rdramd(void)
 {
-    readd(read_rdram_dram, &g_ri, address, rdword);
+    readd(read_rdram_dram, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 void write_rdram(void)
 {
-    writew(write_rdram_dram, &g_ri, address, cpu_word);
+    writew(write_rdram_dram, &g_ri, g_state.access_addr, g_state.write.w);
 }
 
 void write_rdramb(void)
 {
-    writeb(write_rdram_dram, &g_ri, address, cpu_byte);
+    writeb(write_rdram_dram, &g_ri, g_state.access_addr, g_state.write.b);
 }
 
 void write_rdramh(void)
 {
-    writeh(write_rdram_dram, &g_ri, address, cpu_hword);
+    writeh(write_rdram_dram, &g_ri, g_state.access_addr, g_state.write.h);
 }
 
 void write_rdramd(void)
 {
-    writed(write_rdram_dram, &g_ri, address, cpu_dword);
+    writed(write_rdram_dram, &g_ri, g_state.access_addr, g_state.write.d);
 }
 
 
 void read_rdramFB(void)
 {
-    readw(read_rdram_fb, &g_dp, address, rdword);
+    readw(read_rdram_fb, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 void read_rdramFBb(void)
 {
-    readb(read_rdram_fb, &g_dp, address, rdword);
+    readb(read_rdram_fb, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 void read_rdramFBh(void)
 {
-    readh(read_rdram_fb, &g_dp, address, rdword);
+    readh(read_rdram_fb, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 void read_rdramFBd(void)
 {
-    readd(read_rdram_fb, &g_dp, address, rdword);
+    readd(read_rdram_fb, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 void write_rdramFB(void)
 {
-    writew(write_rdram_fb, &g_dp, address, cpu_word);
+    writew(write_rdram_fb, &g_dp, g_state.access_addr, g_state.write.w);
 }
 
 void write_rdramFBb(void)
 {
-    writeb(write_rdram_fb, &g_dp, address, cpu_byte);
+    writeb(write_rdram_fb, &g_dp, g_state.access_addr, g_state.write.b);
 }
 
 void write_rdramFBh(void)
 {
-    writeh(write_rdram_fb, &g_dp, address, cpu_hword);
+    writeh(write_rdram_fb, &g_dp, g_state.access_addr, g_state.write.h);
 }
 
 void write_rdramFBd(void)
 {
-    writed(write_rdram_fb, &g_dp, address, cpu_dword);
+    writed(write_rdram_fb, &g_dp, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_rdramreg(void)
 {
-    readw(read_rdram_regs, &g_ri, address, rdword);
+    readw(read_rdram_regs, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rdramregb(void)
 {
-    readb(read_rdram_regs, &g_ri, address, rdword);
+    readb(read_rdram_regs, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rdramregh(void)
 {
-    readh(read_rdram_regs, &g_ri, address, rdword);
+    readh(read_rdram_regs, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rdramregd(void)
 {
-    readd(read_rdram_regs, &g_ri, address, rdword);
+    readd(read_rdram_regs, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_rdramreg(void)
 {
-    writew(write_rdram_regs, &g_ri, address, cpu_word);
+    writew(write_rdram_regs, &g_ri, g_state.access_addr, g_state.write.w);
 }
 
 static void write_rdramregb(void)
 {
-    writeb(write_rdram_regs, &g_ri, address, cpu_byte);
+    writeb(write_rdram_regs, &g_ri, g_state.access_addr, g_state.write.b);
 }
 
 static void write_rdramregh(void)
 {
-    writeh(write_rdram_regs, &g_ri, address, cpu_hword);
+    writeh(write_rdram_regs, &g_ri, g_state.access_addr, g_state.write.h);
 }
 
 static void write_rdramregd(void)
 {
-    writed(write_rdram_regs, &g_ri, address, cpu_dword);
+    writed(write_rdram_regs, &g_ri, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_rspmem(void)
 {
-    readw(read_rsp_mem, &g_sp, address, rdword);
+    readw(read_rsp_mem, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspmemb(void)
 {
-    readb(read_rsp_mem, &g_sp, address, rdword);
+    readb(read_rsp_mem, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspmemh(void)
 {
-    readh(read_rsp_mem, &g_sp, address, rdword);
+    readh(read_rsp_mem, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspmemd(void)
 {
-    readd(read_rsp_mem, &g_sp, address, rdword);
+    readd(read_rsp_mem, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_rspmem(void)
 {
-    writew(write_rsp_mem, &g_sp, address, cpu_word);
+    writew(write_rsp_mem, &g_sp, g_state.access_addr, g_state.write.w);
 }
 
 static void write_rspmemb(void)
 {
-    writeb(write_rsp_mem, &g_sp, address, cpu_byte);
+    writeb(write_rsp_mem, &g_sp, g_state.access_addr, g_state.write.b);
 }
 
 static void write_rspmemh(void)
 {
-    writeh(write_rsp_mem, &g_sp, address, cpu_hword);
+    writeh(write_rsp_mem, &g_sp, g_state.access_addr, g_state.write.h);
 }
 
 static void write_rspmemd(void)
 {
-    writed(write_rsp_mem, &g_sp, address, cpu_dword);
+    writed(write_rsp_mem, &g_sp, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_rspreg(void)
 {
-    readw(read_rsp_regs, &g_sp, address, rdword);
+    readw(read_rsp_regs, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspregb(void)
 {
-    readb(read_rsp_regs, &g_sp, address, rdword);
+    readb(read_rsp_regs, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspregh(void)
 {
-    readh(read_rsp_regs, &g_sp, address, rdword);
+    readh(read_rsp_regs, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspregd(void)
 {
-    readd(read_rsp_regs, &g_sp, address, rdword);
+    readd(read_rsp_regs, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_rspreg(void)
 {
-    writew(write_rsp_regs, &g_sp, address, cpu_word);
+    writew(write_rsp_regs, &g_sp, g_state.access_addr, g_state.write.w);
 }
 
 static void write_rspregb(void)
 {
-    writeb(write_rsp_regs, &g_sp, address, cpu_byte);
+    writeb(write_rsp_regs, &g_sp, g_state.access_addr, g_state.write.b);
 }
 
 static void write_rspregh(void)
 {
-    writeh(write_rsp_regs, &g_sp, address, cpu_hword);
+    writeh(write_rsp_regs, &g_sp, g_state.access_addr, g_state.write.h);
 }
 
 static void write_rspregd(void)
 {
-    writed(write_rsp_regs, &g_sp, address, cpu_dword);
+    writed(write_rsp_regs, &g_sp, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_rspreg2(void)
 {
-    readw(read_rsp_regs2, &g_sp, address, rdword);
+    readw(read_rsp_regs2, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspreg2b(void)
 {
-    readb(read_rsp_regs2, &g_sp, address, rdword);
+    readb(read_rsp_regs2, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspreg2h(void)
 {
-    readh(read_rsp_regs2, &g_sp, address, rdword);
+    readh(read_rsp_regs2, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rspreg2d(void)
 {
-    readd(read_rsp_regs2, &g_sp, address, rdword);
+    readd(read_rsp_regs2, &g_sp, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_rspreg2(void)
 {
-    writew(write_rsp_regs2, &g_sp, address, cpu_word);
+    writew(write_rsp_regs2, &g_sp, g_state.access_addr, g_state.write.w);
 }
 
 static void write_rspreg2b(void)
 {
-    writeb(write_rsp_regs2, &g_sp, address, cpu_byte);
+    writeb(write_rsp_regs2, &g_sp, g_state.access_addr, g_state.write.b);
 }
 
 static void write_rspreg2h(void)
 {
-    writeh(write_rsp_regs2, &g_sp, address, cpu_hword);
+    writeh(write_rsp_regs2, &g_sp, g_state.access_addr, g_state.write.h);
 }
 
 static void write_rspreg2d(void)
 {
-    writed(write_rsp_regs2, &g_sp, address, cpu_dword);
+    writed(write_rsp_regs2, &g_sp, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_dp(void)
 {
-    readw(read_dpc_regs, &g_dp, address, rdword);
+    readw(read_dpc_regs, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_dpb(void)
 {
-    readb(read_dpc_regs, &g_dp, address, rdword);
+    readb(read_dpc_regs, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_dph(void)
 {
-    readh(read_dpc_regs, &g_dp, address, rdword);
+    readh(read_dpc_regs, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_dpd(void)
 {
-    readd(read_dpc_regs, &g_dp, address, rdword);
+    readd(read_dpc_regs, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_dp(void)
 {
-    writew(write_dpc_regs, &g_dp, address, cpu_word);
+    writew(write_dpc_regs, &g_dp, g_state.access_addr, g_state.write.w);
 }
 
 static void write_dpb(void)
 {
-    writeb(write_dpc_regs, &g_dp, address, cpu_byte);
+    writeb(write_dpc_regs, &g_dp, g_state.access_addr, g_state.write.b);
 }
 
 static void write_dph(void)
 {
-    writeh(write_dpc_regs, &g_dp, address, cpu_hword);
+    writeh(write_dpc_regs, &g_dp, g_state.access_addr, g_state.write.h);
 }
 
 static void write_dpd(void)
 {
-    writed(write_dpc_regs, &g_dp, address, cpu_dword);
+    writed(write_dpc_regs, &g_dp, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_dps(void)
 {
-    readw(read_dps_regs, &g_dp, address, rdword);
+    readw(read_dps_regs, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_dpsb(void)
 {
-    readb(read_dps_regs, &g_dp, address, rdword);
+    readb(read_dps_regs, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_dpsh(void)
 {
-    readh(read_dps_regs, &g_dp, address, rdword);
+    readh(read_dps_regs, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_dpsd(void)
 {
-    readd(read_dps_regs, &g_dp, address, rdword);
+    readd(read_dps_regs, &g_dp, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_dps(void)
 {
-    writew(write_dps_regs, &g_dp, address, cpu_word);
+    writew(write_dps_regs, &g_dp, g_state.access_addr, g_state.write.w);
 }
 
 static void write_dpsb(void)
 {
-    writeb(write_dps_regs, &g_dp, address, cpu_byte);
+    writeb(write_dps_regs, &g_dp, g_state.access_addr, g_state.write.b);
 }
 
 static void write_dpsh(void)
 {
-    writeh(write_dps_regs, &g_dp, address, cpu_hword);
+    writeh(write_dps_regs, &g_dp, g_state.access_addr, g_state.write.h);
 }
 
 static void write_dpsd(void)
 {
-    writed(write_dps_regs, &g_dp, address, cpu_dword);
+    writed(write_dps_regs, &g_dp, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_mi(void)
 {
-    readw(read_mi_regs, &g_r4300, address, rdword);
+    readw(read_mi_regs, &g_r4300, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_mib(void)
 {
-    readb(read_mi_regs, &g_r4300, address, rdword);
+    readb(read_mi_regs, &g_r4300, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_mih(void)
 {
-    readh(read_mi_regs, &g_r4300, address, rdword);
+    readh(read_mi_regs, &g_r4300, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_mid(void)
 {
-    readd(read_mi_regs, &g_r4300, address, rdword);
+    readd(read_mi_regs, &g_r4300, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_mi(void)
 {
-    writew(write_mi_regs, &g_r4300, address, cpu_word);
+    writew(write_mi_regs, &g_r4300, g_state.access_addr, g_state.write.w);
 }
 
 static void write_mib(void)
 {
-    writeb(write_mi_regs, &g_r4300, address, cpu_byte);
+    writeb(write_mi_regs, &g_r4300, g_state.access_addr, g_state.write.b);
 }
 
 static void write_mih(void)
 {
-    writeh(write_mi_regs, &g_r4300, address, cpu_hword);
+    writeh(write_mi_regs, &g_r4300, g_state.access_addr, g_state.write.h);
 }
 
 static void write_mid(void)
 {
-    writed(write_mi_regs, &g_r4300, address, cpu_dword);
+    writed(write_mi_regs, &g_r4300, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_vi(void)
 {
-    readw(read_vi_regs, &g_vi, address, rdword);
+    readw(read_vi_regs, &g_vi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_vib(void)
 {
-    readb(read_vi_regs, &g_vi, address, rdword);
+    readb(read_vi_regs, &g_vi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_vih(void)
 {
-    readh(read_vi_regs, &g_vi, address, rdword);
+    readh(read_vi_regs, &g_vi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_vid(void)
 {
-    readd(read_vi_regs, &g_vi, address, rdword);
+    readd(read_vi_regs, &g_vi, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_vi(void)
 {
-    writew(write_vi_regs, &g_vi, address, cpu_word);
+    writew(write_vi_regs, &g_vi, g_state.access_addr, g_state.write.w);
 }
 
 static void write_vib(void)
 {
-    writeb(write_vi_regs, &g_vi, address, cpu_byte);
+    writeb(write_vi_regs, &g_vi, g_state.access_addr, g_state.write.b);
 }
 
 static void write_vih(void)
 {
-    writeh(write_vi_regs, &g_vi, address, cpu_hword);
+    writeh(write_vi_regs, &g_vi, g_state.access_addr, g_state.write.h);
 }
 
 static void write_vid(void)
 {
-    writed(write_vi_regs, &g_vi, address, cpu_dword);
+    writed(write_vi_regs, &g_vi, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_ai(void)
 {
-    readw(read_ai_regs, &g_ai, address, rdword);
+    readw(read_ai_regs, &g_ai, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_aib(void)
 {
-    readb(read_ai_regs, &g_ai, address, rdword);
+    readb(read_ai_regs, &g_ai, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_aih(void)
 {
-    readh(read_ai_regs, &g_ai, address, rdword);
+    readh(read_ai_regs, &g_ai, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_aid(void)
 {
-    readd(read_ai_regs, &g_ai, address, rdword);
+    readd(read_ai_regs, &g_ai, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_ai(void)
 {
-    writew(write_ai_regs, &g_ai, address, cpu_word);
+    writew(write_ai_regs, &g_ai, g_state.access_addr, g_state.write.w);
 }
 
 static void write_aib(void)
 {
-    writeb(write_ai_regs, &g_ai, address, cpu_byte);
+    writeb(write_ai_regs, &g_ai, g_state.access_addr, g_state.write.b);
 }
 
 static void write_aih(void)
 {
-    writeh(write_ai_regs, &g_ai, address, cpu_hword);
+    writeh(write_ai_regs, &g_ai, g_state.access_addr, g_state.write.h);
 }
 
 static void write_aid(void)
 {
-    writed(write_ai_regs, &g_ai, address, cpu_dword);
+    writed(write_ai_regs, &g_ai, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_pi(void)
 {
-    readw(read_pi_regs, &g_pi, address, rdword);
+    readw(read_pi_regs, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pib(void)
 {
-    readb(read_pi_regs, &g_pi, address, rdword);
+    readb(read_pi_regs, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pih(void)
 {
-    readh(read_pi_regs, &g_pi, address, rdword);
+    readh(read_pi_regs, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pid(void)
 {
-    readd(read_pi_regs, &g_pi, address, rdword);
+    readd(read_pi_regs, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_pi(void)
 {
-    writew(write_pi_regs, &g_pi, address, cpu_word);
+    writew(write_pi_regs, &g_pi, g_state.access_addr, g_state.write.w);
 }
 
 static void write_pib(void)
 {
-    writeb(write_pi_regs, &g_pi, address, cpu_byte);
+    writeb(write_pi_regs, &g_pi, g_state.access_addr, g_state.write.b);
 }
 
 static void write_pih(void)
 {
-    writeh(write_pi_regs, &g_pi, address, cpu_hword);
+    writeh(write_pi_regs, &g_pi, g_state.access_addr, g_state.write.h);
 }
 
 static void write_pid(void)
 {
-    writed(write_pi_regs, &g_pi, address, cpu_dword);
+    writed(write_pi_regs, &g_pi, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_ri(void)
 {
-    readw(read_ri_regs, &g_ri, address, rdword);
+    readw(read_ri_regs, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rib(void)
 {
-    readb(read_ri_regs, &g_ri, address, rdword);
+    readb(read_ri_regs, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rih(void)
 {
-    readh(read_ri_regs, &g_ri, address, rdword);
+    readh(read_ri_regs, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_rid(void)
 {
-    readd(read_ri_regs, &g_ri, address, rdword);
+    readd(read_ri_regs, &g_ri, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_ri(void)
 {
-    writew(write_ri_regs, &g_ri, address, cpu_word);
+    writew(write_ri_regs, &g_ri, g_state.access_addr, g_state.write.w);
 }
 
 static void write_rib(void)
 {
-    writeb(write_ri_regs, &g_ri, address, cpu_byte);
+    writeb(write_ri_regs, &g_ri, g_state.access_addr, g_state.write.b);
 }
 
 static void write_rih(void)
 {
-    writeh(write_ri_regs, &g_ri, address, cpu_hword);
+    writeh(write_ri_regs, &g_ri, g_state.access_addr, g_state.write.h);
 }
 
 static void write_rid(void)
 {
-    writed(write_ri_regs, &g_ri, address, cpu_dword);
+    writed(write_ri_regs, &g_ri, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_si(void)
 {
-    readw(read_si_regs, &g_si, address, rdword);
+    readw(read_si_regs, &g_si, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_sib(void)
 {
-    readb(read_si_regs, &g_si, address, rdword);
+    readb(read_si_regs, &g_si, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_sih(void)
 {
-    readh(read_si_regs, &g_si, address, rdword);
+    readh(read_si_regs, &g_si, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_sid(void)
 {
-    readd(read_si_regs, &g_si, address, rdword);
+    readd(read_si_regs, &g_si, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_si(void)
 {
-    writew(write_si_regs, &g_si, address, cpu_word);
+    writew(write_si_regs, &g_si, g_state.access_addr, g_state.write.w);
 }
 
 static void write_sib(void)
 {
-    writeb(write_si_regs, &g_si, address, cpu_byte);
+    writeb(write_si_regs, &g_si, g_state.access_addr, g_state.write.b);
 }
 
 static void write_sih(void)
 {
-    writeh(write_si_regs, &g_si, address, cpu_hword);
+    writeh(write_si_regs, &g_si, g_state.access_addr, g_state.write.h);
 }
 
 static void write_sid(void)
 {
-    writed(write_si_regs, &g_si, address, cpu_dword);
+    writed(write_si_regs, &g_si, g_state.access_addr, g_state.write.d);
 }
 
 static void read_pi_flashram_status(void)
 {
-    readw(read_flashram_status, &g_pi, address, rdword);
+    readw(read_flashram_status, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pi_flashram_statusb(void)
 {
-    readb(read_flashram_status, &g_pi, address, rdword);
+    readb(read_flashram_status, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pi_flashram_statush(void)
 {
-    readh(read_flashram_status, &g_pi, address, rdword);
+    readh(read_flashram_status, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pi_flashram_statusd(void)
 {
-    readd(read_flashram_status, &g_pi, address, rdword);
+    readd(read_flashram_status, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_pi_flashram_command(void)
 {
-    writew(write_flashram_command, &g_pi, address, cpu_word);
+    writew(write_flashram_command, &g_pi, g_state.access_addr, g_state.write.w);
 }
 
 static void write_pi_flashram_commandb(void)
 {
-    writeb(write_flashram_command, &g_pi, address, cpu_byte);
+    writeb(write_flashram_command, &g_pi, g_state.access_addr, g_state.write.b);
 }
 
 static void write_pi_flashram_commandh(void)
 {
-    writeh(write_flashram_command, &g_pi, address, cpu_hword);
+    writeh(write_flashram_command, &g_pi, g_state.access_addr, g_state.write.h);
 }
 
 static void write_pi_flashram_commandd(void)
 {
-    writed(write_flashram_command, &g_pi, address, cpu_dword);
+    writed(write_flashram_command, &g_pi, g_state.access_addr, g_state.write.d);
 }
 
 
 static void read_rom(void)
 {
-    readw(read_cart_rom, &g_pi, address, rdword);
+    readw(read_cart_rom, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_romb(void)
 {
-    readb(read_cart_rom, &g_pi, address, rdword);
+    readb(read_cart_rom, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_romh(void)
 {
-    readh(read_cart_rom, &g_pi, address, rdword);
+    readh(read_cart_rom, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_romd(void)
 {
-    readd(read_cart_rom, &g_pi, address, rdword);
+    readd(read_cart_rom, &g_pi, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_rom(void)
 {
-    writew(write_cart_rom, &g_pi, address, cpu_word);
+    writew(write_cart_rom, &g_pi, g_state.access_addr, g_state.write.w);
 }
 
 
 static void read_pif(void)
 {
-    readw(read_pif_ram, &g_si, address, rdword);
+    readw(read_pif_ram, &g_si, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pifb(void)
 {
-    readb(read_pif_ram, &g_si, address, rdword);
+    readb(read_pif_ram, &g_si, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pifh(void)
 {
-    readh(read_pif_ram, &g_si, address, rdword);
+    readh(read_pif_ram, &g_si, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_pifd(void)
 {
-    readd(read_pif_ram, &g_si, address, rdword);
+    readd(read_pif_ram, &g_si, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_pif(void)
 {
-    writew(write_pif_ram, &g_si, address, cpu_word);
+    writew(write_pif_ram, &g_si, g_state.access_addr, g_state.write.w);
 }
 
 static void write_pifb(void)
 {
-    writeb(write_pif_ram, &g_si, address, cpu_byte);
+    writeb(write_pif_ram, &g_si, g_state.access_addr, g_state.write.b);
 }
 
 static void write_pifh(void)
 {
-    writeh(write_pif_ram, &g_si, address, cpu_hword);
+    writeh(write_pif_ram, &g_si, g_state.access_addr, g_state.write.h);
 }
 
 static void write_pifd(void)
 {
-    writed(write_pif_ram, &g_si, address, cpu_dword);
+    writed(write_pif_ram, &g_si, g_state.access_addr, g_state.write.d);
 }
 
 /* HACK: just to get F-Zero to boot
@@ -958,42 +942,42 @@ static int write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_
 
 static void read_dd(void)
 {
-    readw(read_dd_regs, NULL, address, rdword);
+    readw(read_dd_regs, NULL, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_ddb(void)
 {
-    readb(read_dd_regs, NULL, address, rdword);
+    readb(read_dd_regs, NULL, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_ddh(void)
 {
-    readh(read_dd_regs, NULL, address, rdword);
+    readh(read_dd_regs, NULL, g_state.access_addr, g_state.read_dest);
 }
 
 static void read_ddd(void)
 {
-    readd(read_dd_regs, NULL, address, rdword);
+    readd(read_dd_regs, NULL, g_state.access_addr, g_state.read_dest);
 }
 
 static void write_dd(void)
 {
-    writew(write_dd_regs, NULL, address, cpu_word);
+    writew(write_dd_regs, NULL, g_state.access_addr, g_state.write.w);
 }
 
 static void write_ddb(void)
 {
-    writeb(write_dd_regs, NULL, address, cpu_byte);
+    writeb(write_dd_regs, NULL, g_state.access_addr, g_state.write.b);
 }
 
 static void write_ddh(void)
 {
-    writeh(write_dd_regs, NULL, address, cpu_hword);
+    writeh(write_dd_regs, NULL, g_state.access_addr, g_state.write.h);
 }
 
 static void write_ddd(void)
 {
-    writed(write_dd_regs, NULL, address, cpu_dword);
+    writed(write_dd_regs, NULL, g_state.access_addr, g_state.write.d);
 }
 
 #ifdef DBG

--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -24,19 +24,16 @@
 
 #include <stdint.h>
 
-#define read_word_in_memory() readmem[address>>16]()
-#define read_byte_in_memory() readmemb[address>>16]()
-#define read_hword_in_memory() readmemh[address>>16]()
-#define read_dword_in_memory() readmemd[address>>16]()
-#define write_word_in_memory() writemem[address>>16]()
-#define write_byte_in_memory() writememb[address >>16]()
-#define write_hword_in_memory() writememh[address >>16]()
-#define write_dword_in_memory() writememd[address >>16]()
+#include "r4300/r4300.h"
 
-extern uint32_t address, cpu_word;
-extern uint8_t cpu_byte;
-extern uint16_t cpu_hword;
-extern uint64_t cpu_dword, *rdword;
+#define read_word_in_memory() readmem[g_state.access_addr >> 16]()
+#define read_byte_in_memory() readmemb[g_state.access_addr >> 16]()
+#define read_hword_in_memory() readmemh[g_state.access_addr >> 16]()
+#define read_dword_in_memory() readmemd[g_state.access_addr >> 16]()
+#define write_word_in_memory() writemem[g_state.access_addr >> 16]()
+#define write_byte_in_memory() writememb[g_state.access_addr >> 16]()
+#define write_hword_in_memory() writememh[g_state.access_addr >> 16]()
+#define write_dword_in_memory() writememd[g_state.access_addr >> 16]()
 
 extern void (*readmem[0x10000])(void);
 extern void (*readmemb[0x10000])(void);

--- a/src/r4300/cp0.c
+++ b/src/r4300/cp0.c
@@ -36,24 +36,17 @@
 #include "debugger/dbg_types.h"
 #endif
 
-/* global variable */
-#if NEW_DYNAREC != NEW_DYNAREC_ARM
-/* ARM backend requires a different memory layout
- * and therefore manually allocate that variable */
-uint32_t g_cp0_regs[CP0_REGS_COUNT];
-#endif
-
 /* global functions */
 uint32_t* r4300_cp0_regs(void)
 {
-    return g_cp0_regs;
+    return g_state.regs.cp0;
 }
 
 int check_cop1_unusable(void)
 {
-   if (!(g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x20000000)))
+   if (!(g_state.regs.cp0[CP0_STATUS_REG] & UINT32_C(0x20000000)))
      {
-    g_cp0_regs[CP0_CAUSE_REG] = (UINT32_C(11) << 2) | UINT32_C(0x10000000);
+    g_state.regs.cp0[CP0_CAUSE_REG] = (UINT32_C(11) << 2) | UINT32_C(0x10000000);
     exception_general();
     return 1;
      }
@@ -66,7 +59,7 @@ void cp0_update_count(void)
     if (r4300emu != CORE_DYNAREC)
     {
 #endif
-        g_cp0_regs[CP0_COUNT_REG] += ((PC->addr - last_addr) >> 2) * count_per_op;
+        g_state.regs.cp0[CP0_COUNT_REG] += ((PC->addr - last_addr) >> 2) * count_per_op;
         last_addr = PC->addr;
 #ifdef NEW_DYNAREC
     }

--- a/src/r4300/cp0_private.h
+++ b/src/r4300/cp0_private.h
@@ -24,8 +24,6 @@
 
 #include "cp0.h"
 
-extern unsigned int g_cp0_regs[CP0_REGS_COUNT];
-
 int check_cop1_unusable(void);
 
 #endif /* M64P_R4300_CP0_PRIVATE_H */

--- a/src/r4300/cp1.c
+++ b/src/r4300/cp1.c
@@ -21,20 +21,8 @@
 
 #include <stdint.h>
 
+#include "r4300.h"
 #include "new_dynarec/new_dynarec.h"
-
-#if NEW_DYNAREC != NEW_DYNAREC_ARM
-float *reg_cop1_simple[32];
-double *reg_cop1_double[32];
-uint32_t FCR0, FCR31;
-#else
-/* ARM backend requires a different memory layout
- * and therefore manually allocates these variables */
-extern float *reg_cop1_simple[32];
-extern double *reg_cop1_double[32];
-extern uint32_t FCR0, FCR31;
-#endif
-int64_t reg_cop1_fgr_64[32];
 
 /* This is the x86 version of the rounding mode contained in FCR31.
  * It should not really be here. Its size should also really be uint16_t,
@@ -46,27 +34,27 @@ uint32_t rounding_mode = UINT32_C(0x33F);
 
 int64_t* r4300_cp1_regs(void)
 {
-    return reg_cop1_fgr_64;
+    return g_state.regs.fpr_data;
 }
 
 float** r4300_cp1_regs_simple(void)
 {
-    return reg_cop1_simple;
+    return g_state.regs.cp1_s;
 }
 
 double** r4300_cp1_regs_double(void)
 {
-    return reg_cop1_double;
+    return g_state.regs.cp1_d;
 }
 
 uint32_t* r4300_cp1_fcr0(void)
 {
-    return &FCR0;
+    return &g_state.regs.fcr_0;
 }
 
 uint32_t* r4300_cp1_fcr31(void)
 {
-    return &FCR31;
+    return &g_state.regs.fcr_31;
 }
 
 
@@ -94,14 +82,14 @@ void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus)
             // retrieve 32 FPR values from packed 32-bit FGR registers
             for (i = 0; i < 32; i++)
             {
-                temp_fgr_32[i] = *((int32_t *) &reg_cop1_fgr_64[i>>1] + ((i & 1) ^ isBigEndian));
+                temp_fgr_32[i] = *((int32_t *) &g_state.regs.fpr_data[i>>1] + ((i & 1) ^ isBigEndian));
             }
             // unpack them into 32 64-bit registers, taking the high 32-bits from their temporary place in the upper 16 FGRs
             for (i = 0; i < 32; i++)
             {
-                int32_t high32 = *((int32_t *) &reg_cop1_fgr_64[(i>>1)+16] + (i & 1));
-                *((int32_t *) &reg_cop1_fgr_64[i] + isBigEndian)     = temp_fgr_32[i];
-                *((int32_t *) &reg_cop1_fgr_64[i] + (isBigEndian^1)) = high32;
+                int32_t high32 = *((int32_t *) &g_state.regs.fpr_data[(i>>1)+16] + (i & 1));
+                *((int32_t *) &g_state.regs.fpr_data[i] + isBigEndian)     = temp_fgr_32[i];
+                *((int32_t *) &g_state.regs.fpr_data[i] + (isBigEndian^1)) = high32;
             }
         }
         else
@@ -109,19 +97,19 @@ void shuffle_fpr_data(uint32_t oldStatus, uint32_t newStatus)
             // retrieve the high 32 bits from each 64-bit FGR register and store in temp array
             for (i = 0; i < 32; i++)
             {
-                temp_fgr_32[i] = *((int32_t *) &reg_cop1_fgr_64[i] + (isBigEndian^1));
+                temp_fgr_32[i] = *((int32_t *) &g_state.regs.fpr_data[i] + (isBigEndian^1));
             }
             // take the low 32 bits from each register and pack them together into 64-bit pairs
             for (i = 0; i < 16; i++)
             {
-                uint32_t least32 = *((uint32_t *) &reg_cop1_fgr_64[i*2] + isBigEndian);
-                uint32_t most32 = *((uint32_t *) &reg_cop1_fgr_64[i*2+1] + isBigEndian);
-                reg_cop1_fgr_64[i] = ((uint64_t) most32 << 32) | (uint64_t) least32;
+                uint32_t least32 = *((uint32_t *) &g_state.regs.fpr_data[i*2] + isBigEndian);
+                uint32_t most32 = *((uint32_t *) &g_state.regs.fpr_data[i*2+1] + isBigEndian);
+                g_state.regs.fpr_data[i] = ((uint64_t) most32 << 32) | (uint64_t) least32;
             }
             // store the high bits in the upper 16 FGRs, which wont be accessible in 32-bit mode
             for (i = 0; i < 32; i++)
             {
-                *((int32_t *) &reg_cop1_fgr_64[(i>>1)+16] + (i & 1)) = temp_fgr_32[i];
+                *((int32_t *) &g_state.regs.fpr_data[(i>>1)+16] + (i & 1)) = temp_fgr_32[i];
             }
         }
     }
@@ -141,16 +129,16 @@ void set_fpr_pointers(uint32_t newStatus)
     {
         for (i = 0; i < 32; i++)
         {
-            reg_cop1_double[i] = (double*) &reg_cop1_fgr_64[i];
-            reg_cop1_simple[i] = ((float*) &reg_cop1_fgr_64[i]) + isBigEndian;
+            g_state.regs.cp1_d[i] = (double*) &g_state.regs.fpr_data[i];
+            g_state.regs.cp1_s[i] = ((float*) &g_state.regs.fpr_data[i]) + isBigEndian;
         }
     }
     else
     {
         for (i = 0; i < 32; i++)
         {
-            reg_cop1_double[i] = (double*) &reg_cop1_fgr_64[i>>1];
-            reg_cop1_simple[i] = ((float*) &reg_cop1_fgr_64[i>>1]) + ((i & 1) ^ isBigEndian);
+            g_state.regs.cp1_d[i] = (double*) &g_state.regs.fpr_data[i>>1];
+            g_state.regs.cp1_s[i] = ((float*) &g_state.regs.fpr_data[i>>1]) + ((i & 1) ^ isBigEndian);
         }
     }
 }
@@ -160,7 +148,7 @@ void set_fpr_pointers(uint32_t newStatus)
  * place for this. */
 void update_x86_rounding_mode(uint32_t FCR31)
 {
-    switch (FCR31 & 3)
+    switch (g_state.regs.fcr_31 & 3)
     {
     case 0: /* Round to nearest, or to even if equidistant */
         rounding_mode = UINT32_C(0x33F);

--- a/src/r4300/cp1_private.h
+++ b/src/r4300/cp1_private.h
@@ -26,10 +26,6 @@
 
 #include "cp1.h"
 
-extern float *reg_cop1_simple[32];
-extern double *reg_cop1_double[32];
-extern uint32_t FCR0, FCR31;
-extern int64_t reg_cop1_fgr_64[32];
 extern uint32_t rounding_mode;
 
 #endif /* M64P_R4300_CP1_PRIVATE_H */

--- a/src/r4300/fpu.h
+++ b/src/r4300/fpu.h
@@ -58,7 +58,7 @@
 
 M64P_FPU_INLINE void set_rounding(void)
 {
-  switch(FCR31 & 3) {
+  switch (g_state.regs.fcr_31 & 3) {
   case 0: /* Round to nearest, or to even if equidistant */
     fesetround(FE_TONEAREST);
     break;
@@ -171,7 +171,7 @@ M64P_FPU_INLINE void floor_w_d(const double *source,int32_t *dest)
 
 M64P_FPU_INLINE void cvt_w_s(const float *source,int32_t *dest)
 {
-  switch(FCR31&3)
+  switch (g_state.regs.fcr_31 & 3)
   {
     case 0: round_w_s(source,dest);return;
     case 1: trunc_w_s(source,dest);return;
@@ -181,7 +181,7 @@ M64P_FPU_INLINE void cvt_w_s(const float *source,int32_t *dest)
 }
 M64P_FPU_INLINE void cvt_w_d(const double *source,int32_t *dest)
 {
-  switch(FCR31&3)
+  switch (g_state.regs.fcr_31 & 3)
   {
     case 0: round_w_d(source,dest);return;
     case 1: trunc_w_d(source,dest);return;
@@ -191,7 +191,7 @@ M64P_FPU_INLINE void cvt_w_d(const double *source,int32_t *dest)
 }
 M64P_FPU_INLINE void cvt_l_s(const float *source,int64_t *dest)
 {
-  switch(FCR31&3)
+  switch (g_state.regs.fcr_31 & 3)
   {
     case 0: round_l_s(source,dest);return;
     case 1: trunc_l_s(source,dest);return;
@@ -201,7 +201,7 @@ M64P_FPU_INLINE void cvt_l_s(const float *source,int64_t *dest)
 }
 M64P_FPU_INLINE void cvt_l_d(const double *source,int64_t *dest)
 {
-  switch(FCR31&3)
+  switch (g_state.regs.fcr_31 & 3)
   {
     case 0: round_l_d(source,dest);return;
     case 1: trunc_l_d(source,dest);return;
@@ -212,174 +212,174 @@ M64P_FPU_INLINE void cvt_l_d(const double *source,int64_t *dest)
 
 M64P_FPU_INLINE void c_f_s()
 {
-  FCR31 &= ~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 &= ~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_un_s(const float *source,const float *target)
 {
-  FCR31=(isnan(*source) || isnan(*target)) ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31=(isnan(*source) || isnan(*target)) ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
                           
 M64P_FPU_INLINE void c_eq_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
-  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31&=~FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source==*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ueq_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
-  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31|=FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source==*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_olt_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
-  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31&=~FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source<*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ult_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
-  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31|=FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source<*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_ole_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
-  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31&=~FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source<=*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ule_s(const float *source,const float *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
-  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31|=FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source<=*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_sf_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31&=~FCR31_CMP_BIT;
+  g_state.regs.fcr_31&=~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ngle_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31&=~FCR31_CMP_BIT;
+  g_state.regs.fcr_31&=~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_seq_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source==*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ngl_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source==*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_lt_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source<*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_nge_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source<*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_le_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source<=*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ngt_s(const float *source,const float *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source<=*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_f_d()
 {
-  FCR31 &= ~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 &= ~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_un_d(const double *source,const double *target)
 {
-  FCR31=(isnan(*source) || isnan(*target)) ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31=(isnan(*source) || isnan(*target)) ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
                           
 M64P_FPU_INLINE void c_eq_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
-  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31&=~FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source==*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ueq_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
-  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31|=FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source==*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_olt_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
-  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31&=~FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source<*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ult_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
-  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31|=FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source<*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_ole_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31&=~FCR31_CMP_BIT;return;}
-  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31&=~FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source<=*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ule_d(const double *source,const double *target)
 {
-  if (isnan(*source) || isnan(*target)) {FCR31|=FCR31_CMP_BIT;return;}
-  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  if (isnan(*source) || isnan(*target)) {g_state.regs.fcr_31|=FCR31_CMP_BIT;return;}
+  g_state.regs.fcr_31 = *source<=*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_sf_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31&=~FCR31_CMP_BIT;
+  g_state.regs.fcr_31&=~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ngle_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31&=~FCR31_CMP_BIT;
+  g_state.regs.fcr_31&=~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_seq_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source==*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ngl_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source==*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source==*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_lt_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source<*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_nge_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source<*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 M64P_FPU_INLINE void c_le_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source<=*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 M64P_FPU_INLINE void c_ngt_d(const double *source,const double *target)
 {
   //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  FCR31 = *source<=*target ? FCR31|FCR31_CMP_BIT : FCR31&~FCR31_CMP_BIT;
+  g_state.regs.fcr_31 = *source<=*target ? g_state.regs.fcr_31|FCR31_CMP_BIT : g_state.regs.fcr_31&~FCR31_CMP_BIT;
 }
 
 

--- a/src/r4300/interpreter_cop0.def
+++ b/src/r4300/interpreter_cop0.def
@@ -31,7 +31,7 @@ DECLARE_INSTRUCTION(MFC0)
         cp0_update_count();
         /* fall through */
       default:
-        rrt = SE32(g_cp0_regs[rfs]);
+        rrt = SE32(g_state.regs.cp0[rfs]);
    }
    ADD_TO_PC(1);
 }
@@ -41,8 +41,8 @@ DECLARE_INSTRUCTION(MTC0)
   switch(rfs)
   {
     case CP0_INDEX_REG:
-      g_cp0_regs[CP0_INDEX_REG] = rrt32 & UINT32_C(0x8000003F);
-      if ((g_cp0_regs[CP0_INDEX_REG] & UINT32_C(0x3F)) > UINT32_C(31))
+      g_state.regs.cp0[CP0_INDEX_REG] = rrt32 & UINT32_C(0x8000003F);
+      if ((g_state.regs.cp0[CP0_INDEX_REG] & UINT32_C(0x3F)) > UINT32_C(31))
       {
         DebugMessage(M64MSG_ERROR, "MTC0 instruction writing Index register with TLB index > 31");
         stop=1;
@@ -51,54 +51,54 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_RANDOM_REG:
       break;
     case CP0_ENTRYLO0_REG:
-      g_cp0_regs[CP0_ENTRYLO0_REG] = rrt32 & UINT32_C(0x3FFFFFFF);
+      g_state.regs.cp0[CP0_ENTRYLO0_REG] = rrt32 & UINT32_C(0x3FFFFFFF);
       break;
     case CP0_ENTRYLO1_REG:
-      g_cp0_regs[CP0_ENTRYLO1_REG] = rrt32 & UINT32_C(0x3FFFFFFF);
+      g_state.regs.cp0[CP0_ENTRYLO1_REG] = rrt32 & UINT32_C(0x3FFFFFFF);
       break;
     case CP0_CONTEXT_REG:
-      g_cp0_regs[CP0_CONTEXT_REG] = (rrt32 & UINT32_C(0xFF800000))
-                                  | (g_cp0_regs[CP0_CONTEXT_REG] & UINT32_C(0x007FFFF0));
+      g_state.regs.cp0[CP0_CONTEXT_REG] = (rrt32 & UINT32_C(0xFF800000))
+                                  | (g_state.regs.cp0[CP0_CONTEXT_REG] & UINT32_C(0x007FFFF0));
       break;
     case CP0_PAGEMASK_REG:
-      g_cp0_regs[CP0_PAGEMASK_REG] = rrt32 & UINT32_C(0x01FFE000);
+      g_state.regs.cp0[CP0_PAGEMASK_REG] = rrt32 & UINT32_C(0x01FFE000);
       break;
     case CP0_WIRED_REG:
-      g_cp0_regs[CP0_WIRED_REG] = rrt32;
-      g_cp0_regs[CP0_RANDOM_REG] = UINT32_C(31);
+      g_state.regs.cp0[CP0_WIRED_REG] = rrt32;
+      g_state.regs.cp0[CP0_RANDOM_REG] = UINT32_C(31);
       break;
     case CP0_BADVADDR_REG:
       break;
     case CP0_COUNT_REG:
       cp0_update_count();
       interupt_unsafe_state = 1;
-      if (next_interupt <= g_cp0_regs[CP0_COUNT_REG]) gen_interupt();
+      if (g_state.next_interrupt <= g_state.regs.cp0[CP0_COUNT_REG]) gen_interupt();
       interupt_unsafe_state = 0;
       translate_event_queue(rrt32);
-      g_cp0_regs[CP0_COUNT_REG] = rrt32;
+      g_state.regs.cp0[CP0_COUNT_REG] = rrt32;
       break;
     case CP0_ENTRYHI_REG:
-      g_cp0_regs[CP0_ENTRYHI_REG] = rrt32 & UINT32_C(0xFFFFE0FF);
+      g_state.regs.cp0[CP0_ENTRYHI_REG] = rrt32 & UINT32_C(0xFFFFE0FF);
       break;
     case CP0_COMPARE_REG:
       cp0_update_count();
       remove_event(COMPARE_INT);
       add_interupt_event_count(COMPARE_INT, rrt32);
-      g_cp0_regs[CP0_COMPARE_REG] = rrt32;
-      g_cp0_regs[CP0_CAUSE_REG] &= UINT32_C(0xFFFF7FFF); //Timer interupt is clear
+      g_state.regs.cp0[CP0_COMPARE_REG] = rrt32;
+      g_state.regs.cp0[CP0_CAUSE_REG] &= UINT32_C(0xFFFF7FFF); //Timer interupt is clear
       break;
     case CP0_STATUS_REG:
-      if((rrt32 & UINT32_C(0x04000000)) != (g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)))
+      if((rrt32 & UINT32_C(0x04000000)) != (g_state.regs.cp0[CP0_STATUS_REG] & UINT32_C(0x04000000)))
       {
-          shuffle_fpr_data(g_cp0_regs[CP0_STATUS_REG], rrt32);
+          shuffle_fpr_data(g_state.regs.cp0[CP0_STATUS_REG], rrt32);
           set_fpr_pointers(rrt32);
       }
-      g_cp0_regs[CP0_STATUS_REG] = rrt32;
+      g_state.regs.cp0[CP0_STATUS_REG] = rrt32;
       cp0_update_count();
       ADD_TO_PC(1);
       check_interupt();
       interupt_unsafe_state = 1;
-      if (next_interupt <= g_cp0_regs[CP0_COUNT_REG]) gen_interupt();
+      if (g_state.next_interrupt <= g_state.regs.cp0[CP0_COUNT_REG]) gen_interupt();
       interupt_unsafe_state = 0;
       ADD_TO_PC(-1);
       break;
@@ -108,27 +108,27 @@ DECLARE_INSTRUCTION(MTC0)
          DebugMessage(M64MSG_ERROR, "MTC0 instruction trying to write Cause register with non-0 value");
          stop = 1;
       }
-      else g_cp0_regs[CP0_CAUSE_REG] = rrt32;
+      else g_state.regs.cp0[CP0_CAUSE_REG] = rrt32;
       break;
     case CP0_EPC_REG:
-      g_cp0_regs[CP0_EPC_REG] = rrt32;
+      g_state.regs.cp0[CP0_EPC_REG] = rrt32;
       break;
     case CP0_PREVID_REG:
       break;
     case CP0_CONFIG_REG:
-      g_cp0_regs[CP0_CONFIG_REG] = rrt32;
+      g_state.regs.cp0[CP0_CONFIG_REG] = rrt32;
       break;
     case CP0_WATCHLO_REG:
-      g_cp0_regs[CP0_WATCHLO_REG] = rrt32;
+      g_state.regs.cp0[CP0_WATCHLO_REG] = rrt32;
       break;
     case CP0_WATCHHI_REG:
-      g_cp0_regs[CP0_WATCHHI_REG] = rrt32;
+      g_state.regs.cp0[CP0_WATCHHI_REG] = rrt32;
       break;
     case CP0_TAGLO_REG:
-      g_cp0_regs[CP0_TAGLO_REG] = rrt32 & UINT32_C(0x0FFFFFC0);
+      g_state.regs.cp0[CP0_TAGLO_REG] = rrt32 & UINT32_C(0x0FFFFFC0);
       break;
     case CP0_TAGHI_REG:
-      g_cp0_regs[CP0_TAGHI_REG] = 0;
+      g_state.regs.cp0[CP0_TAGHI_REG] = 0;
       break;
     default:
       DebugMessage(M64MSG_ERROR, "Unknown MTC0 write: %d", rfs);

--- a/src/r4300/interpreter_cop1.def
+++ b/src/r4300/interpreter_cop1.def
@@ -21,22 +21,22 @@
 
 #include "fpu.h"
 
-DECLARE_JUMP(BC1F,  PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)==0, &reg[0], 0, 1)
-DECLARE_JUMP(BC1T,  PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)!=0, &reg[0], 0, 1)
-DECLARE_JUMP(BC1FL, PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)==0, &reg[0], 1, 1)
-DECLARE_JUMP(BC1TL, PCADDR + (iimmediate+1)*4, (FCR31 & FCR31_CMP_BIT)!=0, &reg[0], 1, 1)
+DECLARE_JUMP(BC1F,  PCADDR + (iimmediate+1)*4, (g_state.regs.fcr_31 & FCR31_CMP_BIT)==0, &g_state.regs.gpr[0], 0, 1)
+DECLARE_JUMP(BC1T,  PCADDR + (iimmediate+1)*4, (g_state.regs.fcr_31 & FCR31_CMP_BIT)!=0, &g_state.regs.gpr[0], 0, 1)
+DECLARE_JUMP(BC1FL, PCADDR + (iimmediate+1)*4, (g_state.regs.fcr_31 & FCR31_CMP_BIT)==0, &g_state.regs.gpr[0], 1, 1)
+DECLARE_JUMP(BC1TL, PCADDR + (iimmediate+1)*4, (g_state.regs.fcr_31 & FCR31_CMP_BIT)!=0, &g_state.regs.gpr[0], 1, 1)
 
 DECLARE_INSTRUCTION(MFC1)
 {
    if (check_cop1_unusable()) return;
-   rrt = SE32(*((int32_t*) reg_cop1_simple[rfs]));
+   rrt = SE32(*((int32_t*) g_state.regs.cp1_s[rfs]));
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DMFC1)
 {
    if (check_cop1_unusable()) return;
-   rrt = *((int64_t*) reg_cop1_double[rfs]);
+   rrt = *((int64_t*) g_state.regs.cp1_d[rfs]);
    ADD_TO_PC(1);
 }
 
@@ -45,11 +45,11 @@ DECLARE_INSTRUCTION(CFC1)
    if (check_cop1_unusable()) return;
    if (rfs==31)
    {
-      rrt32 = SE32(FCR31);
+      rrt32 = SE32(g_state.regs.fcr_31);
    }
    if (rfs==0)
    {
-      rrt32 = SE32(FCR0);
+      rrt32 = SE32(g_state.regs.fcr_0);
    }
    ADD_TO_PC(1);
 }
@@ -57,14 +57,14 @@ DECLARE_INSTRUCTION(CFC1)
 DECLARE_INSTRUCTION(MTC1)
 {
    if (check_cop1_unusable()) return;
-   *((int32_t*) reg_cop1_simple[rfs]) = rrt32;
+   *((int32_t*) g_state.regs.cp1_s[rfs]) = rrt32;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DMTC1)
 {
    if (check_cop1_unusable()) return;
-   *((int64_t*) reg_cop1_double[rfs]) = rrt;
+   *((int64_t*) g_state.regs.cp1_d[rfs]) = rrt;
    ADD_TO_PC(1);
 }
 
@@ -73,11 +73,11 @@ DECLARE_INSTRUCTION(CTC1)
    if (check_cop1_unusable()) return;
    if (rfs==31)
    {
-      FCR31 = rrt32;
+      g_state.regs.fcr_31 = rrt32;
       update_x86_rounding_mode(rrt32);
    }
-   //if ((FCR31 >> 7) & 0x1F) printf("FPU Exception enabled : %x\n",
-   //                 (int)((FCR31 >> 7) & 0x1F));
+   //if ((g_state.regs.fcr_31 >> 7) & 0x1F) printf("FPU Exception enabled : %x\n",
+   //                 (int)((g_state.regs.fcr_31 >> 7) & 0x1F));
    ADD_TO_PC(1);
 }
 
@@ -85,142 +85,142 @@ DECLARE_INSTRUCTION(CTC1)
 DECLARE_INSTRUCTION(ADD_D)
 {
    if (check_cop1_unusable()) return;
-   add_d(reg_cop1_double[cffs], reg_cop1_double[cfft], reg_cop1_double[cffd]);
+   add_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SUB_D)
 {
    if (check_cop1_unusable()) return;
-   sub_d(reg_cop1_double[cffs], reg_cop1_double[cfft], reg_cop1_double[cffd]);
+   sub_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MUL_D)
 {
    if (check_cop1_unusable()) return;
-   mul_d(reg_cop1_double[cffs], reg_cop1_double[cfft], reg_cop1_double[cffd]);
+   mul_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DIV_D)
 {
    if (check_cop1_unusable()) return;
-   if((FCR31 & UINT32_C(0x400)) && *reg_cop1_double[cfft] == 0)
+   if((g_state.regs.fcr_31 & UINT32_C(0x400)) && *g_state.regs.cp1_d[cfft] == 0)
    {
-      //FCR31 |= 0x8020;
-      /*FCR31 |= 0x8000;
+      //g_state.regs.fcr_31 |= 0x8020;
+      /*g_state.regs.fcr_31 |= 0x8000;
       Cause = 15 << 2;
       exception_general();*/
       DebugMessage(M64MSG_ERROR, "DIV_D by 0");
       //return;
    }
-   div_d(reg_cop1_double[cffs], reg_cop1_double[cfft], reg_cop1_double[cffd]);
+   div_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SQRT_D)
 {
    if (check_cop1_unusable()) return;
-   sqrt_d(reg_cop1_double[cffs], reg_cop1_double[cffd]);
+   sqrt_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ABS_D)
 {
    if (check_cop1_unusable()) return;
-   abs_d(reg_cop1_double[cffs], reg_cop1_double[cffd]);
+   abs_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MOV_D)
 {
    if (check_cop1_unusable()) return;
-   mov_d(reg_cop1_double[cffs], reg_cop1_double[cffd]);
+   mov_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(NEG_D)
 {
    if (check_cop1_unusable()) return;
-   neg_d(reg_cop1_double[cffs], reg_cop1_double[cffd]);
+   neg_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_L_D)
 {
    if (check_cop1_unusable()) return;
-   round_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
+   round_l_d(g_state.regs.cp1_d[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_L_D)
 {
    if (check_cop1_unusable()) return;
-   trunc_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
+   trunc_l_d(g_state.regs.cp1_d[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_L_D)
 {
    if (check_cop1_unusable()) return;
-   ceil_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
+   ceil_l_d(g_state.regs.cp1_d[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_L_D)
 {
    if (check_cop1_unusable()) return;
-   floor_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
+   floor_l_d(g_state.regs.cp1_d[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_W_D)
 {
    if (check_cop1_unusable()) return;
-   round_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   round_w_d(g_state.regs.cp1_d[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_W_D)
 {
    if (check_cop1_unusable()) return;
-   trunc_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   trunc_w_d(g_state.regs.cp1_d[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_W_D)
 {
    if (check_cop1_unusable()) return;
-   ceil_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   ceil_w_d(g_state.regs.cp1_d[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_W_D)
 {
    if (check_cop1_unusable()) return;
-   floor_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   floor_w_d(g_state.regs.cp1_d[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_S_D)
 {
    if (check_cop1_unusable()) return;
-   cvt_s_d(reg_cop1_double[cffs], reg_cop1_simple[cffd]);
+   cvt_s_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_W_D)
 {
    if (check_cop1_unusable()) return;
-   cvt_w_d(reg_cop1_double[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   cvt_w_d(g_state.regs.cp1_d[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_L_D)
 {
    if (check_cop1_unusable()) return;
-   cvt_l_d(reg_cop1_double[cffs], (int64_t*) reg_cop1_double[cffd]);
+   cvt_l_d(g_state.regs.cp1_d[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
@@ -234,141 +234,141 @@ DECLARE_INSTRUCTION(C_F_D)
 DECLARE_INSTRUCTION(C_UN_D)
 {
    if (check_cop1_unusable()) return;
-   c_un_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_un_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_EQ_D)
 {
    if (check_cop1_unusable()) return;
-   c_eq_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_eq_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_UEQ_D)
 {
    if (check_cop1_unusable()) return;
-   c_ueq_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_ueq_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_OLT_D)
 {
    if (check_cop1_unusable()) return;
-   c_olt_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_olt_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_ULT_D)
 {
    if (check_cop1_unusable()) return;
-   c_ult_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_ult_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_OLE_D)
 {
    if (check_cop1_unusable()) return;
-   c_ole_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_ole_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_ULE_D)
 {
    if (check_cop1_unusable()) return;
-   c_ule_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_ule_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_SF_D)
 {
-   if (isnan(*reg_cop1_double[cffs]) || isnan(*reg_cop1_double[cfft]))
+   if (isnan(*g_state.regs.cp1_d[cffs]) || isnan(*g_state.regs.cp1_d[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_sf_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_sf_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_NGLE_D)
 {
-   if (isnan(*reg_cop1_double[cffs]) || isnan(*reg_cop1_double[cfft]))
+   if (isnan(*g_state.regs.cp1_d[cffs]) || isnan(*g_state.regs.cp1_d[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_ngle_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_ngle_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_SEQ_D)
 {
-   if (isnan(*reg_cop1_double[cffs]) || isnan(*reg_cop1_double[cfft]))
+   if (isnan(*g_state.regs.cp1_d[cffs]) || isnan(*g_state.regs.cp1_d[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_seq_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_seq_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_NGL_D)
 {
-   if (isnan(*reg_cop1_double[cffs]) || isnan(*reg_cop1_double[cfft]))
+   if (isnan(*g_state.regs.cp1_d[cffs]) || isnan(*g_state.regs.cp1_d[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_ngl_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_ngl_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_LT_D)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_double[cffs]) || isnan(*reg_cop1_double[cfft]))
+   if (isnan(*g_state.regs.cp1_d[cffs]) || isnan(*g_state.regs.cp1_d[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_lt_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_lt_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_NGE_D)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_double[cffs]) || isnan(*reg_cop1_double[cfft]))
+   if (isnan(*g_state.regs.cp1_d[cffs]) || isnan(*g_state.regs.cp1_d[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_nge_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_nge_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_LE_D)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_double[cffs]) || isnan(*reg_cop1_double[cfft]))
+   if (isnan(*g_state.regs.cp1_d[cffs]) || isnan(*g_state.regs.cp1_d[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_le_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_le_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_NGT_D)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_double[cffs]) || isnan(*reg_cop1_double[cfft]))
+   if (isnan(*g_state.regs.cp1_d[cffs]) || isnan(*g_state.regs.cp1_d[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_ngt_d(reg_cop1_double[cffs], reg_cop1_double[cfft]);
+   c_ngt_d(g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cfft]);
    ADD_TO_PC(1);
 }
 
@@ -376,14 +376,14 @@ DECLARE_INSTRUCTION(C_NGT_D)
 DECLARE_INSTRUCTION(CVT_S_L)
 {
    if (check_cop1_unusable()) return;
-   cvt_s_l((int64_t*) reg_cop1_double[cffs], reg_cop1_simple[cffd]);
+   cvt_s_l((int64_t*) g_state.regs.cp1_d[cffs], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_D_L)
 {
    if (check_cop1_unusable()) return;
-   cvt_d_l((int64_t*) reg_cop1_double[cffs], reg_cop1_double[cffd]);
+   cvt_d_l((int64_t*) g_state.regs.cp1_d[cffs], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
@@ -391,137 +391,137 @@ DECLARE_INSTRUCTION(CVT_D_L)
 DECLARE_INSTRUCTION(ADD_S)
 {
    if (check_cop1_unusable()) return;
-   add_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft], reg_cop1_simple[cffd]);
+   add_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SUB_S)
 {
    if (check_cop1_unusable()) return;
-   sub_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft], reg_cop1_simple[cffd]);
+   sub_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MUL_S)
 {
    if (check_cop1_unusable()) return;
-   mul_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft], reg_cop1_simple[cffd]);
+   mul_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DIV_S)
 {  
    if (check_cop1_unusable()) return;
-   if((FCR31 & UINT32_C(0x400)) && *reg_cop1_simple[cfft] == 0)
+   if((g_state.regs.fcr_31 & UINT32_C(0x400)) && *g_state.regs.cp1_s[cfft] == 0)
    {
      DebugMessage(M64MSG_ERROR, "DIV_S by 0");
    }
-   div_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft], reg_cop1_simple[cffd]);
+   div_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SQRT_S)
 {
    if (check_cop1_unusable()) return;
-   sqrt_s(reg_cop1_simple[cffs], reg_cop1_simple[cffd]);
+   sqrt_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ABS_S)
 {
    if (check_cop1_unusable()) return;
-   abs_s(reg_cop1_simple[cffs], reg_cop1_simple[cffd]);
+   abs_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MOV_S)
 {
    if (check_cop1_unusable()) return;
-   mov_s(reg_cop1_simple[cffs], reg_cop1_simple[cffd]);
+   mov_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(NEG_S)
 {
    if (check_cop1_unusable()) return;
-   neg_s(reg_cop1_simple[cffs], reg_cop1_simple[cffd]);
+   neg_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_L_S)
 {
    if (check_cop1_unusable()) return;
-   round_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
+   round_l_s(g_state.regs.cp1_s[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_L_S)
 {
    if (check_cop1_unusable()) return;
-   trunc_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
+   trunc_l_s(g_state.regs.cp1_s[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_L_S)
 {
    if (check_cop1_unusable()) return;
-   ceil_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
+   ceil_l_s(g_state.regs.cp1_s[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_L_S)
 {
    if (check_cop1_unusable()) return;
-   floor_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
+   floor_l_s(g_state.regs.cp1_s[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_W_S)
 {
    if (check_cop1_unusable()) return;
-   round_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   round_w_s(g_state.regs.cp1_s[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_W_S)
 {
    if (check_cop1_unusable()) return;
-   trunc_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   trunc_w_s(g_state.regs.cp1_s[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_W_S)
 {
    if (check_cop1_unusable()) return;
-   ceil_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   ceil_w_s(g_state.regs.cp1_s[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_W_S)
 {
    if (check_cop1_unusable()) return;
-   floor_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   floor_w_s(g_state.regs.cp1_s[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_D_S)
 {
    if (check_cop1_unusable()) return;
-   cvt_d_s(reg_cop1_simple[cffs], reg_cop1_double[cffd]);
+   cvt_d_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_W_S)
 {
    if (check_cop1_unusable()) return;
-   cvt_w_s(reg_cop1_simple[cffs], (int32_t*) reg_cop1_simple[cffd]);
+   cvt_w_s(g_state.regs.cp1_s[cffs], (int32_t*) g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_L_S)
 {
    if (check_cop1_unusable()) return;
-   cvt_l_s(reg_cop1_simple[cffs], (int64_t*) reg_cop1_double[cffd]);
+   cvt_l_s(g_state.regs.cp1_s[cffs], (int64_t*) g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }
 
@@ -535,145 +535,145 @@ DECLARE_INSTRUCTION(C_F_S)
 DECLARE_INSTRUCTION(C_UN_S)
 {
    if (check_cop1_unusable()) return;
-   c_un_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_un_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_EQ_S)
 {
    if (check_cop1_unusable()) return;
-   c_eq_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_eq_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_UEQ_S)
 {
    if (check_cop1_unusable()) return;
-   c_ueq_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_ueq_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_OLT_S)
 {
    if (check_cop1_unusable()) return;
-   c_olt_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_olt_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_ULT_S)
 {
    if (check_cop1_unusable()) return;
-   c_ult_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_ult_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_OLE_S)
 {
    if (check_cop1_unusable()) return;
-   c_ole_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_ole_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_ULE_S)
 {
    if (check_cop1_unusable()) return;
-   c_ule_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_ule_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_SF_S)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_simple[cffs]) || isnan(*reg_cop1_simple[cfft]))
+   if (isnan(*g_state.regs.cp1_s[cffs]) || isnan(*g_state.regs.cp1_s[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_sf_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_sf_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_NGLE_S)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_simple[cffs]) || isnan(*reg_cop1_simple[cfft]))
+   if (isnan(*g_state.regs.cp1_s[cffs]) || isnan(*g_state.regs.cp1_s[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_ngle_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_ngle_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_SEQ_S)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_simple[cffs]) || isnan(*reg_cop1_simple[cfft]))
+   if (isnan(*g_state.regs.cp1_s[cffs]) || isnan(*g_state.regs.cp1_s[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_seq_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_seq_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_NGL_S)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_simple[cffs]) || isnan(*reg_cop1_simple[cfft]))
+   if (isnan(*g_state.regs.cp1_s[cffs]) || isnan(*g_state.regs.cp1_s[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_ngl_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_ngl_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_LT_S)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_simple[cffs]) || isnan(*reg_cop1_simple[cfft]))
+   if (isnan(*g_state.regs.cp1_s[cffs]) || isnan(*g_state.regs.cp1_s[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_lt_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_lt_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_NGE_S)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_simple[cffs]) || isnan(*reg_cop1_simple[cfft]))
+   if (isnan(*g_state.regs.cp1_s[cffs]) || isnan(*g_state.regs.cp1_s[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_nge_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_nge_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_LE_S)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_simple[cffs]) || isnan(*reg_cop1_simple[cfft]))
+   if (isnan(*g_state.regs.cp1_s[cffs]) || isnan(*g_state.regs.cp1_s[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_le_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_le_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_NGT_S)
 {
    if (check_cop1_unusable()) return;
-   if (isnan(*reg_cop1_simple[cffs]) || isnan(*reg_cop1_simple[cfft]))
+   if (isnan(*g_state.regs.cp1_s[cffs]) || isnan(*g_state.regs.cp1_s[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
      stop=1;
    }
-   c_ngt_s(reg_cop1_simple[cffs], reg_cop1_simple[cfft]);
+   c_ngt_s(g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cfft]);
    ADD_TO_PC(1);
 }
 
@@ -681,13 +681,13 @@ DECLARE_INSTRUCTION(C_NGT_S)
 DECLARE_INSTRUCTION(CVT_S_W)
 {  
    if (check_cop1_unusable()) return;
-   cvt_s_w((int32_t*) reg_cop1_simple[cffs], reg_cop1_simple[cffd]);
+   cvt_s_w((int32_t*) g_state.regs.cp1_s[cffs], g_state.regs.cp1_s[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_D_W)
 {
    if (check_cop1_unusable()) return;
-   cvt_d_w((int32_t*) reg_cop1_simple[cffs], reg_cop1_double[cffd]);
+   cvt_d_w((int32_t*) g_state.regs.cp1_s[cffs], g_state.regs.cp1_d[cffd]);
    ADD_TO_PC(1);
 }

--- a/src/r4300/interpreter_r4300.def
+++ b/src/r4300/interpreter_r4300.def
@@ -19,12 +19,12 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-DECLARE_JUMP(J,   (jinst_index<<2) | ((PCADDR+4) & UINT32_C(0xF0000000)), 1, &reg[0],  0, 0)
-DECLARE_JUMP(JAL, (jinst_index<<2) | ((PCADDR+4) & UINT32_C(0xF0000000)), 1, &reg[31], 0, 0)
-DECLARE_JUMP(BEQ,     PCADDR + (iimmediate+1)*4, irs == irt, &reg[0], 0, 0)
-DECLARE_JUMP(BNE,     PCADDR + (iimmediate+1)*4, irs != irt, &reg[0], 0, 0)
-DECLARE_JUMP(BLEZ,    PCADDR + (iimmediate+1)*4, irs <= 0,   &reg[0], 0, 0)
-DECLARE_JUMP(BGTZ,    PCADDR + (iimmediate+1)*4, irs > 0,    &reg[0], 0, 0)
+DECLARE_JUMP(J,   (jinst_index<<2) | ((PCADDR+4) & UINT32_C(0xF0000000)), 1, &g_state.regs.gpr[0],  0, 0)
+DECLARE_JUMP(JAL, (jinst_index<<2) | ((PCADDR+4) & UINT32_C(0xF0000000)), 1, &g_state.regs.gpr[31], 0, 0)
+DECLARE_JUMP(BEQ,     PCADDR + (iimmediate+1)*4, irs == irt, &g_state.regs.gpr[0], 0, 0)
+DECLARE_JUMP(BNE,     PCADDR + (iimmediate+1)*4, irs != irt, &g_state.regs.gpr[0], 0, 0)
+DECLARE_JUMP(BLEZ,    PCADDR + (iimmediate+1)*4, irs <= 0,   &g_state.regs.gpr[0], 0, 0)
+DECLARE_JUMP(BGTZ,    PCADDR + (iimmediate+1)*4, irs > 0,    &g_state.regs.gpr[0], 0, 0)
 
 DECLARE_INSTRUCTION(ADDI)
 {
@@ -77,10 +77,10 @@ DECLARE_INSTRUCTION(LUI)
    ADD_TO_PC(1);
 }
 
-DECLARE_JUMP(BEQL,    PCADDR + (iimmediate+1)*4, irs == irt, &reg[0], 1, 0)
-DECLARE_JUMP(BNEL,    PCADDR + (iimmediate+1)*4, irs != irt, &reg[0], 1, 0)
-DECLARE_JUMP(BLEZL,   PCADDR + (iimmediate+1)*4, irs <= 0,   &reg[0], 1, 0)
-DECLARE_JUMP(BGTZL,   PCADDR + (iimmediate+1)*4, irs > 0,    &reg[0], 1, 0)
+DECLARE_JUMP(BEQL,    PCADDR + (iimmediate+1)*4, irs == irt, &g_state.regs.gpr[0], 1, 0)
+DECLARE_JUMP(BNEL,    PCADDR + (iimmediate+1)*4, irs != irt, &g_state.regs.gpr[0], 1, 0)
+DECLARE_JUMP(BLEZL,   PCADDR + (iimmediate+1)*4, irs <= 0,   &g_state.regs.gpr[0], 1, 0)
+DECLARE_JUMP(BGTZL,   PCADDR + (iimmediate+1)*4, irs > 0,    &g_state.regs.gpr[0], 1, 0)
 
 DECLARE_INSTRUCTION(DADDI)
 {
@@ -120,21 +120,21 @@ DECLARE_INSTRUCTION(DADDIU)
 DECLARE_INSTRUCTION(LDL)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    uint64_t word = 0;
    ADD_TO_PC(1);
    if ((lsaddr & 7) == 0)
    {
-     address = lsaddr;
-     rdword = (uint64_t*) lsrtp;
+     g_state.access_addr = lsaddr;
+     g_state.read_dest = lsrtp;
      read_dword_in_memory();
    }
    else
    {
-     address = lsaddr & UINT32_C(0xFFFFFFF8);
-     rdword = &word;
+     g_state.access_addr = lsaddr & UINT32_C(0xFFFFFFF8);
+     g_state.read_dest = &word;
      read_dword_in_memory();
-     if (address)
+     if (g_state.access_addr)
      {
        /* How many low bits do we want to preserve from the old value? */
        uint64_t old_mask = BITS_BELOW_MASK64((lsaddr & 7) * 8);
@@ -148,20 +148,20 @@ DECLARE_INSTRUCTION(LDL)
 DECLARE_INSTRUCTION(LDR)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    uint64_t word = 0;
    ADD_TO_PC(1);
-   address = lsaddr & UINT32_C(0xFFFFFFF8);
+   g_state.access_addr = lsaddr & UINT32_C(0xFFFFFFF8);
    if ((lsaddr & 7) == 7)
    {
-     rdword = (uint64_t*) lsrtp;
+     g_state.read_dest = lsrtp;
      read_dword_in_memory();
    }
    else
    {
-     rdword = &word;
+     g_state.read_dest = &word;
      read_dword_in_memory();
-     if (address)
+     if (g_state.access_addr)
      {
        /* How many high bits do we want to preserve from the old value? */
        uint64_t old_mask = BITS_ABOVE_MASK64(((lsaddr & 7) + 1) * 8);
@@ -175,47 +175,47 @@ DECLARE_INSTRUCTION(LDR)
 DECLARE_INSTRUCTION(LB)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   rdword = (uint64_t*) lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.read_dest = lsrtp;
    read_byte_in_memory();
-   if (address)
+   if (g_state.access_addr)
      *lsrtp = SE8(*lsrtp);
 }
 
 DECLARE_INSTRUCTION(LH)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   rdword = (uint64_t*) lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.read_dest = lsrtp;
    read_hword_in_memory();
-   if (address)
+   if (g_state.access_addr)
      *lsrtp = SE16(*lsrtp);
 }
 
 DECLARE_INSTRUCTION(LWL)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    uint64_t word = 0;
    ADD_TO_PC(1);
    if ((lsaddr & 3) == 0)
    {
-     address = lsaddr;
-     rdword = (uint64_t*) lsrtp;
+     g_state.access_addr = lsaddr;
+     g_state.read_dest = lsrtp;
      read_word_in_memory();
-     if (address)
+     if (g_state.access_addr)
        *lsrtp = SE32(*lsrtp);
    }
    else
    {
-     address = lsaddr & UINT32_C(0xFFFFFFFC);
-     rdword = &word;
+     g_state.access_addr = lsaddr & UINT32_C(0xFFFFFFFC);
+     g_state.read_dest = &word;
      read_word_in_memory();
-     if (address)
+     if (g_state.access_addr)
      {
        /* How many low bits do we want to preserve from the old value? */
        uint32_t old_mask = BITS_BELOW_MASK32((lsaddr & 3) * 8);
@@ -229,54 +229,54 @@ DECLARE_INSTRUCTION(LWL)
 DECLARE_INSTRUCTION(LW)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   rdword = (uint64_t*) lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.read_dest = lsrtp;
    read_word_in_memory();
-   if (address)
+   if (g_state.access_addr)
      *lsrtp = SE32(*lsrtp);
 }
 
 DECLARE_INSTRUCTION(LBU)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   rdword = (uint64_t*) lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.read_dest = lsrtp;
    read_byte_in_memory();
 }
 
 DECLARE_INSTRUCTION(LHU)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   rdword = (uint64_t*) lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.read_dest = lsrtp;
    read_hword_in_memory();
 }
 
 DECLARE_INSTRUCTION(LWR)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    uint64_t word = 0;
    ADD_TO_PC(1);
-   address = lsaddr & UINT32_C(0xFFFFFFFC);
+   g_state.access_addr = lsaddr & UINT32_C(0xFFFFFFFC);
    if ((lsaddr & 3) == 3)
    {
-     rdword = (uint64_t*) lsrtp;
+     g_state.read_dest = lsrtp;
      read_word_in_memory();
-     if (address)
+     if (g_state.access_addr)
        *lsrtp = SE32(*lsrtp);
    }
    else
    {
-     rdword = &word;
+     g_state.read_dest = &word;
      read_word_in_memory();
-     if (address)
+     if (g_state.access_addr)
      {
        /* How many high bits do we want to preserve from the old value? */
        uint32_t old_mask = BITS_ABOVE_MASK32(((lsaddr & 3) + 1) * 8);
@@ -290,20 +290,20 @@ DECLARE_INSTRUCTION(LWR)
 DECLARE_INSTRUCTION(LWU)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   rdword = (uint64_t*) lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.read_dest = lsrtp;
    read_word_in_memory();
 }
 
 DECLARE_INSTRUCTION(SB)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   cpu_byte = (uint8_t) *lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.write.b = (uint8_t) *lsrtp;
    write_byte_in_memory();
    CHECK_MEMORY();
 }
@@ -311,10 +311,10 @@ DECLARE_INSTRUCTION(SB)
 DECLARE_INSTRUCTION(SH)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   cpu_hword = (uint16_t) *lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.write.h = (uint16_t) *lsrtp;
    write_hword_in_memory();
    CHECK_MEMORY();
 }
@@ -322,22 +322,22 @@ DECLARE_INSTRUCTION(SH)
 DECLARE_INSTRUCTION(SWL)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    uint64_t old_word = 0;
    ADD_TO_PC(1);
    if ((lsaddr & 3) == 0)
    {
-     address = lsaddr;
-     cpu_word = (uint32_t) *lsrtp;
+     g_state.access_addr = lsaddr;
+     g_state.write.w = (uint32_t) *lsrtp;
      write_word_in_memory();
      CHECK_MEMORY();
    }
    else
    {
-     address = lsaddr & UINT32_C(0xFFFFFFFC);
-     rdword = &old_word;
+     g_state.access_addr = lsaddr & UINT32_C(0xFFFFFFFC);
+     g_state.read_dest = &old_word;
      read_word_in_memory();
-     if (address)
+     if (g_state.access_addr)
      {
        /* How many high bits do we want to preserve from what was in memory
         * before? */
@@ -345,7 +345,7 @@ DECLARE_INSTRUCTION(SWL)
        /* How many bits down do we need to shift the register to store some
         * of its high bits into the low bits of the memory word? */
        int new_shift = (lsaddr & 3) * 8;
-       cpu_word = ((uint32_t) old_word & old_mask) | ((uint32_t) *lsrtp >> new_shift);
+       g_state.write.w = ((uint32_t) old_word & old_mask) | ((uint32_t) *lsrtp >> new_shift);
        write_word_in_memory();
        CHECK_MEMORY();
      }
@@ -355,10 +355,10 @@ DECLARE_INSTRUCTION(SWL)
 DECLARE_INSTRUCTION(SW)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   cpu_word = (uint32_t) *lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.write.w = (uint32_t) *lsrtp;
    write_word_in_memory();
    CHECK_MEMORY();
 }
@@ -366,22 +366,22 @@ DECLARE_INSTRUCTION(SW)
 DECLARE_INSTRUCTION(SDL)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    uint64_t old_word = 0;
    ADD_TO_PC(1);
    if ((lsaddr & 7) == 0)
    {
-     address = lsaddr;
-     cpu_dword = *lsrtp;
+     g_state.access_addr = lsaddr;
+     g_state.write.d = *lsrtp;
      write_dword_in_memory();
      CHECK_MEMORY();
    }
    else
    {
-     address = lsaddr & UINT32_C(0xFFFFFFF8);
-     rdword = &old_word;
+     g_state.access_addr = lsaddr & UINT32_C(0xFFFFFFF8);
+     g_state.read_dest = &old_word;
      read_dword_in_memory();
-     if (address)
+     if (g_state.access_addr)
      {
        /* How many high bits do we want to preserve from what was in memory
         * before? */
@@ -389,7 +389,7 @@ DECLARE_INSTRUCTION(SDL)
        /* How many bits down do we need to shift the register to store some
         * of its high bits into the low bits of the memory word? */
        int new_shift = (lsaddr & 7) * 8;
-       cpu_dword = (old_word & old_mask) | ((uint64_t) *lsrtp >> new_shift);
+       g_state.write.d = (old_word & old_mask) | ((uint64_t) *lsrtp >> new_shift);
        write_dword_in_memory();
        CHECK_MEMORY();
      }
@@ -399,21 +399,21 @@ DECLARE_INSTRUCTION(SDL)
 DECLARE_INSTRUCTION(SDR)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    uint64_t old_word = 0;
    ADD_TO_PC(1);
-   address = lsaddr & UINT32_C(0xFFFFFFF8);
+   g_state.access_addr = lsaddr & UINT32_C(0xFFFFFFF8);
    if ((lsaddr & 7) == 7)
    {
-     cpu_dword = *lsrtp;
+     g_state.write.d = *lsrtp;
      write_dword_in_memory();
      CHECK_MEMORY();
    }
    else
    {
-     rdword = &old_word;
+     g_state.read_dest = &old_word;
      read_dword_in_memory();
-     if (address)
+     if (g_state.access_addr)
      {
        /* How many low bits do we want to preserve from what was in memory
         * before? */
@@ -421,7 +421,7 @@ DECLARE_INSTRUCTION(SDR)
        /* How many bits up do we need to shift the register to store some
         * of its low bits into the high bits of the memory word? */
        int new_shift = (7 - (lsaddr & 7)) * 8;
-       cpu_dword = (old_word & old_mask) | (*lsrtp << new_shift);
+       g_state.write.d = (old_word & old_mask) | (*lsrtp << new_shift);
        write_dword_in_memory();
        CHECK_MEMORY();
      }
@@ -431,21 +431,21 @@ DECLARE_INSTRUCTION(SDR)
 DECLARE_INSTRUCTION(SWR)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    uint64_t old_word = 0;
    ADD_TO_PC(1);
-   address = lsaddr & UINT32_C(0xFFFFFFFC);
+   g_state.access_addr = lsaddr & UINT32_C(0xFFFFFFFC);
    if ((lsaddr & 3) == 3)
    {
-     cpu_word = (uint32_t) *lsrtp;
+     g_state.write.w = (uint32_t) *lsrtp;
      write_word_in_memory();
      CHECK_MEMORY();
    }
    else
    {
-     rdword = &old_word;
+     g_state.read_dest = &old_word;
      read_word_in_memory();
-     if (address)
+     if (g_state.access_addr)
      {
        /* How many low bits do we want to preserve from what was in memory
         * before? */
@@ -453,7 +453,7 @@ DECLARE_INSTRUCTION(SWR)
        /* How many bits up do we need to shift the register to store some
         * of its low bits into the high bits of the memory word? */
        int new_shift = (3 - (lsaddr & 3)) * 8;
-       cpu_word = ((uint32_t) old_word & old_mask) | ((uint32_t) *lsrtp << new_shift);
+       g_state.write.w = ((uint32_t) old_word & old_mask) | ((uint32_t) *lsrtp << new_shift);
        write_word_in_memory();
        CHECK_MEMORY();
      }
@@ -468,65 +468,65 @@ DECLARE_INSTRUCTION(CACHE)
 DECLARE_INSTRUCTION(LL)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   rdword = (uint64_t*) lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.read_dest = lsrtp;
    read_word_in_memory();
-   if (address)
+   if (g_state.access_addr)
      {
     *lsrtp = SE32(*lsrtp);
-    llbit = 1;
+    g_state.regs.ll_bit = 1;
      }
 }
 
 DECLARE_INSTRUCTION(LWC1)
 {
    const unsigned char lslfft = lfft;
-   const uint32_t lslfaddr = (uint32_t) reg[lfbase] + lfoffset;
+   const uint32_t lslfaddr = (uint32_t) g_state.regs.gpr[lfbase] + lfoffset;
    uint64_t temp;
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
-   address = lslfaddr;
-   rdword = &temp;
+   g_state.access_addr = lslfaddr;
+   g_state.read_dest = &temp;
    read_word_in_memory();
-   if (address)
-     *((uint32_t*) reg_cop1_simple[lslfft]) = (uint32_t) *rdword;
+   if (g_state.access_addr)
+     *((uint32_t*) g_state.regs.cp1_s[lslfft]) = (uint32_t) temp;
 }
 
 DECLARE_INSTRUCTION(LDC1)
 {
    const unsigned char lslfft = lfft;
-   const uint32_t lslfaddr = (uint32_t) reg[lfbase] + lfoffset;
+   const uint32_t lslfaddr = (uint32_t) g_state.regs.gpr[lfbase] + lfoffset;
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
-   address = lslfaddr;
-   rdword = (uint64_t*) reg_cop1_double[lslfft];
+   g_state.access_addr = lslfaddr;
+   g_state.read_dest = (uint64_t*) g_state.regs.cp1_d[lslfft];
    read_dword_in_memory();
 }
 
 DECLARE_INSTRUCTION(LD)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   rdword = (uint64_t*) lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.read_dest = lsrtp;
    read_dword_in_memory();
 }
 
 DECLARE_INSTRUCTION(SC)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   if(llbit)
+   if (g_state.regs.ll_bit)
    {
-      address = lsaddr;
-      cpu_word = (uint32_t) *lsrtp;
+      g_state.access_addr = lsaddr;
+      g_state.write.w = (uint32_t) *lsrtp;
       write_word_in_memory();
       CHECK_MEMORY();
-      llbit = 0;
+      g_state.regs.ll_bit = 0;
       *lsrtp = 1;
    }
    else
@@ -538,11 +538,11 @@ DECLARE_INSTRUCTION(SC)
 DECLARE_INSTRUCTION(SWC1)
 {
    const unsigned char lslfft = lfft;
-   const uint32_t lslfaddr = (uint32_t) reg[lfbase] + lfoffset;
+   const uint32_t lslfaddr = (uint32_t) g_state.regs.gpr[lfbase] + lfoffset;
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
-   address = lslfaddr;
-   cpu_word = *((uint32_t*) reg_cop1_simple[lslfft]);
+   g_state.access_addr = lslfaddr;
+   g_state.write.w = *((uint32_t*) g_state.regs.cp1_s[lslfft]);
    write_word_in_memory();
    CHECK_MEMORY();
 }
@@ -550,11 +550,11 @@ DECLARE_INSTRUCTION(SWC1)
 DECLARE_INSTRUCTION(SDC1)
 {
    const unsigned char lslfft = lfft;
-   const uint32_t lslfaddr = (uint32_t) reg[lfbase] + lfoffset;
+   const uint32_t lslfaddr = (uint32_t) g_state.regs.gpr[lfbase] + lfoffset;
    if (check_cop1_unusable()) return;
    ADD_TO_PC(1);
-   address = lslfaddr;
-   cpu_dword = *((uint64_t*) reg_cop1_double[lslfft]);
+   g_state.access_addr = lslfaddr;
+   g_state.write.d = *((uint64_t*) g_state.regs.cp1_d[lslfft]);
    write_dword_in_memory();
    CHECK_MEMORY();
 }
@@ -562,10 +562,10 @@ DECLARE_INSTRUCTION(SDC1)
 DECLARE_INSTRUCTION(SD)
 {
    const uint32_t lsaddr = irs32 + iimmediate;
-   int64_t *lsrtp = &irt;
+   uint64_t *lsrtp = (uint64_t*) &irt;
    ADD_TO_PC(1);
-   address = lsaddr;
-   cpu_dword = *lsrtp;
+   g_state.access_addr = lsaddr;
+   g_state.write.d = *lsrtp;
    write_dword_in_memory();
    CHECK_MEMORY();
 }

--- a/src/r4300/interpreter_regimm.def
+++ b/src/r4300/interpreter_regimm.def
@@ -19,11 +19,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-DECLARE_JUMP(BLTZ,    PCADDR + (iimmediate+1)*4, irs < 0,    &reg[0],  0, 0)
-DECLARE_JUMP(BGEZ,    PCADDR + (iimmediate+1)*4, irs >= 0,   &reg[0],  0, 0)
-DECLARE_JUMP(BLTZL,   PCADDR + (iimmediate+1)*4, irs < 0,    &reg[0],  1, 0)
-DECLARE_JUMP(BGEZL,   PCADDR + (iimmediate+1)*4, irs >= 0,   &reg[0],  1, 0)
-DECLARE_JUMP(BLTZAL,  PCADDR + (iimmediate+1)*4, irs < 0,    &reg[31], 0, 0)
-DECLARE_JUMP(BGEZAL,  PCADDR + (iimmediate+1)*4, irs >= 0,   &reg[31], 0, 0)
-DECLARE_JUMP(BLTZALL, PCADDR + (iimmediate+1)*4, irs < 0,    &reg[31], 1, 0)
-DECLARE_JUMP(BGEZALL, PCADDR + (iimmediate+1)*4, irs >= 0,   &reg[31], 1, 0)
+DECLARE_JUMP(BLTZ,    PCADDR + (iimmediate+1)*4, irs < 0,    &g_state.regs.gpr[0],  0, 0)
+DECLARE_JUMP(BGEZ,    PCADDR + (iimmediate+1)*4, irs >= 0,   &g_state.regs.gpr[0],  0, 0)
+DECLARE_JUMP(BLTZL,   PCADDR + (iimmediate+1)*4, irs < 0,    &g_state.regs.gpr[0],  1, 0)
+DECLARE_JUMP(BGEZL,   PCADDR + (iimmediate+1)*4, irs >= 0,   &g_state.regs.gpr[0],  1, 0)
+DECLARE_JUMP(BLTZAL,  PCADDR + (iimmediate+1)*4, irs < 0,    &g_state.regs.gpr[31], 0, 0)
+DECLARE_JUMP(BGEZAL,  PCADDR + (iimmediate+1)*4, irs >= 0,   &g_state.regs.gpr[31], 0, 0)
+DECLARE_JUMP(BLTZALL, PCADDR + (iimmediate+1)*4, irs < 0,    &g_state.regs.gpr[31], 1, 0)
+DECLARE_JUMP(BGEZALL, PCADDR + (iimmediate+1)*4, irs >= 0,   &g_state.regs.gpr[31], 1, 0)

--- a/src/r4300/interpreter_special.def
+++ b/src/r4300/interpreter_special.def
@@ -60,12 +60,12 @@ DECLARE_INSTRUCTION(SRAV)
    ADD_TO_PC(1);
 }
 
-DECLARE_JUMP(JR,   irs32, 1, &reg[0], 0, 0)
+DECLARE_JUMP(JR,   irs32, 1, &g_state.regs.gpr[0], 0, 0)
 DECLARE_JUMP(JALR, irs32, 1, &rrd,    0, 0)
 
 DECLARE_INSTRUCTION(SYSCALL)
 {
-   g_cp0_regs[CP0_CAUSE_REG] = UINT32_C(8) << 2;
+   g_state.regs.cp0[CP0_CAUSE_REG] = UINT32_C(8) << 2;
    exception_general();
 }
 
@@ -76,25 +76,25 @@ DECLARE_INSTRUCTION(SYNC)
 
 DECLARE_INSTRUCTION(MFHI)
 {
-   rrd = hi;
+   rrd = g_state.regs.hi;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MTHI)
 {
-   hi = rrs;
+   g_state.regs.hi = rrs;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MFLO)
 {
-   rrd = lo;
+   rrd = g_state.regs.lo;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MTLO)
 {
-   lo = rrs;
+   g_state.regs.lo = rrs;
    ADD_TO_PC(1);
 }
 
@@ -120,8 +120,8 @@ DECLARE_INSTRUCTION(MULT)
 {
    int64_t temp;
    temp = rrs * rrt;
-   hi = temp >> 32;
-   lo = SE32(temp);
+   g_state.regs.hi = temp >> 32;
+   g_state.regs.lo = SE32(temp);
    ADD_TO_PC(1);
 }
 
@@ -129,8 +129,8 @@ DECLARE_INSTRUCTION(MULTU)
 {
    uint64_t temp;
    temp = (uint32_t) rrs * (uint64_t) ((uint32_t) rrt);
-   hi = (int64_t) temp >> 32;
-   lo = SE32(temp);
+   g_state.regs.hi = (int64_t) temp >> 32;
+   g_state.regs.lo = SE32(temp);
    ADD_TO_PC(1);
 }
 
@@ -138,8 +138,8 @@ DECLARE_INSTRUCTION(DIV)
 {
    if (rrt32)
    {
-     lo = SE32(rrs32 / rrt32);
-     hi = SE32(rrs32 % rrt32);
+     g_state.regs.lo = SE32(rrs32 / rrt32);
+     g_state.regs.hi = SE32(rrs32 % rrt32);
    }
    else DebugMessage(M64MSG_ERROR, "DIV: divide by 0");
    ADD_TO_PC(1);
@@ -149,8 +149,8 @@ DECLARE_INSTRUCTION(DIVU)
 {
    if (rrt32)
    {
-     lo = SE32((uint32_t) rrs32 / (uint32_t) rrt32);
-     hi = SE32((uint32_t) rrs32 % (uint32_t) rrt32);
+     g_state.regs.lo = SE32((uint32_t) rrs32 / (uint32_t) rrt32);
+     g_state.regs.hi = SE32((uint32_t) rrs32 % (uint32_t) rrt32);
    }
    else DebugMessage(M64MSG_ERROR, "DIVU: divide by 0");
    ADD_TO_PC(1);
@@ -191,13 +191,13 @@ DECLARE_INSTRUCTION(DMULT)
    result3 = (result2 >> 32) + temp4;
    result4 = (result3 >> 32);
    
-   lo = result1 | (result2 << 32);
-   hi = (result3 & UINT64_C(0xFFFFFFFF)) | (result4 << 32);
+   g_state.regs.lo = result1 | (result2 << 32);
+   g_state.regs.hi = (result3 & UINT64_C(0xFFFFFFFF)) | (result4 << 32);
    if (sign)
      {
-    hi = ~hi;
-    if (!lo) hi++;
-    else lo = ~lo + 1;
+    g_state.regs.hi = ~g_state.regs.hi;
+    if (!g_state.regs.lo) g_state.regs.hi++;
+    else g_state.regs.lo = ~g_state.regs.lo + 1;
      }
    ADD_TO_PC(1);
 }
@@ -223,8 +223,8 @@ DECLARE_INSTRUCTION(DMULTU)
    result3 = (result2 >> 32) + temp4;
    result4 = (result3 >> 32);
    
-   lo = result1 | (result2 << 32);
-   hi = (result3 & UINT64_C(0xFFFFFFFF)) | (result4 << 32);
+   g_state.regs.lo = result1 | (result2 << 32);
+   g_state.regs.hi = (result3 & UINT64_C(0xFFFFFFFF)) | (result4 << 32);
    
    ADD_TO_PC(1);
 }
@@ -233,8 +233,8 @@ DECLARE_INSTRUCTION(DDIV)
 {
    if (rrt)
    {
-     lo = rrs / rrt;
-     hi = rrs % rrt;
+     g_state.regs.lo = rrs / rrt;
+     g_state.regs.hi = rrs % rrt;
    }
    else DebugMessage(M64MSG_ERROR, "DDIV: divide by 0");
    ADD_TO_PC(1);
@@ -244,8 +244,8 @@ DECLARE_INSTRUCTION(DDIVU)
 {
    if (rrt)
    {
-     lo = (uint64_t) rrs / (uint64_t) rrt;
-     hi = (uint64_t) rrs % (uint64_t) rrt;
+     g_state.regs.lo = (uint64_t) rrs / (uint64_t) rrt;
+     g_state.regs.hi = (uint64_t) rrs % (uint64_t) rrt;
    }
    else DebugMessage(M64MSG_ERROR, "DDIVU: divide by 0");
    ADD_TO_PC(1);

--- a/src/r4300/interpreter_tlb.def
+++ b/src/r4300/interpreter_tlb.def
@@ -24,13 +24,13 @@
 DECLARE_INSTRUCTION(TLBR)
 {
    int index;
-   index = g_cp0_regs[CP0_INDEX_REG] & UINT32_C(0x1F);
-   g_cp0_regs[CP0_PAGEMASK_REG] = tlb_e[index].mask << 13;
-   g_cp0_regs[CP0_ENTRYHI_REG] = ((tlb_e[index].vpn2 << 13) | tlb_e[index].asid);
-   g_cp0_regs[CP0_ENTRYLO0_REG] = (tlb_e[index].pfn_even << 6) | (tlb_e[index].c_even << 3)
+   index = g_state.regs.cp0[CP0_INDEX_REG] & UINT32_C(0x1F);
+   g_state.regs.cp0[CP0_PAGEMASK_REG] = tlb_e[index].mask << 13;
+   g_state.regs.cp0[CP0_ENTRYHI_REG] = ((tlb_e[index].vpn2 << 13) | tlb_e[index].asid);
+   g_state.regs.cp0[CP0_ENTRYLO0_REG] = (tlb_e[index].pfn_even << 6) | (tlb_e[index].c_even << 3)
      | (tlb_e[index].d_even << 2) | (tlb_e[index].v_even << 1)
        | tlb_e[index].g;
-   g_cp0_regs[CP0_ENTRYLO1_REG] = (tlb_e[index].pfn_odd << 6) | (tlb_e[index].c_odd << 3)
+   g_state.regs.cp0[CP0_ENTRYLO1_REG] = (tlb_e[index].pfn_odd << 6) | (tlb_e[index].c_odd << 3)
      | (tlb_e[index].d_odd << 2) | (tlb_e[index].v_odd << 1)
        | tlb_e[index].g;
    ADD_TO_PC(1);
@@ -107,19 +107,19 @@ static void TLBWrite(unsigned int idx)
 
    tlb_unmap(&tlb_e[idx]);
 
-   tlb_e[idx].g = (g_cp0_regs[CP0_ENTRYLO0_REG] & g_cp0_regs[CP0_ENTRYLO1_REG] & 1);
-   tlb_e[idx].pfn_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x3FFFFFC0)) >> 6;
-   tlb_e[idx].pfn_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & UINT32_C(0x3FFFFFC0)) >> 6;
-   tlb_e[idx].c_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x38)) >> 3;
-   tlb_e[idx].c_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & UINT32_C(0x38)) >> 3;
-   tlb_e[idx].d_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x4)) >> 2;
-   tlb_e[idx].d_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & UINT32_C(0x4)) >> 2;
-   tlb_e[idx].v_even = (g_cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x2)) >> 1;
-   tlb_e[idx].v_odd = (g_cp0_regs[CP0_ENTRYLO1_REG] & UINT32_C(0x2)) >> 1;
-   tlb_e[idx].asid = (g_cp0_regs[CP0_ENTRYHI_REG] & UINT32_C(0xFF));
-   tlb_e[idx].vpn2 = (g_cp0_regs[CP0_ENTRYHI_REG] & UINT32_C(0xFFFFE000)) >> 13;
-   //tlb_e[idx].r = (g_cp0_regs[CP0_ENTRYHI_REG] & 0xC000000000000000LL) >> 62;
-   tlb_e[idx].mask = (g_cp0_regs[CP0_PAGEMASK_REG] & UINT32_C(0x1FFE000)) >> 13;
+   tlb_e[idx].g = (g_state.regs.cp0[CP0_ENTRYLO0_REG] & g_state.regs.cp0[CP0_ENTRYLO1_REG] & 1);
+   tlb_e[idx].pfn_even = (g_state.regs.cp0[CP0_ENTRYLO0_REG] & UINT32_C(0x3FFFFFC0)) >> 6;
+   tlb_e[idx].pfn_odd = (g_state.regs.cp0[CP0_ENTRYLO1_REG] & UINT32_C(0x3FFFFFC0)) >> 6;
+   tlb_e[idx].c_even = (g_state.regs.cp0[CP0_ENTRYLO0_REG] & UINT32_C(0x38)) >> 3;
+   tlb_e[idx].c_odd = (g_state.regs.cp0[CP0_ENTRYLO1_REG] & UINT32_C(0x38)) >> 3;
+   tlb_e[idx].d_even = (g_state.regs.cp0[CP0_ENTRYLO0_REG] & UINT32_C(0x4)) >> 2;
+   tlb_e[idx].d_odd = (g_state.regs.cp0[CP0_ENTRYLO1_REG] & UINT32_C(0x4)) >> 2;
+   tlb_e[idx].v_even = (g_state.regs.cp0[CP0_ENTRYLO0_REG] & UINT32_C(0x2)) >> 1;
+   tlb_e[idx].v_odd = (g_state.regs.cp0[CP0_ENTRYLO1_REG] & UINT32_C(0x2)) >> 1;
+   tlb_e[idx].asid = (g_state.regs.cp0[CP0_ENTRYHI_REG] & UINT32_C(0xFF));
+   tlb_e[idx].vpn2 = (g_state.regs.cp0[CP0_ENTRYHI_REG] & UINT32_C(0xFFFFE000)) >> 13;
+   //tlb_e[idx].r = (g_state.regs.cp0[CP0_ENTRYHI_REG] & 0xC000000000000000LL) >> 62;
+   tlb_e[idx].mask = (g_state.regs.cp0[CP0_PAGEMASK_REG] & UINT32_C(0x1FFE000)) >> 13;
    
    tlb_e[idx].start_even = tlb_e[idx].vpn2 << 13;
    tlb_e[idx].end_even = tlb_e[idx].start_even+
@@ -199,31 +199,31 @@ static void TLBWrite(unsigned int idx)
 
 DECLARE_INSTRUCTION(TLBWI)
 {
-   TLBWrite(g_cp0_regs[CP0_INDEX_REG] & UINT32_C(0x3F));
+   TLBWrite(g_state.regs.cp0[CP0_INDEX_REG] & UINT32_C(0x3F));
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TLBWR)
 {
    cp0_update_count();
-   g_cp0_regs[CP0_RANDOM_REG] = (g_cp0_regs[CP0_COUNT_REG]/2 % (32 - g_cp0_regs[CP0_WIRED_REG]))
-                              + g_cp0_regs[CP0_WIRED_REG];
-   TLBWrite(g_cp0_regs[CP0_RANDOM_REG]);
+   g_state.regs.cp0[CP0_RANDOM_REG] = (g_state.regs.cp0[CP0_COUNT_REG]/2 % (32 - g_state.regs.cp0[CP0_WIRED_REG]))
+                              + g_state.regs.cp0[CP0_WIRED_REG];
+   TLBWrite(g_state.regs.cp0[CP0_RANDOM_REG]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TLBP)
 {
    int i;
-   g_cp0_regs[CP0_INDEX_REG] |= UINT32_C(0x80000000);
+   g_state.regs.cp0[CP0_INDEX_REG] |= UINT32_C(0x80000000);
    for (i=0; i<32; i++)
    {
       if (((tlb_e[i].vpn2 & (~tlb_e[i].mask)) ==
-         (((g_cp0_regs[CP0_ENTRYHI_REG] & UINT32_C(0xFFFFE000)) >> 13) & (~tlb_e[i].mask))) &&
+         (((g_state.regs.cp0[CP0_ENTRYHI_REG] & UINT32_C(0xFFFFE000)) >> 13) & (~tlb_e[i].mask))) &&
         ((tlb_e[i].g) ||
-         (tlb_e[i].asid == (g_cp0_regs[CP0_ENTRYHI_REG] & UINT32_C(0xFF)))))
+         (tlb_e[i].asid == (g_state.regs.cp0[CP0_ENTRYHI_REG] & UINT32_C(0xFF)))))
       {
-         g_cp0_regs[CP0_INDEX_REG] = i;
+         g_state.regs.cp0[CP0_INDEX_REG] = i;
          break;
       }
    }
@@ -233,18 +233,18 @@ DECLARE_INSTRUCTION(TLBP)
 DECLARE_INSTRUCTION(ERET)
 {
    cp0_update_count();
-   if (g_cp0_regs[CP0_STATUS_REG] & UINT32_C(0x4))
+   if (g_state.regs.cp0[CP0_STATUS_REG] & UINT32_C(0x4))
    {
      DebugMessage(M64MSG_ERROR, "error in ERET");
      stop=1;
    }
    else
    {
-     g_cp0_regs[CP0_STATUS_REG] &= ~UINT32_C(0x2);
-     generic_jump_to(g_cp0_regs[CP0_EPC_REG]);
+     g_state.regs.cp0[CP0_STATUS_REG] &= ~UINT32_C(0x2);
+     generic_jump_to(g_state.regs.cp0[CP0_EPC_REG]);
    }
-   llbit = 0;
+   g_state.regs.ll_bit = 0;
    check_interupt();
    last_addr = PCADDR;
-   if (next_interupt <= g_cp0_regs[CP0_COUNT_REG]) gen_interupt();
+   if (g_state.next_interrupt <= g_state.regs.cp0[CP0_COUNT_REG]) gen_interupt();
 }

--- a/src/r4300/mi_controller.c
+++ b/src/r4300/mi_controller.c
@@ -102,7 +102,7 @@ int write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 
         check_interupt();
         cp0_update_count();
-        if (next_interupt <= cp0_regs[CP0_COUNT_REG]) gen_interupt();
+        if (g_state.next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interupt();
         break;
     }
 

--- a/src/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/r4300/new_dynarec/arm/linkage_arm.S
@@ -73,27 +73,28 @@ BSS_SECTION
     .align   12
     GLOBAL_VARIABLE(extra_memory, 33554432)
     GLOBAL_VARIABLE(dynarec_local, 64)
-    GLOBAL_VARIABLE(next_interupt, 4)
-    GLOBAL_VARIABLE(cycle_count, 4)
-    GLOBAL_VARIABLE(last_count, 4)
-    GLOBAL_VARIABLE(pending_exception, 4)
-    GLOBAL_VARIABLE(pcaddr, 4)
-    GLOBAL_VARIABLE(stop, 4)
-    GLOBAL_VARIABLE(invc_ptr, 4)
-    GLOBAL_VARIABLE(address, 4)
-    GLOBAL_VARIABLE(readmem_dword, 8)
-    GLOBAL_VARIABLE(cpu_dword, 8)
-    GLOBAL_VARIABLE(cpu_word, 4)
-    GLOBAL_VARIABLE(cpu_hword, 2)
-    GLOBAL_VARIABLE(cpu_byte, 1)
-    GLOBAL_VARIABLE(FCR0, 4)
-    GLOBAL_VARIABLE(FCR31, 4)
+    GLOBAL_VARIABLE(g_state, 1280)
     GLOBAL_VARIABLE(reg, 256)
     GLOBAL_VARIABLE(hi, 8)
     GLOBAL_VARIABLE(lo, 8)
     GLOBAL_VARIABLE(g_cp0_regs, 128)
     GLOBAL_VARIABLE(reg_cop1_simple, 128)
     GLOBAL_VARIABLE(reg_cop1_double, 128)
+    GLOBAL_VARIABLE(FCR0, 4)
+    GLOBAL_VARIABLE(FCR31, 4)
+    GLOBAL_VARIABLE(next_interupt, 4)
+    GLOBAL_VARIABLE(address, 4)
+    GLOBAL_VARIABLE(readmem_dword, 8)
+    GLOBAL_VARIABLE(cpu_dword, 8)
+    GLOBAL_VARIABLE(cpu_word, 4)
+    GLOBAL_VARIABLE(cpu_hword, 2)
+    GLOBAL_VARIABLE(cpu_byte, 1)
+    GLOBAL_VARIABLE(cycle_count, 4)
+    GLOBAL_VARIABLE(last_count, 4)
+    GLOBAL_VARIABLE(pending_exception, 4)
+    GLOBAL_VARIABLE(pcaddr, 4)
+    GLOBAL_VARIABLE(stop, 4)
+    GLOBAL_VARIABLE(invc_ptr, 4)
     GLOBAL_VARIABLE(rounding_modes, 16)
     GLOBAL_VARIABLE(branch_target, 4)
     GLOBAL_VARIABLE(PC, 4)
@@ -107,28 +108,33 @@ extra_memory:
     .space    33554432+64+4+4+4+4+4+4+4+4+8+8+4+2+2+4+4+256+8+8+128+128+128+16+4+4+132+4+256+512+4194304
 
     dynarec_local     = extra_memory      + 33554432
-    next_interupt     = dynarec_local     + 64
-    cycle_count       = next_interupt     + 4
+    /* This creates the g_state variable, used by the interpreters and
+     * Hacktarux JIT, right next to dynarec_local for easy offsetting.
+     * The positions of its members must match those in the declaration
+     * of the structure in r4300.h for 32-bit architectures. */
+    g_state           = dynarec_local     + 64
+    reg               = g_state           + 0    /* = regs.gpr */
+    hi                = g_state           + 256  /* = regs.hi */
+    lo                = g_state           + 264  /* = regs.lo */
+    g_cp0_regs        = g_state           + 272  /* = regs.cp0 */
+    reg_cop1_simple   = g_state           + 400  /* = regs.cp1_s */
+    reg_cop1_double   = g_state           + 528  /* = regs.cp1_d */
+    FCR0              = g_state           + 912  /* = regs.fcr_0 */
+    FCR31             = g_state           + 916  /* = regs.fcr_31 */
+    next_interupt     = g_state           + 928  /* = next_interrupt */
+    address           = g_state           + 932  /* = access_addr */
+    readmem_dword     = g_state           + 936  /* = read_dest */
+    cpu_dword         = g_state           + 940  /* = write.d */
+    cpu_word          = cpu_dword                /* = write.w */
+    cpu_hword         = cpu_dword                /* = write.h */
+    cpu_byte          = cpu_dword                /* = write.b */
+    cycle_count       = g_state           + 1280 /* allow expansion of the struct */
     last_count        = cycle_count       + 4
     pending_exception = last_count        + 4
     pcaddr            = pending_exception + 4
     stop              = pcaddr            + 4
     invc_ptr          = stop              + 4
-    address           = invc_ptr          + 4
-    readmem_dword     = address           + 4
-    cpu_dword         = readmem_dword     + 8
-    cpu_word          = cpu_dword         + 8
-    cpu_hword         = cpu_word          + 4
-    cpu_byte          = cpu_hword         + 2 /* 1 byte free */
-    FCR0              = cpu_hword         + 4
-    FCR31             = FCR0              + 4
-    reg               = FCR31             + 4
-    hi                = reg               + 256
-    lo                = hi                + 8
-    g_cp0_regs        = lo                + 8
-    reg_cop1_simple   = g_cp0_regs        + 128
-    reg_cop1_double   = reg_cop1_simple   + 128
-    rounding_modes    = reg_cop1_double   + 128
+    rounding_modes    = invc_ptr          + 4
     branch_target     = rounding_modes    + 16
     PC                = branch_target     + 4
     fake_pc           = PC                + 4

--- a/src/r4300/r4300.c
+++ b/src/r4300/r4300.c
@@ -57,7 +57,13 @@
 #include "instr_counters.h"
 #endif
 
+#if NEW_DYNAREC != NEW_DYNAREC_ARM
+/* The New Dynarec on ARM will place this structure somewhere within its
+ * block of memory for member access via small offsets. See
+ *   new_dynarec/arm/linkage_arm.S
+ * for the definition. */
 ALIGN(4096, struct r4300_state g_state);
+#endif
 
 unsigned int r4300emu = 0;
 unsigned int count_per_op = COUNT_PER_OP_DEFAULT;

--- a/src/r4300/r4300.c
+++ b/src/r4300/r4300.c
@@ -57,18 +57,16 @@
 #include "instr_counters.h"
 #endif
 
+ALIGN(4096, struct r4300_state g_state);
+
 unsigned int r4300emu = 0;
 unsigned int count_per_op = COUNT_PER_OP_DEFAULT;
 int rompause;
-unsigned int llbit;
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
 int stop;
-int64_t reg[32], hi, lo;
-uint32_t next_interupt;
 precomp_instr *PC;
 #endif
 long long int local_rs;
-unsigned int delay_slot;
 uint32_t skip_jump = 0;
 unsigned int dyna_interp = 0;
 uint32_t last_addr;
@@ -99,9 +97,9 @@ void r4300_reset_hard(void)
     // clear r4300 registers and TLB entries
     for (i = 0; i < 32; i++)
     {
-        reg[i]=0;
-        g_cp0_regs[i]=0;
-        reg_cop1_fgr_64[i]=0;
+        g_state.regs.gpr[i] = 0;
+        g_state.regs.cp0[i] = 0;
+        g_state.regs.fpr_data[i] = 0;
 
         // --------------tlb------------------------
         tlb_e[i].mask=0;
@@ -131,26 +129,26 @@ void r4300_reset_hard(void)
         tlb_LUT_r[i] = 0;
         tlb_LUT_w[i] = 0;
     }
-    llbit=0;
-    hi=0;
-    lo=0;
-    FCR0 = UINT32_C(0x511);
-    FCR31=0;
+    g_state.regs.ll_bit = 0;
+    g_state.regs.hi = 0;
+    g_state.regs.lo = 0;
+    g_state.regs.fcr_0 = UINT32_C(0x511);
+    g_state.regs.fcr_31 = 0;
 
     // set COP0 registers
-    g_cp0_regs[CP0_RANDOM_REG] = UINT32_C(31);
-    g_cp0_regs[CP0_STATUS_REG]= UINT32_C(0x34000000);
-    set_fpr_pointers(g_cp0_regs[CP0_STATUS_REG]);
-    g_cp0_regs[CP0_CONFIG_REG]= UINT32_C(0x6e463);
-    g_cp0_regs[CP0_PREVID_REG] = UINT32_C(0xb00);
-    g_cp0_regs[CP0_COUNT_REG] = UINT32_C(0x5000);
-    g_cp0_regs[CP0_CAUSE_REG] = UINT32_C(0x5C);
-    g_cp0_regs[CP0_CONTEXT_REG] = UINT32_C(0x7FFFF0);
-    g_cp0_regs[CP0_EPC_REG] = UINT32_C(0xFFFFFFFF);
-    g_cp0_regs[CP0_BADVADDR_REG] = UINT32_C(0xFFFFFFFF);
-    g_cp0_regs[CP0_ERROREPC_REG] = UINT32_C(0xFFFFFFFF);
+    g_state.regs.cp0[CP0_RANDOM_REG] = UINT32_C(31);
+    g_state.regs.cp0[CP0_STATUS_REG]= UINT32_C(0x34000000);
+    set_fpr_pointers(g_state.regs.cp0[CP0_STATUS_REG]);
+    g_state.regs.cp0[CP0_CONFIG_REG]= UINT32_C(0x6e463);
+    g_state.regs.cp0[CP0_PREVID_REG] = UINT32_C(0xb00);
+    g_state.regs.cp0[CP0_COUNT_REG] = UINT32_C(0x5000);
+    g_state.regs.cp0[CP0_CAUSE_REG] = UINT32_C(0x5C);
+    g_state.regs.cp0[CP0_CONTEXT_REG] = UINT32_C(0x7FFFF0);
+    g_state.regs.cp0[CP0_EPC_REG] = UINT32_C(0xFFFFFFFF);
+    g_state.regs.cp0[CP0_BADVADDR_REG] = UINT32_C(0xFFFFFFFF);
+    g_state.regs.cp0[CP0_ERROREPC_REG] = UINT32_C(0xFFFFFFFF);
    
-    update_x86_rounding_mode(FCR31);
+    update_x86_rounding_mode(g_state.regs.fcr_31);
 }
 
 
@@ -174,8 +172,8 @@ void r4300_reset_soft(void)
     unsigned int tv_type = get_tv_type();   /* 0:PAL, 1:NTSC, 2:MPAL */
     uint32_t bsd_dom1_config = *(uint32_t*)g_rom;
 
-    g_cp0_regs[CP0_STATUS_REG] = 0x34000000;
-    g_cp0_regs[CP0_CONFIG_REG] = 0x0006e463;
+    g_state.regs.cp0[CP0_STATUS_REG] = 0x34000000;
+    g_state.regs.cp0[CP0_CONFIG_REG] = 0x0006e463;
 
     g_sp.regs[SP_STATUS_REG] = 1;
     g_sp.regs2[SP_PC_REG] = 0;
@@ -197,11 +195,11 @@ void r4300_reset_soft(void)
 
     memcpy((unsigned char*)g_sp.mem+0x40, g_rom+0x40, 0xfc0);
 
-    reg[19] = rom_type;     /* s3 */
-    reg[20] = tv_type;      /* s4 */
-    reg[21] = reset_type;   /* s5 */
-    reg[22] = g_si.pif.cic.seed;/* s6 */
-    reg[23] = s7;           /* s7 */
+    g_state.regs.gpr[19] = rom_type;     /* s3 */
+    g_state.regs.gpr[20] = tv_type;      /* s4 */
+    g_state.regs.gpr[21] = reset_type;   /* s5 */
+    g_state.regs.gpr[22] = g_si.pif.cic.seed;/* s6 */
+    g_state.regs.gpr[23] = s7;           /* s7 */
 
     /* required by CIC x105 */
     g_sp.mem[0x1000/4] = 0x3c0dbfc0;
@@ -214,9 +212,9 @@ void r4300_reset_soft(void)
     g_sp.mem[0x101c/4] = 0x3c0bb000;
 
     /* required by CIC x105 */
-    reg[11] = INT64_C(0xffffffffa4000040); /* t3 */
-    reg[29] = INT64_C(0xffffffffa4001ff0); /* sp */
-    reg[31] = INT64_C(0xffffffffa4001550); /* ra */
+    g_state.regs.gpr[11] = INT64_C(0xffffffffa4000040); /* t3 */
+    g_state.regs.gpr[29] = INT64_C(0xffffffffa4001ff0); /* sp */
+    g_state.regs.gpr[31] = INT64_C(0xffffffffa4001550); /* ra */
 
     /* ready to execute IPL3 */
 }
@@ -242,7 +240,7 @@ void r4300_execute(void)
 
     current_instruction_table = cached_interpreter_table;
 
-    delay_slot=0;
+    g_state.delay_slot = 0;
     stop = 0;
     rompause = 0;
 
@@ -252,7 +250,7 @@ void r4300_execute(void)
 #endif
 
     last_addr = 0xa4000040;
-    next_interupt = 624999;
+    g_state.next_interrupt = 624999;
     init_interupt();
 
     if (r4300emu == CORE_PURE_INTERPRETER)

--- a/src/r4300/r4300_core.c
+++ b/src/r4300/r4300_core.c
@@ -34,22 +34,22 @@ void init_r4300(struct r4300_core* r4300)
 
 int64_t* r4300_regs(void)
 {
-    return reg;
+    return g_state.regs.gpr;
 }
 
 int64_t* r4300_mult_hi(void)
 {
-    return &hi;
+    return &g_state.regs.hi;
 }
 
 int64_t* r4300_mult_lo(void)
 {
-    return &lo;
+    return &g_state.regs.lo;
 }
 
 unsigned int* r4300_llbit(void)
 {
-    return &llbit;
+    return &g_state.regs.ll_bit;
 }
 
 uint32_t* r4300_pc(void)
@@ -70,7 +70,7 @@ uint32_t* r4300_last_addr(void)
 
 unsigned int* r4300_next_interrupt(void)
 {
-    return &next_interupt;
+    return &g_state.next_interrupt;
 }
 
 unsigned int get_r4300_emumode(void)

--- a/src/r4300/recomp.c
+++ b/src/r4300/recomp.c
@@ -91,8 +91,8 @@ static void RNOTCOMPILED(void)
 
 static void recompile_standard_i_type(void)
 {
-   dst->f.i.rs = reg + ((src >> 21) & 0x1F);
-   dst->f.i.rt = reg + ((src >> 16) & 0x1F);
+   dst->f.i.rs = &g_state.regs.gpr[(src >> 21) & 0x1F];
+   dst->f.i.rt = &g_state.regs.gpr[(src >> 16) & 0x1F];
    dst->f.i.immediate = (int16_t) src;
 }
 
@@ -103,9 +103,9 @@ static void recompile_standard_j_type(void)
 
 static void recompile_standard_r_type(void)
 {
-   dst->f.r.rs = reg + ((src >> 21) & 0x1F);
-   dst->f.r.rt = reg + ((src >> 16) & 0x1F);
-   dst->f.r.rd = reg + ((src >> 11) & 0x1F);
+   dst->f.r.rs = &g_state.regs.gpr[(src >> 21) & 0x1F];
+   dst->f.r.rt = &g_state.regs.gpr[(src >> 16) & 0x1F];
+   dst->f.r.rd = &g_state.regs.gpr[(src >> 11) & 0x1F];
    dst->f.r.sa = (src >>  6) & 0x1F;
 }
 
@@ -138,7 +138,7 @@ static void RSLL(void)
    dst->ops = current_instruction_table.SLL;
    recomp_func = gensll;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSRL(void)
@@ -146,7 +146,7 @@ static void RSRL(void)
    dst->ops = current_instruction_table.SRL;
    recomp_func = gensrl;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSRA(void)
@@ -154,7 +154,7 @@ static void RSRA(void)
    dst->ops = current_instruction_table.SRA;
    recomp_func = gensra;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSLLV(void)
@@ -162,7 +162,7 @@ static void RSLLV(void)
    dst->ops = current_instruction_table.SLLV;
    recomp_func = gensllv;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSRLV(void)
@@ -170,7 +170,7 @@ static void RSRLV(void)
    dst->ops = current_instruction_table.SRLV;
    recomp_func = gensrlv;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSRAV(void)
@@ -178,7 +178,7 @@ static void RSRAV(void)
    dst->ops = current_instruction_table.SRAV;
    recomp_func = gensrav;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RJR(void)
@@ -218,7 +218,7 @@ static void RMFHI(void)
    dst->ops = current_instruction_table.MFHI;
    recomp_func = genmfhi;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RMTHI(void)
@@ -233,7 +233,7 @@ static void RMFLO(void)
    dst->ops = current_instruction_table.MFLO;
    recomp_func = genmflo;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RMTLO(void)
@@ -248,7 +248,7 @@ static void RDSLLV(void)
    dst->ops = current_instruction_table.DSLLV;
    recomp_func = gendsllv;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSRLV(void)
@@ -256,7 +256,7 @@ static void RDSRLV(void)
    dst->ops = current_instruction_table.DSRLV;
    recomp_func = gendsrlv;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSRAV(void)
@@ -264,7 +264,7 @@ static void RDSRAV(void)
    dst->ops = current_instruction_table.DSRAV;
    recomp_func = gendsrav;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RMULT(void)
@@ -328,7 +328,7 @@ static void RADD(void)
    dst->ops = current_instruction_table.ADD;
    recomp_func = genadd;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RADDU(void)
@@ -336,7 +336,7 @@ static void RADDU(void)
    dst->ops = current_instruction_table.ADDU;
    recomp_func = genaddu;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSUB(void)
@@ -344,7 +344,7 @@ static void RSUB(void)
    dst->ops = current_instruction_table.SUB;
    recomp_func = gensub;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSUBU(void)
@@ -352,7 +352,7 @@ static void RSUBU(void)
    dst->ops = current_instruction_table.SUBU;
    recomp_func = gensubu;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RAND(void)
@@ -360,7 +360,7 @@ static void RAND(void)
    dst->ops = current_instruction_table.AND;
    recomp_func = genand;
    recompile_standard_r_type();
-   if(dst->f.r.rd == reg) RNOP();
+   if(dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void ROR(void)
@@ -368,7 +368,7 @@ static void ROR(void)
    dst->ops = current_instruction_table.OR;
    recomp_func = genor;
    recompile_standard_r_type();
-   if(dst->f.r.rd == reg) RNOP();
+   if(dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RXOR(void)
@@ -376,7 +376,7 @@ static void RXOR(void)
    dst->ops = current_instruction_table.XOR;
    recomp_func = genxor;
    recompile_standard_r_type();
-   if(dst->f.r.rd == reg) RNOP();
+   if(dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RNOR(void)
@@ -384,7 +384,7 @@ static void RNOR(void)
    dst->ops = current_instruction_table.NOR;
    recomp_func = gennor;
    recompile_standard_r_type();
-   if(dst->f.r.rd == reg) RNOP();
+   if(dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSLT(void)
@@ -392,7 +392,7 @@ static void RSLT(void)
    dst->ops = current_instruction_table.SLT;
    recomp_func = genslt;
    recompile_standard_r_type();
-   if(dst->f.r.rd == reg) RNOP();
+   if(dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RSLTU(void)
@@ -400,7 +400,7 @@ static void RSLTU(void)
    dst->ops = current_instruction_table.SLTU;
    recomp_func = gensltu;
    recompile_standard_r_type();
-   if(dst->f.r.rd == reg) RNOP();
+   if(dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDADD(void)
@@ -408,7 +408,7 @@ static void RDADD(void)
    dst->ops = current_instruction_table.DADD;
    recomp_func = gendadd;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDADDU(void)
@@ -416,7 +416,7 @@ static void RDADDU(void)
    dst->ops = current_instruction_table.DADDU;
    recomp_func = gendaddu;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSUB(void)
@@ -424,7 +424,7 @@ static void RDSUB(void)
    dst->ops = current_instruction_table.DSUB;
    recomp_func = gendsub;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSUBU(void)
@@ -432,7 +432,7 @@ static void RDSUBU(void)
    dst->ops = current_instruction_table.DSUBU;
    recomp_func = gendsubu;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RTGE(void)
@@ -477,7 +477,7 @@ static void RDSLL(void)
    dst->ops = current_instruction_table.DSLL;
    recomp_func = gendsll;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSRL(void)
@@ -485,7 +485,7 @@ static void RDSRL(void)
    dst->ops = current_instruction_table.DSRL;
    recomp_func = gendsrl;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSRA(void)
@@ -493,7 +493,7 @@ static void RDSRA(void)
    dst->ops = current_instruction_table.DSRA;
    recomp_func = gendsra;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSLL32(void)
@@ -501,7 +501,7 @@ static void RDSLL32(void)
    dst->ops = current_instruction_table.DSLL32;
    recomp_func = gendsll32;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSRL32(void)
@@ -509,7 +509,7 @@ static void RDSRL32(void)
    dst->ops = current_instruction_table.DSRL32;
    recomp_func = gendsrl32;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void RDSRA32(void)
@@ -517,7 +517,7 @@ static void RDSRA32(void)
    dst->ops = current_instruction_table.DSRA32;
    recomp_func = gendsra32;
    recompile_standard_r_type();
-   if (dst->f.r.rd == reg) RNOP();
+   if (dst->f.r.rd == g_state.regs.gpr) RNOP();
 }
 
 static void (*recomp_special[64])(void) =
@@ -811,9 +811,9 @@ static void RMFC0(void)
    dst->ops = current_instruction_table.MFC0;
    recomp_func = genmfc0;
    recompile_standard_r_type();
-   dst->f.r.rd = (int64_t*) (g_cp0_regs + ((src >> 11) & 0x1F));
+   dst->f.r.rd = (int64_t*) (g_state.regs.cp0 + ((src >> 11) & 0x1F));
    dst->f.r.nrd = (src >> 11) & 0x1F;
-   if (dst->f.r.rt == reg) RNOP();
+   if (dst->f.r.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RMTC0(void)
@@ -1527,7 +1527,7 @@ static void RMFC1(void)
    recomp_func = genmfc1;
    recompile_standard_r_type();
    dst->f.r.nrd = (src >> 11) & 0x1F;
-   if (dst->f.r.rt == reg) RNOP();
+   if (dst->f.r.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RDMFC1(void)
@@ -1536,7 +1536,7 @@ static void RDMFC1(void)
    recomp_func = gendmfc1;
    recompile_standard_r_type();
    dst->f.r.nrd = (src >> 11) & 0x1F;
-   if (dst->f.r.rt == reg) RNOP();
+   if (dst->f.r.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RCFC1(void)
@@ -1545,7 +1545,7 @@ static void RCFC1(void)
    recomp_func = gencfc1;
    recompile_standard_r_type();
    dst->f.r.nrd = (src >> 11) & 0x1F;
-   if (dst->f.r.rt == reg) RNOP();
+   if (dst->f.r.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RMTC1(void)
@@ -1756,7 +1756,7 @@ static void RADDI(void)
    dst->ops = current_instruction_table.ADDI;
    recomp_func = genaddi;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RADDIU(void)
@@ -1764,7 +1764,7 @@ static void RADDIU(void)
    dst->ops = current_instruction_table.ADDIU;
    recomp_func = genaddiu;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RSLTI(void)
@@ -1772,7 +1772,7 @@ static void RSLTI(void)
    dst->ops = current_instruction_table.SLTI;
    recomp_func = genslti;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RSLTIU(void)
@@ -1780,7 +1780,7 @@ static void RSLTIU(void)
    dst->ops = current_instruction_table.SLTIU;
    recomp_func = gensltiu;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RANDI(void)
@@ -1788,7 +1788,7 @@ static void RANDI(void)
    dst->ops = current_instruction_table.ANDI;
    recomp_func = genandi;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RORI(void)
@@ -1796,7 +1796,7 @@ static void RORI(void)
    dst->ops = current_instruction_table.ORI;
    recomp_func = genori;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RXORI(void)
@@ -1804,7 +1804,7 @@ static void RXORI(void)
    dst->ops = current_instruction_table.XORI;
    recomp_func = genxori;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLUI(void)
@@ -1812,7 +1812,7 @@ static void RLUI(void)
    dst->ops = current_instruction_table.LUI;
    recomp_func = genlui;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RCOP0(void)
@@ -1918,7 +1918,7 @@ static void RDADDI(void)
    dst->ops = current_instruction_table.DADDI;
    recomp_func = gendaddi;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RDADDIU(void)
@@ -1926,7 +1926,7 @@ static void RDADDIU(void)
    dst->ops = current_instruction_table.DADDIU;
    recomp_func = gendaddiu;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLDL(void)
@@ -1934,7 +1934,7 @@ static void RLDL(void)
    dst->ops = current_instruction_table.LDL;
    recomp_func = genldl;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLDR(void)
@@ -1942,7 +1942,7 @@ static void RLDR(void)
    dst->ops = current_instruction_table.LDR;
    recomp_func = genldr;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLB(void)
@@ -1950,7 +1950,7 @@ static void RLB(void)
    dst->ops = current_instruction_table.LB;
    recomp_func = genlb;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLH(void)
@@ -1958,7 +1958,7 @@ static void RLH(void)
    dst->ops = current_instruction_table.LH;
    recomp_func = genlh;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLWL(void)
@@ -1966,7 +1966,7 @@ static void RLWL(void)
    dst->ops = current_instruction_table.LWL;
    recomp_func = genlwl;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLW(void)
@@ -1974,7 +1974,7 @@ static void RLW(void)
    dst->ops = current_instruction_table.LW;
    recomp_func = genlw;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLBU(void)
@@ -1982,7 +1982,7 @@ static void RLBU(void)
    dst->ops = current_instruction_table.LBU;
    recomp_func = genlbu;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLHU(void)
@@ -1990,7 +1990,7 @@ static void RLHU(void)
    dst->ops = current_instruction_table.LHU;
    recomp_func = genlhu;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLWR(void)
@@ -1998,7 +1998,7 @@ static void RLWR(void)
    dst->ops = current_instruction_table.LWR;
    recomp_func = genlwr;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLWU(void)
@@ -2006,7 +2006,7 @@ static void RLWU(void)
    dst->ops = current_instruction_table.LWU;
    recomp_func = genlwu;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RSB(void)
@@ -2069,7 +2069,7 @@ static void RLL(void)
    recomp_func = genll;
    dst->ops = current_instruction_table.LL;
    recompile_standard_i_type();
-   if(dst->f.i.rt == reg) RNOP();
+   if(dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RLWC1(void)
@@ -2098,7 +2098,7 @@ static void RLD(void)
    dst->ops = current_instruction_table.LD;
    recomp_func = genld;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RSC(void)
@@ -2106,7 +2106,7 @@ static void RSC(void)
    dst->ops = current_instruction_table.SC;
    recomp_func = gensc;
    recompile_standard_i_type();
-   if (dst->f.i.rt == reg) RNOP();
+   if (dst->f.i.rt == g_state.regs.gpr) RNOP();
 }
 
 static void RSWC1(void)

--- a/src/r4300/reset.c
+++ b/src/r4300/reset.c
@@ -39,7 +39,7 @@ void reset_hard(void)
     r4300_reset_hard();
     r4300_reset_soft();
     last_addr = UINT32_C(0xa4000040);
-    next_interupt = 624999;
+    g_state.next_interrupt = 624999;
     init_interupt();
     if(r4300emu != CORE_PURE_INTERPRETER)
     {

--- a/src/r4300/x86/assemble.h
+++ b/src/r4300/x86/assemble.h
@@ -29,8 +29,6 @@
 #include "osal/preproc.h"
 #include "r4300/recomph.h"
 
-extern int64_t reg[32];
-
 #define EAX 0
 #define ECX 1
 #define EDX 2

--- a/src/r4300/x86/gbc.c
+++ b/src/r4300/x86/gbc.c
@@ -31,7 +31,7 @@
 
 static void genbc1f_test(void)
 {
-   test_m32_imm32((unsigned int*)&FCR31, 0x800000);
+   test_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000);
    jne_rj(12);
    mov_m32_imm32((unsigned int*)(&branch_taken), 1); // 10
    jmp_imm_short(10); // 2
@@ -97,7 +97,7 @@ void genbc1f_idle(void)
 
 static void genbc1t_test(void)
 {
-   test_m32_imm32((unsigned int*)&FCR31, 0x800000);
+   test_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000);
    je_rj(12);
    mov_m32_imm32((unsigned int*)(&branch_taken), 1); // 10
    jmp_imm_short(10); // 2

--- a/src/r4300/x86/gcop1.c
+++ b/src/r4300/x86/gcop1.c
@@ -45,7 +45,7 @@ void genmfc1(void)
    gencallinterp((unsigned int)cached_interpreter_table.MFC1, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.r.nrd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.r.nrd]));
    mov_reg32_preg32(EBX, EAX);
    mov_m32_reg32((unsigned int*)dst->f.r.rt, EBX);
    sar_reg32_imm8(EBX, 31);
@@ -59,7 +59,7 @@ void gendmfc1(void)
    gencallinterp((unsigned int)cached_interpreter_table.DMFC1, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.r.nrd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.r.nrd]));
    mov_reg32_preg32(EBX, EAX);
    mov_reg32_preg32pimm32(ECX, EAX, 4);
    mov_m32_reg32((unsigned int*)dst->f.r.rt, EBX);
@@ -73,8 +73,8 @@ void gencfc1(void)
    gencallinterp((unsigned int)cached_interpreter_table.CFC1, 0);
 #else
    gencheck_cop1_unusable();
-   if(dst->f.r.nrd == 31) mov_eax_memoffs32((unsigned int*)&FCR31);
-   else mov_eax_memoffs32((unsigned int*)&FCR0);
+   if(dst->f.r.nrd == 31) mov_eax_memoffs32((unsigned int*) &g_state.regs.fcr_31);
+   else mov_eax_memoffs32((unsigned int*) &g_state.regs.fcr_0);
    mov_memoffs32_eax((unsigned int*)dst->f.r.rt);
    sar_reg32_imm8(EAX, 31);
    mov_memoffs32_eax(((unsigned int*)dst->f.r.rt)+1);
@@ -88,7 +88,7 @@ void genmtc1(void)
 #else
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned int*)dst->f.r.rt);
-   mov_reg32_m32(EBX, (unsigned int*)(&reg_cop1_simple[dst->f.r.nrd]));
+   mov_reg32_m32(EBX, (unsigned int*) (&g_state.regs.cp1_s[dst->f.r.nrd]));
    mov_preg32_reg32(EBX, EAX);
 #endif
 }
@@ -101,7 +101,7 @@ void gendmtc1(void)
    gencheck_cop1_unusable();
    mov_eax_memoffs32((unsigned int*)dst->f.r.rt);
    mov_reg32_m32(EBX, ((unsigned int*)dst->f.r.rt)+1);
-   mov_reg32_m32(EDX, (unsigned int*)(&reg_cop1_double[dst->f.r.nrd]));
+   mov_reg32_m32(EDX, (unsigned int*) (&g_state.regs.cp1_d[dst->f.r.nrd]));
    mov_preg32_reg32(EDX, EAX);
    mov_preg32pimm32_reg32(EDX, 4, EBX);
 #endif
@@ -116,7 +116,7 @@ void genctc1(void)
    
    if (dst->f.r.nrd != 31) return;
    mov_eax_memoffs32((unsigned int*)dst->f.r.rt);
-   mov_memoffs32_eax((unsigned int*)&FCR31);
+   mov_memoffs32_eax((unsigned int*) &g_state.regs.fcr_31);
    and_eax_imm32(3);
    
    cmp_eax_imm32(0);

--- a/src/r4300/x86/gcop1_d.c
+++ b/src/r4300/x86/gcop1_d.c
@@ -34,11 +34,11 @@ void genadd_d(void)
     gencallinterp((unsigned int)cached_interpreter_table.ADD_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fadd_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }
@@ -49,11 +49,11 @@ void gensub_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.SUB_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fsub_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }
@@ -64,11 +64,11 @@ void genmul_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.MUL_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fmul_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }
@@ -79,11 +79,11 @@ void gendiv_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.DIV_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fdiv_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }
@@ -94,10 +94,10 @@ void gensqrt_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.SQRT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fsqrt();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }
@@ -108,10 +108,10 @@ void genabs_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.ABS_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fabs_();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }
@@ -122,10 +122,10 @@ void genmov_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.MOV_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    mov_reg32_preg32(EBX, EAX);
    mov_reg32_preg32pimm32(ECX, EAX, 4);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    mov_preg32_reg32(EAX, EBX);
    mov_preg32pimm32_reg32(EAX, 4, ECX);
 #endif
@@ -137,10 +137,10 @@ void genneg_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.NEG_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fchs();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }
@@ -152,9 +152,9 @@ void genround_l_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&round_mode);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -167,9 +167,9 @@ void gentrunc_l_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&trunc_mode);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -182,9 +182,9 @@ void genceil_l_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&ceil_mode);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -197,9 +197,9 @@ void genfloor_l_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&floor_mode);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -212,9 +212,9 @@ void genround_w_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&round_mode);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -227,9 +227,9 @@ void gentrunc_w_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&trunc_mode);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -242,9 +242,9 @@ void genceil_w_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&ceil_mode);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -257,9 +257,9 @@ void genfloor_w_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&floor_mode);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -271,9 +271,9 @@ void gencvt_s_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_S_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -284,9 +284,9 @@ void gencvt_w_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_W_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
 #endif
 }
@@ -297,9 +297,9 @@ void gencvt_l_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_L_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
 #endif
 }
@@ -310,7 +310,7 @@ void genc_f_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_F_D, 0);
 #else
    gencheck_cop1_unusable();
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000);
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000);
 #endif
 }
 
@@ -320,16 +320,16 @@ void genc_un_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_UN_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(12);
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
    jmp_imm_short(10); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
 #endif
 }
 
@@ -339,16 +339,16 @@ void genc_eq_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_EQ_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jne_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -358,17 +358,17 @@ void genc_ueq_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_UEQ_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    jne_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -378,16 +378,16 @@ void genc_olt_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_OLT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jae_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -397,17 +397,17 @@ void genc_ult_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_ULT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    jae_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -417,16 +417,16 @@ void genc_ole_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_OLE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    ja_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -436,17 +436,17 @@ void genc_ule_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_ULE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    ja_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -456,13 +456,13 @@ void genc_sf_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_SF_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000);
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000);
 #endif
 }
 
@@ -472,16 +472,16 @@ void genc_ngle_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_NGLE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(12);
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
    jmp_imm_short(10); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
 #endif
 }
 
@@ -491,16 +491,16 @@ void genc_seq_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_SEQ_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jne_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -510,17 +510,17 @@ void genc_ngl_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_NGL_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    jne_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -530,16 +530,16 @@ void genc_lt_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_LT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jae_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -549,17 +549,17 @@ void genc_nge_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_NGE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    jae_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -569,16 +569,16 @@ void genc_le_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_LE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    ja_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -588,17 +588,17 @@ void genc_ngt_d(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_NGT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg32_qword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    ja_rj(12); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 

--- a/src/r4300/x86/gcop1_l.c
+++ b/src/r4300/x86/gcop1_l.c
@@ -32,9 +32,9 @@ void gencvt_s_l(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_S_L, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fild_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -45,9 +45,9 @@ void gencvt_d_l(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_D_L, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fild_preg32_qword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }

--- a/src/r4300/x86/gcop1_s.c
+++ b/src/r4300/x86/gcop1_s.c
@@ -35,11 +35,11 @@ void genadd_s(void)
     gencallinterp((unsigned int)cached_interpreter_table.ADD_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fadd_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -50,11 +50,11 @@ void gensub_s(void)
     gencallinterp((unsigned int)cached_interpreter_table.SUB_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fsub_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -65,11 +65,11 @@ void genmul_s(void)
     gencallinterp((unsigned int)cached_interpreter_table.MUL_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fmul_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -80,11 +80,11 @@ void gendiv_s(void)
     gencallinterp((unsigned int)cached_interpreter_table.DIV_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fdiv_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -95,10 +95,10 @@ void gensqrt_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.SQRT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fsqrt();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -109,10 +109,10 @@ void genabs_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.ABS_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fabs_();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -123,9 +123,9 @@ void genmov_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.MOV_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    mov_reg32_preg32(EBX, EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    mov_preg32_reg32(EAX, EBX);
 #endif
 }
@@ -136,10 +136,10 @@ void genneg_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.NEG_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fchs();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -151,9 +151,9 @@ void genround_l_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&round_mode);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -166,9 +166,9 @@ void gentrunc_l_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&trunc_mode);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -181,9 +181,9 @@ void genceil_l_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&ceil_mode);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -196,9 +196,9 @@ void genfloor_l_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&floor_mode);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -211,9 +211,9 @@ void genround_w_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&round_mode);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -226,9 +226,9 @@ void gentrunc_w_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&trunc_mode);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -241,9 +241,9 @@ void genceil_w_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&ceil_mode);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -256,9 +256,9 @@ void genfloor_w_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16((unsigned short*)&floor_mode);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
    fldcw_m16((unsigned short*)&rounding_mode);
 #endif
@@ -270,9 +270,9 @@ void gencvt_d_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_D_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }
@@ -283,9 +283,9 @@ void gencvt_w_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_W_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg32_dword(EAX);
 #endif
 }
@@ -296,9 +296,9 @@ void gencvt_l_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_L_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg32_qword(EAX);
 #endif
 }
@@ -309,7 +309,7 @@ void genc_f_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_F_S, 0);
 #else
    gencheck_cop1_unusable();
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000);
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000);
 #endif
 }
 
@@ -319,16 +319,16 @@ void genc_un_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_UN_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(12);
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
    jmp_imm_short(10); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
 #endif
 }
 
@@ -338,16 +338,16 @@ void genc_eq_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_EQ_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jne_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -357,17 +357,17 @@ void genc_ueq_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_UEQ_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    jne_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -377,16 +377,16 @@ void genc_olt_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_OLT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jae_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -396,17 +396,17 @@ void genc_ult_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_ULT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    jae_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -416,16 +416,16 @@ void genc_ole_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_OLE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    ja_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -435,17 +435,17 @@ void genc_ule_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_ULE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    ja_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -455,13 +455,13 @@ void genc_sf_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_SF_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000);
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000);
 #endif
 }
 
@@ -471,16 +471,16 @@ void genc_ngle_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_NGLE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(12);
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
    jmp_imm_short(10); // 2
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
 #endif
 }
 
@@ -490,16 +490,16 @@ void genc_seq_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_SEQ_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jne_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -509,17 +509,17 @@ void genc_ngl_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_NGL_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    jne_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -529,16 +529,16 @@ void genc_lt_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_LT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jae_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -548,17 +548,17 @@ void genc_nge_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_NGE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    jae_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -568,16 +568,16 @@ void genc_le_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_LE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    ja_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 
@@ -587,17 +587,17 @@ void genc_ngt_s(void)
    gencallinterp((unsigned int)cached_interpreter_table.C_NGT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg32_dword(EAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(14);
    ja_rj(12);
-   or_m32_imm32((unsigned int*)&FCR31, 0x800000); // 10
+   or_m32_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 10
    jmp_imm_short(10); // 2
-   and_m32_imm32((unsigned int*)&FCR31, ~0x800000); // 10
+   and_m32_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 10
 #endif
 }
 

--- a/src/r4300/x86/gcop1_w.c
+++ b/src/r4300/x86/gcop1_w.c
@@ -34,9 +34,9 @@ void gencvt_s_w(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_S_W, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fild_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg32_dword(EAX);
 #endif
 }
@@ -47,9 +47,9 @@ void gencvt_d_w(void)
    gencallinterp((unsigned int)cached_interpreter_table.CVT_D_W, 0);
 #else
    gencheck_cop1_unusable();
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fild_preg32_dword(EAX);
-   mov_eax_memoffs32((unsigned int*)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_eax_memoffs32((unsigned int*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg32_qword(EAX);
 #endif
 }

--- a/src/r4300/x86/gregimm.c
+++ b/src/r4300/x86/gregimm.c
@@ -317,26 +317,26 @@ void genbgezl_idle(void)
 
 static void genbranchlink(void)
 {
-   int r31_64bit = is64((unsigned int*)&reg[31]);
+   int r31_64bit = is64((unsigned int*) &g_state.regs.gpr[31]);
    
    if (!r31_64bit)
      {
-    int r31 = allocate_register_w((unsigned int *)&reg[31]);
+    int r31 = allocate_register_w((unsigned int*) &g_state.regs.gpr[31]);
     
     mov_reg32_imm32(r31, dst->addr+8);
      }
    else if (r31_64bit == -1)
      {
-    mov_m32_imm32((unsigned int *)&reg[31], dst->addr + 8);
+    mov_m32_imm32((unsigned int*) &g_state.regs.gpr[31], dst->addr + 8);
     if (dst->addr & 0x80000000)
-      mov_m32_imm32(((unsigned int *)&reg[31])+1, 0xFFFFFFFF);
+      mov_m32_imm32(((unsigned int*) &g_state.regs.gpr[31]) + 1, 0xFFFFFFFF);
     else
-      mov_m32_imm32(((unsigned int *)&reg[31])+1, 0);
+      mov_m32_imm32(((unsigned int*) &g_state.regs.gpr[31]) + 1, 0);
      }
    else
      {
-    int r311 = allocate_64_register1_w((unsigned int *)&reg[31]);
-    int r312 = allocate_64_register2_w((unsigned int *)&reg[31]);
+    int r311 = allocate_64_register1_w((unsigned int*) &g_state.regs.gpr[31]);
+    int r312 = allocate_64_register2_w((unsigned int*) &g_state.regs.gpr[31]);
     
     mov_reg32_imm32(r311, dst->addr+8);
     if (dst->addr & 0x80000000)

--- a/src/r4300/x86/gspecial.c
+++ b/src/r4300/x86/gspecial.c
@@ -296,7 +296,7 @@ void gensyscall(void)
 #else
    free_all_registers();
    simplify_access();
-   mov_m32_imm32(&g_cp0_regs[CP0_CAUSE_REG], 8 << 2);
+   mov_m32_imm32(&g_state.regs.cp0[CP0_CAUSE_REG], 8 << 2);
    gencallinterp((unsigned int)exception_general, 0);
 #endif
 }
@@ -325,8 +325,8 @@ void genmthi(void)
 #ifdef INTERPRET_MTHI
    gencallinterp((unsigned int)cached_interpreter_table.MTHI, 0);
 #else
-   int hi1 = allocate_64_register1_w((unsigned int*)&hi);
-   int hi2 = allocate_64_register2_w((unsigned int*)&hi);
+   int hi1 = allocate_64_register1_w((unsigned int*) &g_state.regs.hi);
+   int hi2 = allocate_64_register2_w((unsigned int*) &g_state.regs.hi);
    int rs1 = allocate_64_register1((unsigned int*)dst->f.r.rs);
    int rs2 = allocate_64_register2((unsigned int*)dst->f.r.rs);
    
@@ -342,8 +342,8 @@ void genmflo(void)
 #else
    int rd1 = allocate_64_register1_w((unsigned int*)dst->f.r.rd);
    int rd2 = allocate_64_register2_w((unsigned int*)dst->f.r.rd);
-   int lo1 = allocate_64_register1((unsigned int*)&lo);
-   int lo2 = allocate_64_register2((unsigned int*)&lo);
+   int lo1 = allocate_64_register1((unsigned int*) &g_state.regs.lo);
+   int lo2 = allocate_64_register2((unsigned int*) &g_state.regs.lo);
    
    mov_reg32_reg32(rd1, lo1);
    mov_reg32_reg32(rd2, lo2);
@@ -355,8 +355,8 @@ void genmtlo(void)
 #ifdef INTERPRET_MTLO
    gencallinterp((unsigned int)cached_interpreter_table.MTLO, 0);
 #else
-   int lo1 = allocate_64_register1_w((unsigned int*)&lo);
-   int lo2 = allocate_64_register2_w((unsigned int*)&lo);
+   int lo1 = allocate_64_register1_w((unsigned int*) &g_state.regs.lo);
+   int lo2 = allocate_64_register2_w((unsigned int*) &g_state.regs.lo);
    int rs1 = allocate_64_register1((unsigned int*)dst->f.r.rs);
    int rs2 = allocate_64_register2((unsigned int*)dst->f.r.rs);
    
@@ -515,8 +515,8 @@ void genmult(void)
    gencallinterp((unsigned int)cached_interpreter_table.MULT, 0);
 #else
    int rs, rt;
-   allocate_register_manually_w(EAX, (unsigned int *)&lo, 0);
-   allocate_register_manually_w(EDX, (unsigned int *)&hi, 0);
+   allocate_register_manually_w(EAX, (unsigned int*) &g_state.regs.lo, 0);
+   allocate_register_manually_w(EDX, (unsigned int*) &g_state.regs.hi, 0);
    rs = allocate_register((unsigned int*)dst->f.r.rs);
    rt = allocate_register((unsigned int*)dst->f.r.rt);
    mov_reg32_reg32(EAX, rs);
@@ -530,8 +530,8 @@ void genmultu(void)
    gencallinterp((unsigned int)cached_interpreter_table.MULTU, 0);
 #else
    int rs, rt;
-   allocate_register_manually_w(EAX, (unsigned int *)&lo, 0);
-   allocate_register_manually_w(EDX, (unsigned int *)&hi, 0);
+   allocate_register_manually_w(EAX, (unsigned int*) &g_state.regs.lo, 0);
+   allocate_register_manually_w(EDX, (unsigned int*) &g_state.regs.hi, 0);
    rs = allocate_register((unsigned int*)dst->f.r.rs);
    rt = allocate_register((unsigned int*)dst->f.r.rt);
    mov_reg32_reg32(EAX, rs);
@@ -545,8 +545,8 @@ void gendiv(void)
    gencallinterp((unsigned int)cached_interpreter_table.DIV, 0);
 #else
    int rs, rt;
-   allocate_register_manually_w(EAX, (unsigned int *)&lo, 0);
-   allocate_register_manually_w(EDX, (unsigned int *)&hi, 0);
+   allocate_register_manually_w(EAX, (unsigned int*) &g_state.regs.lo, 0);
+   allocate_register_manually_w(EDX, (unsigned int*) &g_state.regs.hi, 0);
    rs = allocate_register((unsigned int*)dst->f.r.rs);
    rt = allocate_register((unsigned int*)dst->f.r.rt);
    cmp_reg32_imm32(rt, 0);
@@ -563,8 +563,8 @@ void gendivu(void)
    gencallinterp((unsigned int)cached_interpreter_table.DIVU, 0);
 #else
    int rs, rt;
-   allocate_register_manually_w(EAX, (unsigned int *)&lo, 0);
-   allocate_register_manually_w(EDX, (unsigned int *)&hi, 0);
+   allocate_register_manually_w(EAX, (unsigned int*) &g_state.regs.lo, 0);
+   allocate_register_manually_w(EDX, (unsigned int*) &g_state.regs.hi, 0);
    rs = allocate_register((unsigned int*)dst->f.r.rs);
    rt = allocate_register((unsigned int*)dst->f.r.rt);
    cmp_reg32_imm32(rt, 0);
@@ -590,7 +590,7 @@ void gendmultu(void)
    
    mov_eax_memoffs32((unsigned int *)dst->f.r.rs);
    mul_m32((unsigned int *)dst->f.r.rt); // EDX:EAX = temp1
-   mov_memoffs32_eax((unsigned int *)(&lo));
+   mov_memoffs32_eax((unsigned int*) (&g_state.regs.lo));
    
    mov_reg32_reg32(EBX, EDX); // EBX = temp1>>32
    mov_eax_memoffs32((unsigned int *)dst->f.r.rs);
@@ -604,7 +604,7 @@ void gendmultu(void)
    
    add_reg32_reg32(EBX, EAX);
    adc_reg32_imm32(ECX, 0); // ECX:EBX = result2
-   mov_m32_reg32((unsigned int*)(&lo)+1, EBX);
+   mov_m32_reg32((unsigned int*) (&g_state.regs.lo) + 1, EBX);
    
    mov_reg32_reg32(ESI, EDX); // ESI = temp3>>32
    mov_eax_memoffs32((unsigned int *)(dst->f.r.rs)+1);
@@ -614,8 +614,8 @@ void gendmultu(void)
    
    add_reg32_reg32(EAX, ECX);
    adc_reg32_imm32(EDX, 0); // EDX:EAX = result3
-   mov_memoffs32_eax((unsigned int *)(&hi));
-   mov_m32_reg32((unsigned int *)(&hi)+1, EDX);
+   mov_memoffs32_eax((unsigned int*) (&g_state.regs.hi));
+   mov_m32_reg32((unsigned int*) (&g_state.regs.hi) + 1, EDX);
 #endif
 }
 

--- a/src/r4300/x86/regcache.c
+++ b/src/r4300/x86/regcache.c
@@ -41,7 +41,7 @@ void init_cache(precomp_instr* start)
     last_access[i] = NULL;
     free_since[i] = start;
      }
-     r0 = (unsigned int*)reg;
+     r0 = (unsigned int*) g_state.regs.gpr;
 }
 
 void free_all_registers(void)

--- a/src/r4300/x86_64/assemble.h
+++ b/src/r4300/x86_64/assemble.h
@@ -30,9 +30,8 @@
 #include "api/callbacks.h"
 #include "api/m64p_types.h"
 #include "osal/preproc.h"
+#include "r4300/r4300.h"
 #include "r4300/recomph.h"
-
-extern int64_t reg[32];
 
 #define RAX 0
 #define RCX 1
@@ -116,11 +115,11 @@ static osal_inline void put64(unsigned long long qword)
 static osal_inline int rel_r15_offset(void *dest, const char *op_name)
 {
     /* calculate the destination pointer's offset from the base of the r4300 registers */
-    long long rel_offset = (long long) ((unsigned char *) dest - (unsigned char *) reg);
+    long long rel_offset = (long long) ((unsigned char *) dest - (unsigned char *) g_state.regs.gpr);
 
     if (llabs(rel_offset) > 0x7fffffff)
     {
-        DebugMessage(M64MSG_ERROR, "Error: destination %p more than 2GB away from r15 base %p in %s()", dest, reg, op_name);
+        DebugMessage(M64MSG_ERROR, "Error: destination %p more than 2GB away from r15 base %p in %s()", dest, g_state.regs.gpr, op_name);
         OSAL_BREAKPOINT_INTERRUPT;
     }
 

--- a/src/r4300/x86_64/gbc.c
+++ b/src/r4300/x86_64/gbc.c
@@ -38,7 +38,7 @@
 
 static void genbc1f_test(void)
 {
-   test_m32rel_imm32((unsigned int*)&FCR31, 0x800000);
+   test_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000);
    sete_m8rel((unsigned char *) &branch_taken);
 }
 
@@ -107,7 +107,7 @@ void genbc1f_idle(void)
 
 static void genbc1t_test(void)
 {
-   test_m32rel_imm32((unsigned int*)&FCR31, 0x800000);
+   test_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000);
    setne_m8rel((unsigned char *) &branch_taken);
 }
 

--- a/src/r4300/x86_64/gcop1.c
+++ b/src/r4300/x86_64/gcop1.c
@@ -53,7 +53,7 @@ void genmfc1(void)
    gencallinterp((unsigned long long)cached_interpreter_table.MFC1, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.r.nrd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.r.nrd]));
    mov_reg32_preg64(EBX, RAX);
    mov_m32rel_xreg32((unsigned int*)dst->f.r.rt, EBX);
    sar_reg32_imm8(EBX, 31);
@@ -70,7 +70,7 @@ void gendmfc1(void)
    gencallinterp((unsigned long long)cached_interpreter_table.DMFC1, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *) (&reg_cop1_double[dst->f.r.nrd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.r.nrd]));
    mov_reg32_preg64(EBX, RAX);
    mov_reg32_preg64pimm32(ECX, RAX, 4);
    mov_m32rel_xreg32((unsigned int*)dst->f.r.rt, EBX);
@@ -87,8 +87,8 @@ void gencfc1(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CFC1, 0);
 #else
    gencheck_cop1_unusable();
-   if(dst->f.r.nrd == 31) mov_xreg32_m32rel(EAX, (unsigned int*)&FCR31);
-   else mov_xreg32_m32rel(EAX, (unsigned int*)&FCR0);
+   if(dst->f.r.nrd == 31) mov_xreg32_m32rel(EAX, (unsigned int*) &g_state.regs.fcr_31);
+   else mov_xreg32_m32rel(EAX, (unsigned int*) &g_state.regs.fcr_0);
    mov_m32rel_xreg32((unsigned int*)dst->f.r.rt, EAX);
    sar_reg32_imm8(EAX, 31);
    mov_m32rel_xreg32(((unsigned int*)dst->f.r.rt)+1, EAX);
@@ -105,7 +105,7 @@ void genmtc1(void)
 #else
    gencheck_cop1_unusable();
    mov_xreg32_m32rel(EAX, (unsigned int*)dst->f.r.rt);
-   mov_xreg64_m64rel(RBX, (unsigned long long *)(&reg_cop1_simple[dst->f.r.nrd]));
+   mov_xreg64_m64rel(RBX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.r.nrd]));
    mov_preg64_reg32(RBX, EAX);
 #endif
 }
@@ -121,7 +121,7 @@ void gendmtc1(void)
    gencheck_cop1_unusable();
    mov_xreg32_m32rel(EAX, (unsigned int*)dst->f.r.rt);
    mov_xreg32_m32rel(EBX, ((unsigned int*)dst->f.r.rt)+1);
-   mov_xreg64_m64rel(RDX, (unsigned long long *)(&reg_cop1_double[dst->f.r.nrd]));
+   mov_xreg64_m64rel(RDX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.r.nrd]));
    mov_preg64_reg32(RDX, EAX);
    mov_preg64pimm32_reg32(RDX, 4, EBX);
 #endif
@@ -139,7 +139,7 @@ void genctc1(void)
    
    if (dst->f.r.nrd != 31) return;
    mov_xreg32_m32rel(EAX, (unsigned int*)dst->f.r.rt);
-   mov_m32rel_xreg32((unsigned int*)&FCR31, EAX);
+   mov_m32rel_xreg32((unsigned int*) &g_state.regs.fcr_31, EAX);
    and_eax_imm32(3);
    
    cmp_eax_imm32(0);

--- a/src/r4300/x86_64/gcop1_d.c
+++ b/src/r4300/x86_64/gcop1_d.c
@@ -43,11 +43,11 @@ void genadd_d(void)
     gencallinterp((unsigned long long)cached_interpreter_table.ADD_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fadd_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }
@@ -61,11 +61,11 @@ void gensub_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.SUB_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fsub_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }
@@ -79,11 +79,11 @@ void genmul_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.MUL_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fmul_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }
@@ -97,11 +97,11 @@ void gendiv_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.DIV_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fdiv_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }
@@ -115,10 +115,10 @@ void gensqrt_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.SQRT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fsqrt();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }
@@ -132,10 +132,10 @@ void genabs_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.ABS_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fabs_();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }
@@ -149,10 +149,10 @@ void genmov_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.MOV_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    mov_reg32_preg64(EBX, RAX);
    mov_reg32_preg64pimm32(ECX, RAX, 4);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    mov_preg64_reg32(RAX, EBX);
    mov_preg64pimm32_reg32(RAX, 4, ECX);
 #endif
@@ -167,10 +167,10 @@ void genneg_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.NEG_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fchs();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }
@@ -185,9 +185,9 @@ void genround_l_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&round_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -203,9 +203,9 @@ void gentrunc_l_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&trunc_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -221,9 +221,9 @@ void genceil_l_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&ceil_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -239,9 +239,9 @@ void genfloor_l_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&floor_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -257,9 +257,9 @@ void genround_w_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&round_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -275,9 +275,9 @@ void gentrunc_w_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&trunc_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -293,9 +293,9 @@ void genceil_w_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&ceil_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -311,9 +311,9 @@ void genfloor_w_d(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&floor_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -328,9 +328,9 @@ void gencvt_s_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_S_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -344,9 +344,9 @@ void gencvt_w_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_W_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
 #endif
 }
@@ -360,9 +360,9 @@ void gencvt_l_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_L_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
 #endif
 }
@@ -376,7 +376,7 @@ void genc_f_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_F_D, 0);
 #else
    gencheck_cop1_unusable();
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000);
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000);
 #endif
 }
 
@@ -389,16 +389,16 @@ void genc_un_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_UN_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(13);
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
    jmp_imm_short(11); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
 #endif
 }
 
@@ -411,16 +411,16 @@ void genc_eq_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_EQ_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jne_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -433,17 +433,17 @@ void genc_ueq_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_UEQ_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    jne_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -456,16 +456,16 @@ void genc_olt_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_OLT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jae_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -478,17 +478,17 @@ void genc_ult_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_ULT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    jae_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -501,16 +501,16 @@ void genc_ole_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_OLE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    ja_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -523,17 +523,17 @@ void genc_ule_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_ULE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    ja_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -546,13 +546,13 @@ void genc_sf_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_SF_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000);
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000);
 #endif
 }
 
@@ -565,16 +565,16 @@ void genc_ngle_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_NGLE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(13);
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
    jmp_imm_short(11); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
 #endif
 }
 
@@ -587,16 +587,16 @@ void genc_seq_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_SEQ_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jne_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -609,17 +609,17 @@ void genc_ngl_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_NGL_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    jne_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -632,16 +632,16 @@ void genc_lt_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_LT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jae_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -654,17 +654,17 @@ void genc_nge_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_NGE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    jae_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -677,16 +677,16 @@ void genc_le_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_LE_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    ja_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -699,17 +699,17 @@ void genc_ngt_d(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_NGT_D, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.ft]));
    fld_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fld_preg64_qword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    ja_rj(13); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 

--- a/src/r4300/x86_64/gcop1_l.c
+++ b/src/r4300/x86_64/gcop1_l.c
@@ -41,9 +41,9 @@ void gencvt_s_l(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_S_L, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fild_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -57,9 +57,9 @@ void gencvt_d_l(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_D_L, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fs]));
    fild_preg64_qword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }

--- a/src/r4300/x86_64/gcop1_s.c
+++ b/src/r4300/x86_64/gcop1_s.c
@@ -44,11 +44,11 @@ void genadd_s(void)
     gencallinterp((unsigned long long)cached_interpreter_table.ADD_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fadd_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -62,11 +62,11 @@ void gensub_s(void)
     gencallinterp((unsigned long long)cached_interpreter_table.SUB_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fsub_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -80,11 +80,11 @@ void genmul_s(void)
     gencallinterp((unsigned long long)cached_interpreter_table.MUL_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fmul_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -98,11 +98,11 @@ void gendiv_s(void)
     gencallinterp((unsigned long long)cached_interpreter_table.DIV_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fdiv_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -116,10 +116,10 @@ void gensqrt_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.SQRT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fsqrt();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -133,10 +133,10 @@ void genabs_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.ABS_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fabs_();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -150,9 +150,9 @@ void genmov_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.MOV_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    mov_reg32_preg64(EBX, RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    mov_preg64_reg32(RAX, EBX);
 #endif
 }
@@ -166,10 +166,10 @@ void genneg_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.NEG_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fchs();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -184,9 +184,9 @@ void genround_l_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&round_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -202,9 +202,9 @@ void gentrunc_l_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&trunc_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -220,9 +220,9 @@ void genceil_l_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&ceil_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -238,9 +238,9 @@ void genfloor_l_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&floor_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -256,9 +256,9 @@ void genround_w_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&round_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -274,9 +274,9 @@ void gentrunc_w_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&trunc_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -292,9 +292,9 @@ void genceil_w_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&ceil_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -310,9 +310,9 @@ void genfloor_w_s(void)
 #else
    gencheck_cop1_unusable();
    fldcw_m16rel((unsigned short*)&floor_mode);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
    fldcw_m16rel((unsigned short*)&rounding_mode);
 #endif
@@ -327,9 +327,9 @@ void gencvt_d_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_D_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }
@@ -343,9 +343,9 @@ void gencvt_w_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_W_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fistp_preg64_dword(RAX);
 #endif
 }
@@ -359,9 +359,9 @@ void gencvt_l_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_L_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fistp_preg64_qword(RAX);
 #endif
 }
@@ -375,7 +375,7 @@ void genc_f_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_F_S, 0);
 #else
    gencheck_cop1_unusable();
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000);
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000);
 #endif
 }
 
@@ -388,16 +388,16 @@ void genc_un_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_UN_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(13);
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
    jmp_imm_short(11); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
 #endif
 }
 
@@ -410,16 +410,16 @@ void genc_eq_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_EQ_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jne_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -432,17 +432,17 @@ void genc_ueq_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_UEQ_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    jne_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -455,16 +455,16 @@ void genc_olt_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_OLT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jae_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -477,17 +477,17 @@ void genc_ult_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_ULT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    jae_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -500,16 +500,16 @@ void genc_ole_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_OLE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    ja_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -522,17 +522,17 @@ void genc_ule_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_ULE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fucomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    ja_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -545,13 +545,13 @@ void genc_sf_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_SF_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000);
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000);
 #endif
 }
 
@@ -564,16 +564,16 @@ void genc_ngle_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_NGLE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(13);
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
    jmp_imm_short(11); // 2
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
 #endif
 }
 
@@ -586,16 +586,16 @@ void genc_seq_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_SEQ_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jne_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -608,17 +608,17 @@ void genc_ngl_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_NGL_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    jne_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -631,16 +631,16 @@ void genc_lt_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_LT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jae_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -653,17 +653,17 @@ void genc_nge_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_NGE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    jae_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -676,16 +676,16 @@ void genc_le_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_LE_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    ja_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 
@@ -698,17 +698,17 @@ void genc_ngt_s(void)
    gencallinterp((unsigned long long)cached_interpreter_table.C_NGT_S, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.ft]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.ft]));
    fld_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fld_preg64_dword(RAX);
    fcomip_fpreg(1);
    ffree_fpreg(0);
    jp_rj(15);
    ja_rj(13);
-   or_m32rel_imm32((unsigned int*)&FCR31, 0x800000); // 11
+   or_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, 0x800000); // 11
    jmp_imm_short(11); // 2
-   and_m32rel_imm32((unsigned int*)&FCR31, ~0x800000); // 11
+   and_m32rel_imm32((unsigned int*) &g_state.regs.fcr_31, ~0x800000); // 11
 #endif
 }
 

--- a/src/r4300/x86_64/gcop1_w.c
+++ b/src/r4300/x86_64/gcop1_w.c
@@ -43,9 +43,9 @@ void gencvt_s_w(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_S_W, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fild_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fd]));
    fstp_preg64_dword(RAX);
 #endif
 }
@@ -59,9 +59,9 @@ void gencvt_d_w(void)
    gencallinterp((unsigned long long)cached_interpreter_table.CVT_D_W, 0);
 #else
    gencheck_cop1_unusable();
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_simple[dst->f.cf.fs]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_s[dst->f.cf.fs]));
    fild_preg64_dword(RAX);
-   mov_xreg64_m64rel(RAX, (unsigned long long *)(&reg_cop1_double[dst->f.cf.fd]));
+   mov_xreg64_m64rel(RAX, (unsigned long long*) (&g_state.regs.cp1_d[dst->f.cf.fd]));
    fstp_preg64_qword(RAX);
 #endif
 }

--- a/src/r4300/x86_64/gregimm.c
+++ b/src/r4300/x86_64/gregimm.c
@@ -328,25 +328,25 @@ void genbgezl_idle(void)
 
 static void genbranchlink(void)
 {
-   int r31_64bit = is64((unsigned int*)&reg[31]);
+   int r31_64bit = is64((unsigned int*) &g_state.regs.gpr[31]);
    
    if (r31_64bit == 0)
      {
-    int r31 = allocate_register_32_w((unsigned int *)&reg[31]);
+    int r31 = allocate_register_32_w((unsigned int*) &g_state.regs.gpr[31]);
     
     mov_reg32_imm32(r31, dst->addr+8);
      }
    else if (r31_64bit == -1)
      {
-    mov_m32rel_imm32((unsigned int *)&reg[31], dst->addr + 8);
+    mov_m32rel_imm32((unsigned int*) &g_state.regs.gpr[31], dst->addr + 8);
     if (dst->addr & 0x80000000)
-      mov_m32rel_imm32(((unsigned int *)&reg[31])+1, 0xFFFFFFFF);
+      mov_m32rel_imm32(((unsigned int*) &g_state.regs.gpr[31]) + 1, 0xFFFFFFFF);
     else
-      mov_m32rel_imm32(((unsigned int *)&reg[31])+1, 0);
+      mov_m32rel_imm32(((unsigned int*) &g_state.regs.gpr[31]) + 1, 0);
      }
    else
      {
-    int r31 = allocate_register_64_w((unsigned long long *)&reg[31]);
+    int r31 = allocate_register_64_w((unsigned long long*) &g_state.regs.gpr[31]);
     
     mov_reg32_imm32(r31, dst->addr+8);
     movsxd_reg64_reg32(r31, r31);

--- a/src/r4300/x86_64/gspecial.c
+++ b/src/r4300/x86_64/gspecial.c
@@ -334,7 +334,7 @@ void gensyscall(void)
 #else
    free_registers_move_start();
 
-   mov_m32rel_imm32(&g_cp0_regs[CP0_CAUSE_REG], 8 << 2);
+   mov_m32rel_imm32(&g_state.regs.cp0[CP0_CAUSE_REG], 8 << 2);
    gencallinterp((unsigned long long)exception_general, 0);
 #endif
 }
@@ -352,7 +352,7 @@ void genmfhi(void)
    gencallinterp((unsigned long long)cached_interpreter_table.MFHI, 0);
 #else
    int rd = allocate_register_64_w((unsigned long long *) dst->f.r.rd);
-   int _hi = allocate_register_64((unsigned long long *) &hi);
+   int _hi = allocate_register_64((unsigned long long*) &g_state.regs.hi);
    
    mov_reg64_reg64(rd, _hi);
 #endif
@@ -366,7 +366,7 @@ void genmthi(void)
 #ifdef INTERPRET_MTHI
    gencallinterp((unsigned long long)cached_interpreter_table.MTHI, 0);
 #else
-   int _hi = allocate_register_64_w((unsigned long long *) &hi);
+   int _hi = allocate_register_64_w((unsigned long long*) &g_state.regs.hi);
    int rs = allocate_register_64((unsigned long long *) dst->f.r.rs);
 
    mov_reg64_reg64(_hi, rs);
@@ -382,7 +382,7 @@ void genmflo(void)
    gencallinterp((unsigned long long)cached_interpreter_table.MFLO, 0);
 #else
    int rd = allocate_register_64_w((unsigned long long *) dst->f.r.rd);
-   int _lo = allocate_register_64((unsigned long long *) &lo);
+   int _lo = allocate_register_64((unsigned long long*) &g_state.regs.lo);
    
    mov_reg64_reg64(rd, _lo);
 #endif
@@ -396,7 +396,7 @@ void genmtlo(void)
 #ifdef INTERPRET_MTLO
    gencallinterp((unsigned long long)cached_interpreter_table.MTLO, 0);
 #else
-   int _lo = allocate_register_64_w((unsigned long long *)&lo);
+   int _lo = allocate_register_64_w((unsigned long long*) &g_state.regs.lo);
    int rs = allocate_register_64((unsigned long long *)dst->f.r.rs);
 
    mov_reg64_reg64(_lo, rs);
@@ -508,8 +508,8 @@ void genmult(void)
    gencallinterp((unsigned long long)cached_interpreter_table.MULT, 0);
 #else
    int rs, rt;
-   allocate_register_32_manually_w(EAX, (unsigned int *)&lo); /* these must be done first so they are not assigned by allocate_register() */
-   allocate_register_32_manually_w(EDX, (unsigned int *)&hi);
+   allocate_register_32_manually_w(EAX, (unsigned int*) &g_state.regs.lo); /* these must be done first so they are not assigned by allocate_register() */
+   allocate_register_32_manually_w(EDX, (unsigned int*) &g_state.regs.hi);
    rs = allocate_register_32((unsigned int*)dst->f.r.rs);
    rt = allocate_register_32((unsigned int*)dst->f.r.rt);
    mov_reg32_reg32(EAX, rs);
@@ -526,8 +526,8 @@ void genmultu(void)
    gencallinterp((unsigned long long)cached_interpreter_table.MULTU, 0);
 #else
    int rs, rt;
-   allocate_register_32_manually_w(EAX, (unsigned int *)&lo);
-   allocate_register_32_manually_w(EDX, (unsigned int *)&hi);
+   allocate_register_32_manually_w(EAX, (unsigned int*) &g_state.regs.lo);
+   allocate_register_32_manually_w(EDX, (unsigned int*) &g_state.regs.hi);
    rs = allocate_register_32((unsigned int*)dst->f.r.rs);
    rt = allocate_register_32((unsigned int*)dst->f.r.rt);
    mov_reg32_reg32(EAX, rs);
@@ -544,8 +544,8 @@ void gendiv(void)
    gencallinterp((unsigned long long)cached_interpreter_table.DIV, 0);
 #else
    int rs, rt;
-   allocate_register_32_manually_w(EAX, (unsigned int *)&lo);
-   allocate_register_32_manually_w(EDX, (unsigned int *)&hi);
+   allocate_register_32_manually_w(EAX, (unsigned int*) &g_state.regs.lo);
+   allocate_register_32_manually_w(EDX, (unsigned int*) &g_state.regs.hi);
    rs = allocate_register_32((unsigned int*)dst->f.r.rs);
    rt = allocate_register_32((unsigned int*)dst->f.r.rt);
    cmp_reg32_imm32(rt, 0);
@@ -565,8 +565,8 @@ void gendivu(void)
    gencallinterp((unsigned long long)cached_interpreter_table.DIVU, 0);
 #else
    int rs, rt;
-   allocate_register_32_manually_w(EAX, (unsigned int *)&lo);
-   allocate_register_32_manually_w(EDX, (unsigned int *)&hi);
+   allocate_register_32_manually_w(EAX, (unsigned int*) &g_state.regs.lo);
+   allocate_register_32_manually_w(EDX, (unsigned int*) &g_state.regs.hi);
    rs = allocate_register_32((unsigned int*)dst->f.r.rs);
    rt = allocate_register_32((unsigned int*)dst->f.r.rt);
    cmp_reg32_imm32(rt, 0);
@@ -598,8 +598,8 @@ void gendmultu(void)
    mov_xreg64_m64rel(RAX, (unsigned long long *) dst->f.r.rs);
    mov_xreg64_m64rel(RDX, (unsigned long long *) dst->f.r.rt);
    mul_reg64(RDX);
-   mov_m64rel_xreg64((unsigned long long *) &lo, RAX);
-   mov_m64rel_xreg64((unsigned long long *) &hi, RDX);
+   mov_m64rel_xreg64((unsigned long long*) &g_state.regs.lo, RAX);
+   mov_m64rel_xreg64((unsigned long long*) &g_state.regs.hi, RDX);
 #endif
 }
 

--- a/src/r4300/x86_64/regcache.c
+++ b/src/r4300/x86_64/regcache.c
@@ -50,7 +50,7 @@ void init_cache(precomp_instr* start)
     dirty[i] = 0;
     is64bits[i] = 0;
   }
-  r0 = (unsigned long long *) reg;
+  r0 = (unsigned long long *) g_state.regs.gpr;
 }
 
 void free_all_registers(void)
@@ -614,7 +614,7 @@ static void build_wrapper(precomp_instr *instr, unsigned char* pCode, precomp_bl
 
    *pCode++ = 0x48;
    *pCode++ = 0xB8;
-   *((unsigned long long *) pCode) = (unsigned long long) &reg[0];
+   *((unsigned long long *) pCode) = (unsigned long long) &g_state.regs.gpr[0];
    pCode += 8;
 
    for (i=7; i>=0; i--)
@@ -625,13 +625,13 @@ static void build_wrapper(precomp_instr *instr, unsigned char* pCode, precomp_bl
        *pCode++ = 0x48;
        *pCode++ = 0x8B;
        *pCode++ = 0x80 | (i << 3);
-       riprel = (long long) ((unsigned char *) instr->reg_cache_infos.needed_registers[i] - (unsigned char *) &reg[0]);
+       riprel = (long long) ((unsigned char *) instr->reg_cache_infos.needed_registers[i] - (unsigned char *) &g_state.regs.gpr[0]);
        *((int *) pCode) = (int) riprel;
        pCode += 4;
        if (riprel >= 0x7fffffffLL || riprel < -0x80000000LL)
        {
-         DebugMessage(M64MSG_ERROR, "build_wrapper error: reg[%i] offset too big for relative address from %p to %p",
-                i, (&reg[0]), instr->reg_cache_infos.needed_registers[i]);
+         DebugMessage(M64MSG_ERROR, "build_wrapper error: g_state.regs.gpr[%i] offset too big for relative address from %p to %p",
+                i, (&g_state.regs.gpr[0]), instr->reg_cache_infos.needed_registers[i]);
          OSAL_BREAKPOINT_INTERRUPT;
        }
      }

--- a/src/r4300/x86_64/rjump.c
+++ b/src/r4300/x86_64/rjump.c
@@ -92,7 +92,7 @@ void dyna_start(void *code)
      " pop  %%r12              \n"
      " pop  %%rbx              \n"
      : [save_rsp]"=m"(save_rsp), [save_rip]"=m"(save_rip), [return_address]"=m"(return_address)
-     : "b" (code), [reg]"m"(*reg)
+     : "b" (code), [reg]"m"(*g_state.regs.gpr)
      : "%rax", "memory"
      );
 


### PR DESCRIPTION
The New Dynarec/ARM redefines global variables in its own memory block in order to bring a lot of them together in memory for easy indexing. This commit does the same for all other R4300 cores on all architectures by moving a lot of often-used global variables from many files into one struct in `r4300.c`:

> `reg[32]`, `hi`, `lo`, `g_cp0_regs[32]`, `FCR0`, `FCR31`, `llbit`, `reg_cop1_simple[32]`, `reg_cop1_double[32]`, `reg_cop1_fgr_64[32]`, `delay_slot`, `next_interupt`, `address`, `rdword`, `cpu_byte`, `cpu_hword`, `cpu_word`, `cpu_dword` => `g_state`

The compiler is then allowed to reference every member of that structure with offsets from a single address, which is faster on ARM and MIPS (and may or may not be faster on x86 due to processor microarchitecture changes) when emitting position-independent code.

In addition, I have aligned the new structure to 4 KiB in order to induce only 1 TLB miss for accessing it.

The new structure is hidden and recreated in the New Dynarec/ARM as usual, but the number of recreated variables is greatly reduced.

I expect the performance to increase in these cores:

* Pure Interpreter: 2%..10% faster, due to fewer reloads of global variable addresses, increased cache locality and reduced TLB misses; this depends on a game's use of multiplier unit instructions, `MFC0`, `MTC0`, `[D]MFC1`, `[D]MTC1`, floating-point width conversion instructions and memory access instructions, which accessed more than one global variable (and now access the members of the structure).
* Cached Interpreter: <2% faster, due to increased cache locality and reduced TLB misses. It loads operand pointers from a `struct precomp_instr`, so after compilation, there are no reloads of global variable addresses.
* Hacktarux JIT/x86, x86-64: <2% faster, due to increased cache locality and reduced TLB misses. Better code could be generated to take advantage of the new structure, but I didn't change anything there.

A possibly undesirable aspect of this change is that the Coprocessor 0-related variables are no longer in `cp0.c`, the FPU is no longer in `cp1.c`, and the global variables used as parameters to the memory accessor functions are no longer in `memory.c`.

Commit 3c9a3fcea55a4f43f60c761e49d62320288ef3fe will definitely not build on ARM, and bbe2a26b623d582a4d83bea55a8b50f8c8a17d7c should build, but I don't know if it works properly because I don't have an ARM device to test with.