### PR TITLE
Avoid processing CIC response pif ram as commands

### DIFF
--- a/src/si/pif.c
+++ b/src/si/pif.c
@@ -123,6 +123,8 @@ void update_pif_write(struct si_controller* si)
 
     char challenge[30], response[30];
     int i=0, channel=0;
+
+    pif->cic_challenge = 0;
     if (pif->ram[0x3F] > 1)
     {
         switch (pif->ram[0x3F])
@@ -148,6 +150,7 @@ void update_pif_write(struct si_controller* si)
             }
             // the last byte (2 nibbles) is always 0
             pif->ram[63] = 0;
+            pif->cic_challenge = 1;
             break;
         case 0x08:
 #ifdef DEBUG_PIF
@@ -160,6 +163,7 @@ void update_pif_write(struct si_controller* si)
         }
         return;
     }
+
     while (i<0x40)
     {
         switch (pif->ram[i])
@@ -204,6 +208,12 @@ void update_pif_read(struct si_controller* si)
     struct pif* pif = &si->pif;
 
     int i=0, channel=0;
+
+    /* When PIF ram contains a CIC challenge result, do not
+     * process the memory as if it were normal commands. */
+    if (pif->cic_challenge)
+        return;
+
     while (i<0x40)
     {
         switch (pif->ram[i])

--- a/src/si/pif.h
+++ b/src/si/pif.h
@@ -52,6 +52,7 @@ enum pif_commands
 struct pif
 {
     uint8_t ram[PIF_RAM_SIZE];
+    uint8_t cic_challenge;
 
     struct game_controller controllers[GAME_CONTROLLERS_COUNT];
     struct eeprom eeprom;


### PR DESCRIPTION
When a CIC challenge took place in update_pif_write(), the pif ram
contains a bunch 0xFF followed by 0x00 at offsets 46 and 47. Offsets
48 onwards contains the challenge answer.

Then when update_pif_read() is called, the 0xFF bytes are skipped
up to the two 0x00 bytes that increase the channel to 2. Then the
challenge answer is (incorrectly) processed as if it were commands
for the third controller.

This cause issues with the raphnetraw plugin since it modifies pif ram
to store the result or command error flags. This corrupts the response
and leads to challenge failure.