### PR TITLE
Make SDL usage optional in some files

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -257,7 +257,7 @@ ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
       $(warning Using SDL 1.2 libraries)
     endif
   endif
-  SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
+  SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags) -DUSE_SDL
   SDL_LDLIBS += $(shell $(SDL_CONFIG) --libs)
 endif
 CFLAGS += $(SDL_CFLAGS)

--- a/src/main/savestates.h
+++ b/src/main/savestates.h
@@ -48,6 +48,9 @@ void savestates_deinit(void);
 int savestates_load(void);
 int savestates_save(void);
 
+int savestates_save_m64p(char *filepath);
+int savestates_load_m64p(char *filepath);
+
 void savestates_select_slot(unsigned int s);
 unsigned int savestates_get_slot(void);
 void savestates_set_autoinc_slot(int b);

--- a/src/r4300/interupt.c
+++ b/src/r4300/interupt.c
@@ -23,7 +23,6 @@
 
 #include "interupt.h"
 
-#include <SDL.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
This is needed to make the savestate/cheat code work with GLupeN64 (RetroArch).

RetroArch doesn't use/need SDL, so this protects the SDL calls inside "USE_SDL"

It also exposes savestates_save_m64p/savestates_load_m64p, since RetroArch has its own slot management system.

I'm not sure about Visual Studio, somewhere in there it will need to define USE_SDL for this to work.