### PR TITLE
Allow CountPerScan and ViTiming in ROM database to be overridden

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -244,6 +244,8 @@ int main_set_core_defaults(void)
     ConfigSetDefaultString(g_CoreConfig, "SharedDataPath", "", "Path to a directory to search when looking for shared data files");
     ConfigSetDefaultBool(g_CoreConfig, "DelaySI", 1, "Delay interrupt after DMA SI read/write");
     ConfigSetDefaultInt(g_CoreConfig, "CountPerOp", 0, "Force number of cycles per emulated instruction");
+    ConfigSetDefaultInt(g_CoreConfig, "ViTiming", -1, "Use alternate VI timing (-1=Game default, 0=Don't use alternate timing, 1=Use alternate timing)");
+    ConfigSetDefaultInt(g_CoreConfig, "CountPerScanline", -1, "Modify the default count per scanline(-1 or 0=Game default)");
     ConfigSetDefaultBool(g_CoreConfig, "DisableSpecRecomp", 1, "Disable speculative precompilation in new dynarec");
 
     /* handle upgrades */
@@ -909,8 +911,17 @@ m64p_error main_run(void)
     g_delay_si = ConfigGetParamBool(g_CoreConfig, "DelaySI");
     disable_extra_mem = ConfigGetParamInt(g_CoreConfig, "DisableExtraMem");
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
+    int alternate_vi_timing = ConfigGetParamInt(g_CoreConfig, "ViTiming");
+    int count_per_scanline  = ConfigGetParamInt(g_CoreConfig, "CountPerScanline");
     if (count_per_op <= 0)
         count_per_op = ROM_PARAMS.countperop;
+
+    if (alternate_vi_timing < 0)
+        alternate_vi_timing = ROM_PARAMS.vitiming;
+
+    if (count_per_scanline  <= 0)
+        count_per_scanline = ROM_PARAMS.countperscanline;
+
     cheat_add_hacks();
 
     /* do byte-swapping if it's not been done yet */
@@ -953,7 +964,7 @@ m64p_error main_run(void)
                 rumbles,
                 storage_file_ptr(&eep, 0), (ROM_SETTINGS.savetype != EEPROM_16KB) ? 0x200 : 0x800, (ROM_SETTINGS.savetype != EEPROM_16KB) ? 0x8000 : 0xc000, &eep_storage,
                 &rtc,
-                vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype), g_count_per_scanline, g_alternate_vi_timing);
+                vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype), count_per_scanline, alternate_vi_timing);
 
     // Attach rom to plugins
     if (!gfx.romOpen())

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -45,11 +45,10 @@
 #include "util.h"
 
 #define DEFAULT 16
+#define ALTERNATE_VI_TIMING_DEFAULT 0
+#define DEFAULT_COUNT_PER_SCANLINE 1500
 
 #define CHUNKSIZE 1024*128 /* Read files 128KB at a time. */
-
-/* Amount of cpu cycles per vi scanline - empirically determined */
-enum { DEFAULT_COUNT_PER_SCANLINE = 1500 };
 
 static romdatabase_entry* ini_search_by_md5(md5_byte_t* md5);
 
@@ -59,9 +58,6 @@ static _romdatabase g_romdatabase;
 unsigned char* g_rom = NULL;
 /* Global loaded rom size. */
 int g_rom_size = 0;
-/* Global hacks */
-unsigned char g_alternate_vi_timing = 0;
-int           g_count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
 unsigned char isGoldeneyeRom = 0;
 
 m64p_rom_header   ROM_HEADER;
@@ -178,15 +174,13 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     /* add some useful properties to ROM_PARAMS */
     ROM_PARAMS.systemtype = rom_country_code_to_system_type(ROM_HEADER.Country_code);
     ROM_PARAMS.countperop = COUNT_PER_OP_DEFAULT;
+    ROM_PARAMS.vitiming = ALTERNATE_VI_TIMING_DEFAULT;
+    ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.cheats = NULL;
 
     memcpy(ROM_PARAMS.headername, ROM_HEADER.Name, 20);
     ROM_PARAMS.headername[20] = '\0';
     trim(ROM_PARAMS.headername); /* Remove trailing whitespace from ROM name. */
-
-    /* set default values for global variables which can be set by the ROM ini */
-    g_alternate_vi_timing = 0;
-    g_count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
 
     /* Look up this ROM in the .ini file and fill in goodname, etc */
     if ((entry=ini_search_by_md5(digest)) != NULL ||
@@ -199,10 +193,9 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.players = entry->players;
         ROM_SETTINGS.rumble = entry->rumble;
         ROM_PARAMS.countperop = entry->countperop;
+        ROM_PARAMS.vitiming = entry->alternate_vi_timing;
+        ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.cheats = entry->cheats;
-        g_alternate_vi_timing = entry->alternate_vi_timing;
-        if (entry->count_per_scanline > 0)
-            g_count_per_scanline = entry->count_per_scanline;
     }
     else
     {
@@ -213,6 +206,8 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.players = 0;
         ROM_SETTINGS.rumble = 0;
         ROM_PARAMS.countperop = COUNT_PER_OP_DEFAULT;
+        ROM_PARAMS.vitiming = ALTERNATE_VI_TIMING_DEFAULT;
+        ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.cheats = NULL;
     }
 
@@ -452,6 +447,8 @@ void romdatabase_open(void)
             search->entry.players = DEFAULT;
             search->entry.rumble = DEFAULT; 
             search->entry.countperop = COUNT_PER_OP_DEFAULT;
+            search->entry.alternate_vi_timing = ALTERNATE_VI_TIMING_DEFAULT;
+            search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.cheats = NULL;
             search->entry.set_flags = ROMDATABASE_ENTRY_NONE;
 

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -43,8 +43,6 @@ m64p_error close_rom(void);
 
 extern unsigned char* g_rom;
 extern int g_rom_size;
-extern int g_count_per_scanline;
-extern unsigned char g_alternate_vi_timing;
 
 extern unsigned char isGoldeneyeRom;
 
@@ -54,6 +52,8 @@ typedef struct _rom_params
    m64p_system_type systemtype;
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
+   int vitiming;
+   int countperscanline;
 } rom_params;
 
 extern m64p_rom_header   ROM_HEADER;


### PR DESCRIPTION
Allow ViRefresh and ViTiming in ROM database to be overridden in mupen64plus.cfg

This makes it easier to search for a correct value for a ROM because we don't have to find the correct ROM in the database.

This was done in the same style as CountPerOp.