### PR TITLE
Fix link directory for Raspberry Pi

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -265,7 +265,7 @@ LDLIBS += $(SDL_LDLIBS)
 
 ifeq ($(VC), 1)
   CFLAGS += -DUSE_GLES -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/vmcs_host/linux
-  LDLIBS += -L/opt/vc/lib -lGLESv2 -lEGL -lbcm_host -lvcos -lvchiq_arm
+  LDLIBS += -L/opt/vc/lib -L/opt/vc/lib/GL -lGLESv2 -lEGL -lbcm_host -lvcos -lvchiq_arm
   # OSD uses non-ES code and breaks attribs of video plugins
   OSD=0
 endif


### PR DESCRIPTION
The newest Raspberry Pi firmware moves some libraries into a "GL" folder.