### PR TITLE
word-wise dma copy

### DIFF
--- a/src/memory/memory.h
+++ b/src/memory/memory.h
@@ -72,6 +72,14 @@ extern void (*writememd[0x10000])(void);
 
 #endif
 
+#ifdef __arm__
+    void __aeabi_memcpy4(void*, void*, uint32_t);		//this is present in libc6 on Raspberry PI
+    #define MEMCPY4(...) __aeabi_memcpy4(__VA_ARGS__)
+#else
+    #define MEMCPY4(...) memcpy(__VA_ARGS__)
+#endif
+
+
 static void masked_write(uint32_t* dst, uint32_t value, uint32_t mask)
 {
     *dst = (*dst & ~mask) | (value & mask);

--- a/src/pi/pi_controller.c
+++ b/src/pi/pi_controller.c
@@ -126,10 +126,17 @@ static void dma_pi_write(struct pi_controller* pi)
     dram = (uint8_t*)pi->ri->rdram.dram;
     rom = pi->cart_rom.rom;
 
-    for(i = 0; i < longueur; ++i)
-    {
-        dram[(dram_address+i)^S8] = rom[(rom_address+i)^S8];
-    }
+	if (((dram_address | rom_address | longueur) & 3) != 0)
+	{	
+    	for(i = 0; i < longueur; ++i)
+    	{
+        	dram[(dram_address+i)^S8] = rom[(rom_address+i)^S8];
+    	}
+	}
+	else
+	{
+		MEMCPY4(&dram[dram_address], &rom[rom_address], longueur);
+	}
 
     invalidate_r4300_cached_code(0x80000000 + dram_address, longueur);
     invalidate_r4300_cached_code(0xa0000000 + dram_address, longueur);


### PR DESCRIPTION
If DMA transfers are word aligned then a more efficient copy can be done. I have not seen a dma transfer that is not word aligned however I have not extensively checked all roms so have left the safer byte-wise implementation in. 