### PR TITLE
Use custom ViRefresh for some games

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -792,6 +792,7 @@ RefMD5=90448C4175EE9D0247674474DCABDFED
 GoodName=All-Star Baseball 2001 (U) [!]
 CRC=5446C6EF E18E47BB
 RefMD5=90448C4175EE9D0247674474DCABDFED
+ViRefresh=1400
 
 [CD04ABC5979F22EF5D6FDC4DCFAA4D50]
 GoodName=All-Star Baseball 2001 (U) [f1] (PAL)
@@ -1397,6 +1398,7 @@ CRC=A1B64A61 D014940B
 Players=4
 SaveType=Controller Pack
 CountPerOp=3
+ViRefresh=1450
 
 [9D5A1B779F8B43E63E8CE8427675A7EF]
 GoodName=Beetle Adventure Racing! (E) (M3) [h1C]
@@ -1413,6 +1415,8 @@ GoodName=Beetle Adventure Racing! (J) [!]
 CRC=9C7318D2 24AE0DC1
 Players=4
 SaveType=Controller Pack
+CountPerOp=3
+ViRefresh=1400
 
 [E126B84FA242916289D04D68C0E20BFE]
 GoodName=Beetle Adventure Racing! (J) [b1]
@@ -1424,6 +1428,8 @@ GoodName=Beetle Adventure Racing! (U) (M3) [!]
 CRC=EDF419A8 BF1904CC
 SaveType=Controller Pack
 Players=4
+CountPerOp=3
+ViRefresh=1400
 
 [D11BC38F26EA2835FBF017FE9BD404FE]
 GoodName=Beetle Adventure Racing! (U) (M3) [b1]
@@ -1935,6 +1941,7 @@ CRC=8F12C096 45DC17E1
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+ViRefresh=2200
 
 [5BF0F2351AEE577A8345D6E13D197E06]
 GoodName=Bug's Life, A (E) [f1] (NTSC)
@@ -1947,6 +1954,7 @@ CRC=2B38AEC0 6350B810
 SaveType=Controller Pack
 Players=1
 CountPerOp=1
+ViRefresh=2200
 
 [504C92A5978B7EAE7A3FD30645E06D39]
 GoodName=Bug's Life, A (F) [f1] (NTSC)
@@ -1959,6 +1967,7 @@ CRC=DFF227D9 0D4D8169
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+ViRefresh=2200
 
 [919E5D60A7F9A79D89AC179123D47EEE]
 GoodName=Bug's Life, A (G) [f1] (NTSC)
@@ -1971,6 +1980,7 @@ CRC=F63B89CE 4582D57D
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+ViRefresh=2200
 
 [7FD6BFFB80F920E01EF869829D485EA3]
 GoodName=Bug's Life, A (U) [!]
@@ -1978,6 +1988,7 @@ CRC=82DC04FD CF2D82F4
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+ViRefresh=2200
 
 [14ACC20454B0C2789C9F7EF7A556231A]
 GoodName=Bug's Life, A (U) [b1]
@@ -1985,6 +1996,7 @@ CRC=82DC04FD CF2D82F4
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+ViRefresh=2200
 
 [6472BD444D2025B1D883FFAE35D94FD4]
 GoodName=Bug's Life, A (U) [b1][f1] (PAL)
@@ -2852,12 +2864,14 @@ GoodName=Conker's Bad Fur Day (E) [!]
 CRC=373F5889 9A6CA80A
 SaveType=Eeprom 16KB
 Players=4
+ViRefresh=2200
 
 [00E2920665F2329B95797A7EAABC2390]
 GoodName=Conker's Bad Fur Day (U) [!]
 CRC=30C7AC50 7704072D
 SaveType=Eeprom 16KB
 Players=4
+ViRefresh=2200
 
 [DB7A03B77D44DB81B8A3FCDFC4B72D8C]
 GoodName=Cruis'n Exotica (U) [!]
@@ -4630,6 +4644,7 @@ GoodName=FIFA Soccer 64 (E) (M3) [!]
 CRC=C3F19159 65D2BC5A
 Players=4
 SaveType=Controller Pack
+ViRefresh=2504
 
 [1D71761771E3BFFC091E38B9E8B5E590]
 GoodName=FIFA Soccer 64 (E) (M3) [b1]
@@ -4661,6 +4676,7 @@ GoodName=FIFA Soccer 64 (U) (M3) [!]
 CRC=C3F19159 65D2BC5A
 Players=4
 SaveType=Controller Pack
+ViRefresh=2504
 
 [CA56F2DE80839EC88750C15A21AA7C53]
 GoodName=FIFA Soccer 64 (U) (M3) [b1]
@@ -5400,6 +5416,7 @@ CRC=BD1263E5 388C9BE7
 GoodName=HSV Adventure Racing (A) [b1]
 CRC=72611D7D 9919BDD2
 CountPerOp=3
+ViRefresh=1450
 
 [8C7AF37A3CB7306EBCCAC4029EB5C57D]
 GoodName=HSV Adventure Racing (A) [f1] (NTSC)
@@ -5409,6 +5426,7 @@ CRC=B20CC247 B879579A
 GoodName=HSV Adventure Racing (A)
 CRC=72611D7D 9919BDD2
 CountPerOp=3
+ViRefresh=1450
 
 [3D4C7B11076BAFA4620BCC154C0EEEF3]
 GoodName=Hamster Monogatari 64 (J) [!]
@@ -5949,12 +5967,16 @@ GoodName=Indiana Jones and the Infernal Machine (U) [!]
 CRC=AF9DCC15 1A723D88
 Players=1
 SaveType=Eeprom 4KB
+CountPerOp=1
+ViRefresh=2050
 
 [6F417D30D772F4420C9384E9BBB7BC01]
 GoodName=Indiana Jones and the Infernal Machine (E)
 CRC=3A6F8C6B 2897BAEB
 SaveType=Eeprom 4KB
 Players=1
+CountPerOp=1
+ViRefresh=1800
 
 [A7781D441AF55C4FF8AFC68AB3A59313]
 GoodName=Indy Racing 2000 (U) [!]
@@ -7414,6 +7436,7 @@ SaveType=Eeprom 4KB
 Rumble=Yes
 Players=1
 Status=3
+ViRefresh=1450
 
 [6B1E294A9199E6F22DBC6ABC59BD7568]
 GoodName=Lode Runner 3-D (E) (M5) [b1]
@@ -7427,6 +7450,7 @@ SaveType=Eeprom 4KB
 Rumble=Yes
 Players=1
 Status=3
+ViRefresh=1400
 
 [D038813541589F0B3F1F900F4FD22C9B]
 GoodName=Lode Runner 3-D (U) [!]
@@ -7435,6 +7459,7 @@ SaveType=Eeprom 4KB
 Rumble=Yes
 Players=1
 Status=3
+ViRefresh=1400
 
 [5FBA92D908B9962F26D389C85F6E88CF]
 GoodName=Lode Runner 3-D (U) [b1][f1] (PAL)
@@ -9661,6 +9686,7 @@ Players=4
 Rumble=Yes
 SaveType=Controller Pack
 CountPerOp=1
+ViRefresh=500
 
 [76DB89759121710C416ECFB1736B5E39]
 GoodName=NBA Showtime - NBA on NBC (U) [f1] (Country Check)
@@ -10133,7 +10159,7 @@ CRC=2857674D CC4337DA
 Players=1
 Rumble=Yes
 SaveType=Controller Pack
-CountPerOp=1
+ViRefresh=2200
 
 [60A2CFF1515D4C7902DDE32A6E01D411]
 GoodName=Nightmare Creatures (U) [b1]
@@ -10168,6 +10194,7 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
+ViRefresh=2200
 
 [B2DF29627E0219A9C14605F46803C94C]
 GoodName=Nintendo All-Star! Dairantou Smash Brothers (J) [b1]
@@ -12133,6 +12160,7 @@ CRC=0AC61D39 ABFA03A6
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
+ViRefresh=2200
 
 [207EFE58C7C221DBDFFF285AB80126C1]
 GoodName=Rugrats in Paris - The Movie (U) [!]
@@ -12140,6 +12168,7 @@ CRC=1FC21532 0B6466D4
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
+ViRefresh=2200
 
 [F3515A45EC01D2C9FEAFBAB2B85D72C4]
 GoodName=Rugrats in Paris - The Movie (U) [T+Spa0.10]
@@ -13737,6 +13766,7 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
+ViRefresh=2200
 
 [7F18A06BB16A507E23F9DD636B7046A6]
 GoodName=Super Smash Bros. (A) [f1]
@@ -13750,6 +13780,7 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
+ViRefresh=2200
 
 [4D37726FDFEC039CB36E2AAE65B9727D]
 GoodName=Super Smash Bros. (E) (M3) [b1]
@@ -13768,6 +13799,7 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
+ViRefresh=2200
 
 [508BE860974B75470851A2D25C0FCB36]
 GoodName=Super Smash Bros. (U) [b1]

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -887,6 +887,8 @@ m64p_error main_run(void)
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
     if (count_per_op <= 0)
         count_per_op = ROM_PARAMS.countperop;
+    if (g_vi_refresh_rate == 0)
+        g_vi_refresh_rate = 1500;
     cheat_add_hacks();
 
     /* do byte-swapping if it's not been done yet */

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -58,6 +58,7 @@ unsigned char* g_rom = NULL;
 int g_rom_size = 0;
 unsigned char g_alternate_vi_timing = 0;
 
+int g_vi_refresh_rate = 0;
 unsigned char isGoldeneyeRom = 0;
 
 m64p_rom_header   ROM_HEADER;
@@ -197,6 +198,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.countperop = entry->countperop;
         ROM_PARAMS.cheats = entry->cheats;
         g_alternate_vi_timing = entry->alternate_vi_timing;
+        g_vi_refresh_rate = entry->vi_refresh_rate;
     }
     else
     {
@@ -521,6 +523,10 @@ void romdatabase_open(void)
                 if(!strcmp(l.value, "Alternate")) {
                     search->entry.alternate_vi_timing = 1;
                 }
+            }
+            else if(!strcmp(l.name, "ViRefresh"))
+            {
+                 search->entry.vi_refresh_rate = atoi(l.value);
             }
             else if(!strcmp(l.name, "RefMD5"))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -43,6 +43,7 @@ m64p_error close_rom(void);
 
 extern unsigned char* g_rom;
 extern int g_rom_size;
+extern int g_vi_refresh_rate;
 extern unsigned char g_alternate_vi_timing;
 
 extern unsigned char isGoldeneyeRom;
@@ -126,6 +127,7 @@ typedef struct
    unsigned char players; /* Local players 0-4, 2/3/4 way Netplay indicated by 5/6/7. */
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
    unsigned char alternate_vi_timing;
+   int vi_refresh_rate;
    unsigned char countperop;
    uint32_t set_flags;
 } romdatabase_entry;

--- a/src/vi/vi_controller.c
+++ b/src/vi/vi_controller.c
@@ -55,7 +55,7 @@ int read_vi_regs(void* opaque, uint32_t address, uint32_t* value)
         if (g_alternate_vi_timing)
             vi->regs[VI_CURRENT_REG] = (vi->delay - (vi->next_vi - cp0_regs[CP0_COUNT_REG])) % 0x20E;
         else
-            vi->regs[VI_CURRENT_REG] = (vi->delay - (vi->next_vi - cp0_regs[CP0_COUNT_REG]))/1500;
+            vi->regs[VI_CURRENT_REG] = (vi->delay - (vi->next_vi - cp0_regs[CP0_COUNT_REG]))/g_vi_refresh_rate;
         vi->regs[VI_CURRENT_REG] = (vi->regs[VI_CURRENT_REG] & (~1)) | vi->field;
     }
 
@@ -110,7 +110,7 @@ void vi_vertical_interrupt_event(struct vi_controller* vi)
     /* schedule next vertical interrupt */
     vi->delay = (vi->regs[VI_V_SYNC_REG] == 0)
             ? 500000
-            : (vi->regs[VI_V_SYNC_REG] + 1)*1500;
+            : (vi->regs[VI_V_SYNC_REG] + 1)*g_vi_refresh_rate;
 
     vi->next_vi += vi->delay;
 


### PR DESCRIPTION
This is meant to resolve https://github.com/mupen64plus/mupen64plus-core/issues/139

These values were taken from Project64's RDB file:
https://github.com/project64/project64/blob/master/Config/Project64.rdb

I assume they came to those values via some testing, but this should probably receive some testing as well before it is merged.

For games that had a ViRefresh value I also made sure the CountPerOp (Counter Factor for PJ64) matched. That includes Beetle Adventure Racing, Indiana Jones and the Infernal Machine, and Nightmare Creatures