### PR TITLE
Allow setting a loadstate job before emulator is running.

### DIFF
--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -235,8 +235,6 @@ EXPORT m64p_error CALL CoreDoCommand(m64p_command Command, int ParamInt, void *P
                 return M64ERR_INPUT_ASSERT;
             return main_core_state_set((m64p_core_param) ParamInt, *((int *)ParamPtr));
         case M64CMD_STATE_LOAD:
-            if (!g_EmulatorRunning)
-                return M64ERR_INVALID_STATE;
             main_state_load((char *) ParamPtr);
             return M64ERR_SUCCESS;
         case M64CMD_STATE_SAVE:

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -443,10 +443,13 @@ void main_state_inc_slot(void)
 
 void main_state_load(const char *filename)
 {
-    rumblepak_rumble(&g_si.pif.controllers[0].rumblepak, RUMBLE_STOP);
-    rumblepak_rumble(&g_si.pif.controllers[1].rumblepak, RUMBLE_STOP);
-    rumblepak_rumble(&g_si.pif.controllers[2].rumblepak, RUMBLE_STOP);
-    rumblepak_rumble(&g_si.pif.controllers[3].rumblepak, RUMBLE_STOP);
+    if (g_EmulatorRunning)
+    {
+        rumblepak_rumble(&g_si.pif.controllers[0].rumblepak, RUMBLE_STOP);
+        rumblepak_rumble(&g_si.pif.controllers[1].rumblepak, RUMBLE_STOP);
+        rumblepak_rumble(&g_si.pif.controllers[2].rumblepak, RUMBLE_STOP);
+        rumblepak_rumble(&g_si.pif.controllers[3].rumblepak, RUMBLE_STOP);
+    }
 
     if (filename == NULL) // Save to slot
         savestates_set_job(savestates_job_load, savestates_type_m64p, NULL);


### PR DESCRIPTION
If a loadstate job is set before emulator is running the loadstate will happen on the first safe state interrupt.