### PR TITLE
Framelimiter: Discard frames with excessive execution time

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -782,6 +782,10 @@ static void apply_speed_limiter(void)
         }
     }
 
+    // Discard frames with excessive execution time
+    if (ThisFrameDelta > AdjustedLimit * 3)
+    	ThisFrameDelta = 0.f;
+
     // update our data structures
     LastFPSTime = CurrentFPSTime ;
     VITotalDelta += ThisFrameDelta - VIDeltas[VIDeltasIndex];


### PR DESCRIPTION
Sometimes a frame takes an excessive amount of time to execute, this usually happens when moving to another zone (ingame loading).
I noticed that the framerate becomes very unstable in this case. Discarding these frames help to get a more stable framerate.
