### PR TITLE
Fix Kirby 64 save size

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -5708,7 +5708,7 @@ RefMD5=AB676C3E9D26A77450DDB4AACD1A3861
 [B1A67AEBC2BE89A800E5EB60C0DFA968]
 GoodName=Hoshi no Kirby 64 (J) (V1.0) [!]
 CRC=C1D702BD 6D416547
-SaveType=Eeprom 4KB
+SaveType=SRAM
 Players=4
 
 [460A42ED5612EBBF92F386689067384E]
@@ -5725,19 +5725,19 @@ RefMD5=B1A67AEBC2BE89A800E5EB60C0DFA968
 GoodName=Hoshi no Kirby 64 (J) (V1.1) [!]
 CRC=CA1BB86F 41CCA5C5
 Players=4
-SaveType=Eeprom 4KB
+SaveType=SRAM
 
 [3EC0471E2CBEE17471DDBF80C56606D5]
 GoodName=Hoshi no Kirby 64 (J) (V1.2) [!]
 CRC=0C581C7A 3D6E20E4
 Players=4
-SaveType=Eeprom 4KB
+SaveType=Eeprom 16KB
 
 [35E039F8E79843917D02BE06D00C457B]
 GoodName=Hoshi no Kirby 64 (J) (V1.3) [!]
 CRC=BCB1F89F 060752A2
 Players=4
-SaveType=Eeprom 4KB
+SaveType=Eeprom 16KB
 
 [EF34DA35EF8A0734843CB182C19FEB26]
 GoodName=Hot Wheels Turbo Racing (E) (M3) [!]
@@ -6668,7 +6668,7 @@ Players=4
 GoodName=Kirby 64 - The Crystal Shards (E) [!]
 CRC=0D93BA11 683868A6
 Players=4
-SaveType=Eeprom 4KB
+SaveType=Eeprom 16KB
 
 [E3BFAF1AD4A58A3AB7FD7310C1F45D81]
 GoodName=Kirby 64 - The Crystal Shards (E) [b1]
@@ -6684,7 +6684,7 @@ RefMD5=A44B7A612964A6D6139D0426E569D9C9
 GoodName=Kirby 64 - The Crystal Shards (U) [!]
 CRC=46039FB4 0337822C
 Players=4
-SaveType=Eeprom 4KB
+SaveType=Eeprom 16KB
 
 [329C0A564D3B4477E2887097389AB7D6]
 GoodName=Kirby 64 - The Crystal Shards (U) [b1]


### PR DESCRIPTION
My cart for Kirby 64 (U) has the BK16D 9851 eeprom chip.
The (J) V1.0+V1.1 seem to use sram. The emulator creates .sra, which matches Project64's behavior as well.