### PR TITLE
Avoid g_dev in r4300 code

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -363,7 +363,7 @@ what's new in 0.5:
       feature. Mariokart's monitor in first race running fullspeed and
       puzzle effect in banjo's intro are two examples that i can think
       about but there are many more.
-    + detection of VI interupt rate works on weird country codes
+    + detection of VI interrupt rate works on weird country codes
     + better detection of self modifying code in dma
     + warnings fixed on new gcc versions
     + rsp's dmem and imem are now contiguous in PC's memory (some windows
@@ -510,7 +510,7 @@ what's new in 0.1:
   - Core
     + sram bug zelda oot fixed
     + flashram is working
-    + a new interupt system that'll enabled
+    + a new interrupt system that'll enabled
       more accurate timing in the future but can cause
       some compatibility issues right now
     + bug in DMULT/DMULTU opcode fixed

--- a/doc/new_dynarec.mediawiki
+++ b/doc/new_dynarec.mediawiki
@@ -186,7 +186,7 @@ As in the original mupen64plus, the emulated clock runs at 37.5 MHz, and each in
 
 ==Interrupt handler==
 
-When the cycle count register reaches its limit, cc_interrupt is called, which in turn calls gen_interupt [sic].  If interrupts are not enabled, cc_interrupt returns.  If interrupts are enabled, and an interrupt is to be taken, the pending_exception flag will be set.  In this case, cc_interrupt does not return, and instead pops the stack and causes an unconditional jump to the address in pcaddr (usually 0x80000180).
+When the cycle count register reaches its limit, cc_interrupt is called, which in turn calls gen_interrupt.  If interrupts are not enabled, cc_interrupt returns.  If interrupts are enabled, and an interrupt is to be taken, the pending_exception flag will be set.  In this case, cc_interrupt does not return, and instead pops the stack and causes an unconditional jump to the address in pcaddr (usually 0x80000180).
 
 There is one additional case where the interrupt handler may be called.  If interrupts were disabled, and are enabled by writing to coprocessor 0 register 12, any pending interrupts are handled immediately.
 

--- a/projects/VisualStudio2013/mupen64plus-core.vcxproj
+++ b/projects/VisualStudio2013/mupen64plus-core.vcxproj
@@ -124,7 +124,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\device\r4300\exception.c" />
     <ClCompile Include="..\..\src\device\r4300\instr_counters.c" />
-    <ClCompile Include="..\..\src\device\r4300\interupt.c" />
+    <ClCompile Include="..\..\src\device\r4300\interrupt.c" />
     <ClCompile Include="..\..\src\device\r4300\mi_controller.c" />
     <ClCompile Include="..\..\src\device\r4300\new_dynarec\arm\arm_cpu_features.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -517,7 +517,7 @@
     <ClInclude Include="..\..\src\device\r4300\exception.h" />
     <ClInclude Include="..\..\src\device\r4300\fpu.h" />
     <ClInclude Include="..\..\src\device\r4300\instr_counters.h" />
-    <ClInclude Include="..\..\src\device\r4300\interupt.h" />
+    <ClInclude Include="..\..\src\device\r4300\interrupt.h" />
     <ClInclude Include="..\..\src\device\r4300\macros.h" />
     <ClInclude Include="..\..\src\device\r4300\mi_controller.h" />
     <ClInclude Include="..\..\src\device\r4300\new_dynarec\arm\arm_cpu_features.h">

--- a/projects/VisualStudio2013/mupen64plus-core.vcxproj.filters
+++ b/projects/VisualStudio2013/mupen64plus-core.vcxproj.filters
@@ -264,7 +264,7 @@
     <ClCompile Include="..\..\src\device\r4300\instr_counters.c">
       <Filter>device\r4300</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\device\r4300\interupt.c">
+    <ClCompile Include="..\..\src\device\r4300\interrupt.c">
       <Filter>device\r4300</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\device\r4300\mi_controller.c">
@@ -632,7 +632,7 @@
     <ClInclude Include="..\..\src\device\r4300\instr_counters.h">
       <Filter>device\r4300</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\device\r4300\interupt.h">
+    <ClInclude Include="..\..\src\device\r4300\interrupt.h">
       <Filter>device\r4300</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\device\r4300\macros.h">

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -463,7 +463,7 @@ SOURCE = \
     $(SRCDIR)/device/r4300/cp1.c \
     $(SRCDIR)/device/r4300/exception.c \
     $(SRCDIR)/device/r4300/instr_counters.c \
-    $(SRCDIR)/device/r4300/interupt.c \
+    $(SRCDIR)/device/r4300/interrupt.c \
     $(SRCDIR)/device/r4300/mi_controller.c \
     $(SRCDIR)/device/r4300/pure_interp.c \
     $(SRCDIR)/device/r4300/r4300_core.c \

--- a/src/api/debugger.c
+++ b/src/api/debugger.c
@@ -126,7 +126,7 @@ EXPORT int CALL DebugGetState(m64p_dbg_state statenum)
         case M64P_DBG_NUM_BREAKPOINTS:
             return g_NumBreakpoints;
         case M64P_DBG_CPU_DYNACORE:
-            return get_r4300_emumode();
+            return get_r4300_emumode(&g_dev.r4300);
         case M64P_DBG_CPU_NEXT_INTERRUPT:
             return *r4300_cp0_next_interrupt();
         default:

--- a/src/debugger/dbg_memory.c
+++ b/src/debugger/dbg_memory.c
@@ -56,7 +56,7 @@ static void *opaddr_recompiled[564];
 static disassemble_info dis_info;
 
 #define CHECK_MEM(address) \
-   invalidate_r4300_cached_code(address, 4);
+   invalidate_r4300_cached_code(&g_dev.r4300, address, 4);
 
 static void process_opcode_out(void *strm, const char *fmt, ...){
   va_list ap;

--- a/src/debugger/dbg_memory.c
+++ b/src/debugger/dbg_memory.c
@@ -121,7 +121,7 @@ static void decode_recompiled(uint32 addr)
         return;
 
     if(g_dev.r4300.cached_interp.blocks[addr>>12]->block[(addr&0xFFF)/4].ops == g_dev.r4300.current_instruction_table.NOTCOMPILED)
-    //      recompile_block((int *) g_dev.sp_mem, g_dev.r4300.cached_interp.blocks[addr>>12], addr);
+    //      recompile_block(&g_dev.r4300, (int *) g_dev.sp_mem, g_dev.r4300.cached_interp.blocks[addr>>12], addr);
       {
     strcpy(opcode_recompiled[0],"INVLD");
     strcpy(args_recompiled[0],"NOTCOMPILED");

--- a/src/device/ai/ai_controller.c
+++ b/src/device/ai/ai_controller.c
@@ -46,7 +46,7 @@ static uint32_t get_remaining_dma_length(struct ai_controller* ai)
         return 0;
 
     cp0_update_count();
-    next_ai_event = get_event(AI_INT);
+    next_ai_event = get_event(&ai->r4300->cp0.q, AI_INT);
     if (next_ai_event == 0)
         return 0;
 

--- a/src/device/ai/ai_controller.c
+++ b/src/device/ai/ai_controller.c
@@ -92,7 +92,7 @@ static void do_dma(struct ai_controller* ai, const struct ai_dma* dma)
 
     /* schedule end of dma event */
     cp0_update_count();
-    add_interupt_event(AI_INT, dma->duration);
+    add_interrupt_event(AI_INT, dma->duration);
 }
 
 static void fifo_push(struct ai_controller* ai)

--- a/src/device/ai/ai_controller.c
+++ b/src/device/ai/ai_controller.c
@@ -92,7 +92,7 @@ static void do_dma(struct ai_controller* ai, const struct ai_dma* dma)
 
     /* schedule end of dma event */
     cp0_update_count();
-    add_interrupt_event(AI_INT, dma->duration);
+    add_interrupt_event(&ai->r4300->cp0, AI_INT, dma->duration);
 }
 
 static void fifo_push(struct ai_controller* ai)

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -89,7 +89,7 @@ void poweron_device(struct device* dev)
 void run_device(struct device* dev)
 {
     /* device execution is driven by the r4300 */
-    run_r4300();
+    run_r4300(&dev->r4300);
 }
 
 void stop_device(struct device* dev)

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -107,6 +107,6 @@ void hard_reset_device(struct device* dev)
 void soft_reset_device(struct device* dev)
 {
     /* schedule HW2 interrupt now and an NMI after 1/2 seconds */
-    add_interupt_event(HW2_INT, 0);
-    add_interupt_event(NMI_INT, 50000000);
+    add_interrupt_event(HW2_INT, 0);
+    add_interrupt_event(NMI_INT, 50000000);
 }

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -107,6 +107,6 @@ void hard_reset_device(struct device* dev)
 void soft_reset_device(struct device* dev)
 {
     /* schedule HW2 interrupt now and an NMI after 1/2 seconds */
-    add_interrupt_event(HW2_INT, 0);
-    add_interrupt_event(NMI_INT, 50000000);
+    add_interrupt_event(&dev->r4300.cp0, HW2_INT, 0);
+    add_interrupt_event(&dev->r4300.cp0, NMI_INT, 50000000);
 }

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -226,28 +226,28 @@ static void write_nothingd(void)
 
 static void read_nomem(void)
 {
-    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),0);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300, *memory_address(),0);
     if (*memory_address() == 0x00000000) return;
     read_word_in_memory();
 }
 
 static void read_nomemb(void)
 {
-    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),0);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300, *memory_address(),0);
     if (*memory_address() == 0x00000000) return;
     read_byte_in_memory();
 }
 
 static void read_nomemh(void)
 {
-    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),0);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300, *memory_address(),0);
     if (*memory_address() == 0x00000000) return;
     read_hword_in_memory();
 }
 
 static void read_nomemd(void)
 {
-    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),0);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300, *memory_address(),0);
     if (*memory_address() == 0x00000000) return;
     read_dword_in_memory();
 }
@@ -255,7 +255,7 @@ static void read_nomemd(void)
 static void write_nomem(void)
 {
     invalidate_r4300_cached_code(&g_dev.r4300, *memory_address(), 4);
-    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_word_in_memory();
 }
@@ -263,7 +263,7 @@ static void write_nomem(void)
 static void write_nomemb(void)
 {
     invalidate_r4300_cached_code(&g_dev.r4300, *memory_address(), 1);
-    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_byte_in_memory();
 }
@@ -271,7 +271,7 @@ static void write_nomemb(void)
 static void write_nomemh(void)
 {
     invalidate_r4300_cached_code(&g_dev.r4300, *memory_address(), 2);
-    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_hword_in_memory();
 }
@@ -279,7 +279,7 @@ static void write_nomemh(void)
 static void write_nomemd(void)
 {
     invalidate_r4300_cached_code(&g_dev.r4300, *memory_address(), 8);
-    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_dword_in_memory();
 }
@@ -1436,7 +1436,7 @@ uint32_t *fast_mem_access(uint32_t address)
      * Removing error checking saves some time, but the emulator may crash. */
 
     if ((address & UINT32_C(0xc0000000)) != UINT32_C(0x80000000))
-        address = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, address, 2);
+        address = virtual_to_physical_address(&g_dev.r4300, address, 2);
 
     address &= UINT32_C(0x1ffffffc);
 

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -254,7 +254,7 @@ static void read_nomemd(void)
 
 static void write_nomem(void)
 {
-    invalidate_r4300_cached_code(*memory_address(), 4);
+    invalidate_r4300_cached_code(&g_dev.r4300, *memory_address(), 4);
     *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_word_in_memory();
@@ -262,7 +262,7 @@ static void write_nomem(void)
 
 static void write_nomemb(void)
 {
-    invalidate_r4300_cached_code(*memory_address(), 1);
+    invalidate_r4300_cached_code(&g_dev.r4300, *memory_address(), 1);
     *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_byte_in_memory();
@@ -270,7 +270,7 @@ static void write_nomemb(void)
 
 static void write_nomemh(void)
 {
-    invalidate_r4300_cached_code(*memory_address(), 2);
+    invalidate_r4300_cached_code(&g_dev.r4300, *memory_address(), 2);
     *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_hword_in_memory();
@@ -278,7 +278,7 @@ static void write_nomemh(void)
 
 static void write_nomemd(void)
 {
-    invalidate_r4300_cached_code(*memory_address(), 8);
+    invalidate_r4300_cached_code(&g_dev.r4300, *memory_address(), 8);
     *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_dword_in_memory();

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -226,28 +226,28 @@ static void write_nothingd(void)
 
 static void read_nomem(void)
 {
-    *memory_address() = virtual_to_physical_address(*memory_address(),0);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),0);
     if (*memory_address() == 0x00000000) return;
     read_word_in_memory();
 }
 
 static void read_nomemb(void)
 {
-    *memory_address() = virtual_to_physical_address(*memory_address(),0);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),0);
     if (*memory_address() == 0x00000000) return;
     read_byte_in_memory();
 }
 
 static void read_nomemh(void)
 {
-    *memory_address() = virtual_to_physical_address(*memory_address(),0);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),0);
     if (*memory_address() == 0x00000000) return;
     read_hword_in_memory();
 }
 
 static void read_nomemd(void)
 {
-    *memory_address() = virtual_to_physical_address(*memory_address(),0);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),0);
     if (*memory_address() == 0x00000000) return;
     read_dword_in_memory();
 }
@@ -255,7 +255,7 @@ static void read_nomemd(void)
 static void write_nomem(void)
 {
     invalidate_r4300_cached_code(*memory_address(), 4);
-    *memory_address() = virtual_to_physical_address(*memory_address(),1);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_word_in_memory();
 }
@@ -263,7 +263,7 @@ static void write_nomem(void)
 static void write_nomemb(void)
 {
     invalidate_r4300_cached_code(*memory_address(), 1);
-    *memory_address() = virtual_to_physical_address(*memory_address(),1);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_byte_in_memory();
 }
@@ -271,7 +271,7 @@ static void write_nomemb(void)
 static void write_nomemh(void)
 {
     invalidate_r4300_cached_code(*memory_address(), 2);
-    *memory_address() = virtual_to_physical_address(*memory_address(),1);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_hword_in_memory();
 }
@@ -279,7 +279,7 @@ static void write_nomemh(void)
 static void write_nomemd(void)
 {
     invalidate_r4300_cached_code(*memory_address(), 8);
-    *memory_address() = virtual_to_physical_address(*memory_address(),1);
+    *memory_address() = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, *memory_address(),1);
     if (*memory_address() == 0x00000000) return;
     write_dword_in_memory();
 }
@@ -1436,7 +1436,7 @@ uint32_t *fast_mem_access(uint32_t address)
      * Removing error checking saves some time, but the emulator may crash. */
 
     if ((address & UINT32_C(0xc0000000)) != UINT32_C(0x80000000))
-        address = virtual_to_physical_address(address, 2);
+        address = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, address, 2);
 
     address &= UINT32_C(0x1ffffffc);
 

--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -72,7 +72,7 @@ static void dma_pi_read(struct pi_controller* pi)
 
     /* schedule end of dma interrupt event */
     cp0_update_count();
-    add_interupt_event(PI_INT, 0x1000/*pi->regs[PI_RD_LEN_REG]*/); /* XXX: 0x1000 ??? */
+    add_interrupt_event(PI_INT, 0x1000/*pi->regs[PI_RD_LEN_REG]*/); /* XXX: 0x1000 ??? */
 }
 
 static void dma_pi_write(struct pi_controller* pi)
@@ -111,7 +111,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count();
-        add_interupt_event(PI_INT, /*pi->regs[PI_WR_LEN_REG]*/0x1000); /* XXX: 0x1000 ??? */
+        add_interrupt_event(PI_INT, /*pi->regs[PI_WR_LEN_REG]*/0x1000); /* XXX: 0x1000 ??? */
 
         return;
     }
@@ -124,7 +124,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count();
-        add_interupt_event(PI_INT, 0x1000); /* XXX: 0x1000 ??? */
+        add_interrupt_event(PI_INT, 0x1000); /* XXX: 0x1000 ??? */
 
         return;
     }
@@ -144,7 +144,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count();
-        add_interupt_event(PI_INT, longueur/8);
+        add_interrupt_event(PI_INT, longueur/8);
 
         return;
     }
@@ -175,7 +175,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
     /* schedule end of dma interrupt event */
     cp0_update_count();
-    add_interupt_event(PI_INT, longueur/8);
+    add_interrupt_event(PI_INT, longueur/8);
 }
 
 

--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -72,7 +72,7 @@ static void dma_pi_read(struct pi_controller* pi)
 
     /* schedule end of dma interrupt event */
     cp0_update_count();
-    add_interrupt_event(PI_INT, 0x1000/*pi->regs[PI_RD_LEN_REG]*/); /* XXX: 0x1000 ??? */
+    add_interrupt_event(&pi->r4300->cp0, PI_INT, 0x1000/*pi->regs[PI_RD_LEN_REG]*/); /* XXX: 0x1000 ??? */
 }
 
 static void dma_pi_write(struct pi_controller* pi)
@@ -111,7 +111,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count();
-        add_interrupt_event(PI_INT, /*pi->regs[PI_WR_LEN_REG]*/0x1000); /* XXX: 0x1000 ??? */
+        add_interrupt_event(&pi->r4300->cp0, PI_INT, /*pi->regs[PI_WR_LEN_REG]*/0x1000); /* XXX: 0x1000 ??? */
 
         return;
     }
@@ -124,7 +124,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count();
-        add_interrupt_event(PI_INT, 0x1000); /* XXX: 0x1000 ??? */
+        add_interrupt_event(&pi->r4300->cp0, PI_INT, 0x1000); /* XXX: 0x1000 ??? */
 
         return;
     }
@@ -144,7 +144,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count();
-        add_interrupt_event(PI_INT, longueur/8);
+        add_interrupt_event(&pi->r4300->cp0, PI_INT, longueur/8);
 
         return;
     }
@@ -175,7 +175,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
     /* schedule end of dma interrupt event */
     cp0_update_count();
-    add_interrupt_event(PI_INT, longueur/8);
+    add_interrupt_event(&pi->r4300->cp0, PI_INT, longueur/8);
 }
 
 

--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -159,8 +159,8 @@ static void dma_pi_write(struct pi_controller* pi)
         dram[(dram_address+i)^S8] = rom[(rom_address+i)^S8];
     }
 
-    invalidate_r4300_cached_code(0x80000000 + dram_address, longueur);
-    invalidate_r4300_cached_code(0xa0000000 + dram_address, longueur);
+    invalidate_r4300_cached_code(pi->r4300, 0x80000000 + dram_address, longueur);
+    invalidate_r4300_cached_code(pi->r4300, 0xa0000000 + dram_address, longueur);
 
     /* HACK: monitor PI DMA to trigger RDRAM size detection
      * hack just before initial cart ROM loading. */

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -511,7 +511,7 @@ static unsigned int update_invalid_addr(unsigned int addr)
      }
    else
      {
-    unsigned int paddr = virtual_to_physical_address(addr, 2);
+    unsigned int paddr = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, addr, 2);
     if (paddr)
       {
          unsigned int beg_paddr = paddr - (addr - (addr&~0xFFF));

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -552,26 +552,28 @@ void jump_to_func(void)
    if (g_dev.r4300.emumode == EMUMODE_DYNAREC) dyna_jump();
 }
 
-void init_blocks(void)
+void init_blocks(struct cached_interp* cinterp)
 {
-   int i;
-   for (i=0; i<0x100000; i++)
+   size_t i;
+
+   for (i = 0; i < 0x100000; ++i)
    {
-      g_dev.r4300.cached_interp.invalid_code[i] = 1;
-      g_dev.r4300.cached_interp.blocks[i] = NULL;
+      cinterp->invalid_code[i] = 1;
+      cinterp->blocks[i] = NULL;
    }
 }
 
-void free_blocks(void)
+void free_blocks(struct cached_interp* cinterp)
 {
-   int i;
-   for (i=0; i<0x100000; i++)
+   size_t i;
+
+   for (i = 0; i < 0x100000; ++i)
    {
-        if (g_dev.r4300.cached_interp.blocks[i])
+        if (cinterp->blocks[i])
         {
-            free_block(g_dev.r4300.cached_interp.blocks[i]);
-            free(g_dev.r4300.cached_interp.blocks[i]);
-            g_dev.r4300.cached_interp.blocks[i] = NULL;
+            free_block(cinterp->blocks[i]);
+            free(cinterp->blocks[i]);
+            cinterp->blocks[i] = NULL;
         }
     }
 }

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -515,7 +515,7 @@ static uint32_t update_invalid_addr(struct r4300_core* r4300, uint32_t addr)
     }
     else
     {
-        uint32_t paddr = virtual_to_physical_address(&r4300->cp0.tlb, addr, 2);
+        uint32_t paddr = virtual_to_physical_address(r4300, addr, 2);
         if (paddr)
         {
             uint32_t beg_paddr = paddr - (addr - (addr & ~0xfff));
@@ -664,7 +664,7 @@ void run_cached_interpreter(struct r4300_core* r4300)
     {
 #ifdef COMPARE_CORE
         if ((*r4300_pc_struct())->ops == cached_interpreter_table.FIN_BLOCK && ((*r4300_pc_struct())->addr < 0x80000000 || (*r4300_pc_struct())->addr >= 0xc0000000))
-            virtual_to_physical_address(&r4300->cp0.tlb, (*r4300_pc_struct())->addr, 2);
+            virtual_to_physical_address(r4300, (*r4300_pc_struct())->addr, 2);
         CoreCompareCallback();
 #endif
 #ifdef DBG

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -576,7 +576,7 @@ void free_blocks(void)
     }
 }
 
-void invalidate_cached_code_hacktarux(uint32_t address, size_t size)
+void invalidate_cached_code_hacktarux(struct r4300_core* r4300, uint32_t address, size_t size)
 {
     size_t i;
     uint32_t addr;
@@ -585,7 +585,7 @@ void invalidate_cached_code_hacktarux(uint32_t address, size_t size)
     if (size == 0)
     {
         /* invalidate everthing */
-        memset(g_dev.r4300.cached_interp.invalid_code, 1, 0x100000);
+        memset(r4300->cached_interp.invalid_code, 1, 0x100000);
     }
     else
     {
@@ -596,12 +596,12 @@ void invalidate_cached_code_hacktarux(uint32_t address, size_t size)
         {
             i = (addr >> 12);
 
-            if (g_dev.r4300.cached_interp.invalid_code[i] == 0)
+            if (r4300->cached_interp.invalid_code[i] == 0)
             {
-                if (g_dev.r4300.cached_interp.blocks[i] == NULL
-                || g_dev.r4300.cached_interp.blocks[i]->block[(addr & 0xfff) / 4].ops != g_dev.r4300.current_instruction_table.NOTCOMPILED)
+                if (r4300->cached_interp.blocks[i] == NULL
+                || r4300->cached_interp.blocks[i]->block[(addr & 0xfff) / 4].ops != r4300->current_instruction_table.NOTCOMPILED)
                 {
-                    g_dev.r4300.cached_interp.invalid_code[i] = 1;
+                    r4300->cached_interp.invalid_code[i] = 1;
                     /* go directly to next i */
                     addr &= ~0xfff;
                     addr |= 0xffc;

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -539,12 +539,6 @@ static uint32_t update_invalid_addr(struct r4300_core* r4300, uint32_t addr)
     }
 }
 
-
-void jump_to_func(void)
-{
-    cached_interpreter_dynarec_jump_to(&g_dev.r4300, g_dev.r4300.cached_interp.jump_to_address);
-}
-
 void cached_interpreter_dynarec_jump_to(struct r4300_core* r4300, uint32_t address)
 {
     struct cached_interp* const cinterp = &r4300->cached_interp;

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -585,26 +585,28 @@ void cached_interpreter_dynarec_jump_to(struct r4300_core* r4300, uint32_t addre
 }
 
 
-void init_blocks(struct cached_interp* cinterp)
+void init_blocks(struct r4300_core* r4300)
 {
-   size_t i;
+    size_t i;
+    struct cached_interp* cinterp = &r4300->cached_interp;
 
-   for (i = 0; i < 0x100000; ++i)
-   {
-      cinterp->invalid_code[i] = 1;
-      cinterp->blocks[i] = NULL;
-   }
+    for (i = 0; i < 0x100000; ++i)
+    {
+        cinterp->invalid_code[i] = 1;
+        cinterp->blocks[i] = NULL;
+    }
 }
 
-void free_blocks(struct cached_interp* cinterp)
+void free_blocks(struct r4300_core* r4300)
 {
-   size_t i;
+    size_t i;
+    struct cached_interp* cinterp = &r4300->cached_interp;
 
-   for (i = 0; i < 0x100000; ++i)
-   {
+    for (i = 0; i < 0x100000; ++i)
+    {
         if (cinterp->blocks[i])
         {
-            free_block(cinterp->blocks[i]);
+            free_block(r4300, cinterp->blocks[i]);
             free(cinterp->blocks[i]);
             cinterp->blocks[i] = NULL;
         }

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -572,7 +572,7 @@ void cached_interpreter_dynarec_jump_to(struct r4300_core* r4300, uint32_t addre
         (*b)->start = (address & ~0xfff);
         (*b)->end = (address & ~0xfff) + 0x1000;
 
-        init_block(*b);
+        init_block(r4300, *b);
     }
 
     /* set new PC */

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -32,7 +32,7 @@
 #include "device/memory/memory.h"
 #include "device/r4300/cached_interp.h"
 #include "device/r4300/exception.h"
-#include "device/r4300/interupt.h"
+#include "device/r4300/interrupt.h"
 #include "device/r4300/macros.h"
 #include "device/r4300/ops.h"
 #include "device/r4300/recomp.h"
@@ -87,7 +87,7 @@
          cp0_update_count(); \
       } \
       g_dev.r4300.cp0.last_addr = *r4300_pc(); \
-      if (*r4300_cp0_next_interrupt() <= r4300_cp0_regs()[CP0_COUNT_REG]) gen_interupt(); \
+      if (*r4300_cp0_next_interrupt() <= r4300_cp0_regs()[CP0_COUNT_REG]) gen_interrupt(); \
    } \
    static void name##_OUT(void) \
    { \
@@ -118,7 +118,7 @@
          cp0_update_count(); \
       } \
       g_dev.r4300.cp0.last_addr = *r4300_pc(); \
-      if (*r4300_cp0_next_interrupt() <= r4300_cp0_regs()[CP0_COUNT_REG]) gen_interupt(); \
+      if (*r4300_cp0_next_interrupt() <= r4300_cp0_regs()[CP0_COUNT_REG]) gen_interrupt(); \
    } \
    static void name##_IDLE(void) \
    { \

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -199,7 +199,7 @@ static void NOTCOMPILED(void)
 #endif
 
    if (mem != NULL)
-      recompile_block(mem, g_dev.r4300.cached_interp.blocks[*r4300_pc() >> 12], *r4300_pc());
+      recompile_block(&g_dev.r4300, mem, g_dev.r4300.cached_interp.blocks[*r4300_pc() >> 12], *r4300_pc());
    else
       DebugMessage(M64MSG_ERROR, "not compiled exception");
 

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -617,3 +617,18 @@ void invalidate_cached_code_hacktarux(uint32_t address, size_t size)
     }
 }
 
+void run_cached_interpreter(struct r4300_core* r4300)
+{
+    while (!*r4300_stop())
+    {
+#ifdef COMPARE_CORE
+        if ((*r4300_pc_struct())->ops == cached_interpreter_table.FIN_BLOCK && ((*r4300_pc_struct())->addr < 0x80000000 || (*r4300_pc_struct())->addr >= 0xc0000000))
+            virtual_to_physical_address(&r4300->cp0.tlb, (*r4300_pc_struct())->addr, 2);
+        CoreCompareCallback();
+#endif
+#ifdef DBG
+        if (g_DebuggerActive) update_debugger((*r4300_pc_struct())->addr);
+#endif
+        (*r4300_pc_struct())->ops();
+    }
+}

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -63,7 +63,7 @@
       const int take_jump = (condition); \
       const uint32_t jump_target = (destination); \
       int64_t *link_register = (link); \
-      if (cop1 && check_cop1_unusable()) return; \
+      if (cop1 && check_cop1_unusable(&g_dev.r4300)) return; \
       if (link_register != &r4300_regs()[0]) \
       { \
          *link_register = SE32(*r4300_pc() + 8); \
@@ -94,7 +94,7 @@
       const int take_jump = (condition); \
       const uint32_t jump_target = (destination); \
       int64_t *link_register = (link); \
-      if (cop1 && check_cop1_unusable()) return; \
+      if (cop1 && check_cop1_unusable(&g_dev.r4300)) return; \
       if (link_register != &r4300_regs()[0]) \
       { \
          *link_register = SE32(*r4300_pc() + 8); \
@@ -125,7 +125,7 @@
       uint32_t* cp0_regs = r4300_cp0_regs(); \
       const int take_jump = (condition); \
       int skip; \
-      if (cop1 && check_cop1_unusable()) return; \
+      if (cop1 && check_cop1_unusable(&g_dev.r4300)) return; \
       if (take_jump) \
       { \
          cp0_update_count(); \

--- a/src/device/r4300/cached_interp.h
+++ b/src/device/r4300/cached_interp.h
@@ -26,7 +26,6 @@
 #include <stdint.h>
 
 #include "ops.h"
-#include "main/main.h"
 
 struct r4300_core;
 struct cached_interp;

--- a/src/device/r4300/cached_interp.h
+++ b/src/device/r4300/cached_interp.h
@@ -28,10 +28,13 @@
 #include "ops.h"
 #include "main/main.h"
 
+struct r4300_core;
+struct cached_interp;
+
 extern const struct cpu_instruction_table cached_interpreter_table;
 
-void init_blocks(void);
-void free_blocks(void);
+void init_blocks(struct cached_interp* cinterp);
+void free_blocks(struct cached_interp* cinterp);
 void jump_to_func(void);
 
 void invalidate_cached_code_hacktarux(struct r4300_core* r4300, uint32_t address, size_t size);

--- a/src/device/r4300/cached_interp.h
+++ b/src/device/r4300/cached_interp.h
@@ -35,13 +35,17 @@ extern const struct cpu_instruction_table cached_interpreter_table;
 
 void init_blocks(struct cached_interp* cinterp);
 void free_blocks(struct cached_interp* cinterp);
-void jump_to_func(void);
 
 void invalidate_cached_code_hacktarux(struct r4300_core* r4300, uint32_t address, size_t size);
 
 void run_cached_interpreter(struct r4300_core* r4300);
 
 /* Jumps to the given address. This is for the cached interpreter / dynarec. */
-#define jump_to(a) { g_dev.r4300.cached_interp.jump_to_address = a; jump_to_func(); }
+void cached_interpreter_dynarec_jump_to(struct r4300_core* r4300, uint32_t address);
+
+/* Jumps to jump_to_address.
+ * Parameterless version of cached_interpreter_dynarec_jump_to to ease usage in dynarec.
+ */
+void jump_to_func(void);
 
 #endif /* M64P_DEVICE_R4300_CACHED_INTERP_H */

--- a/src/device/r4300/cached_interp.h
+++ b/src/device/r4300/cached_interp.h
@@ -28,12 +28,11 @@
 #include "ops.h"
 
 struct r4300_core;
-struct cached_interp;
 
 extern const struct cpu_instruction_table cached_interpreter_table;
 
-void init_blocks(struct cached_interp* cinterp);
-void free_blocks(struct cached_interp* cinterp);
+void init_blocks(struct r4300_core* r4300);
+void free_blocks(struct r4300_core* r4300);
 
 void invalidate_cached_code_hacktarux(struct r4300_core* r4300, uint32_t address, size_t size);
 

--- a/src/device/r4300/cached_interp.h
+++ b/src/device/r4300/cached_interp.h
@@ -34,7 +34,7 @@ void init_blocks(void);
 void free_blocks(void);
 void jump_to_func(void);
 
-void invalidate_cached_code_hacktarux(uint32_t address, size_t size);
+void invalidate_cached_code_hacktarux(struct r4300_core* r4300, uint32_t address, size_t size);
 
 void run_cached_interpreter(struct r4300_core* r4300);
 

--- a/src/device/r4300/cached_interp.h
+++ b/src/device/r4300/cached_interp.h
@@ -36,6 +36,8 @@ void jump_to_func(void);
 
 void invalidate_cached_code_hacktarux(uint32_t address, size_t size);
 
+void run_cached_interpreter(struct r4300_core* r4300);
+
 /* Jumps to the given address. This is for the cached interpreter / dynarec. */
 #define jump_to(a) { g_dev.r4300.cached_interp.jump_to_address = a; jump_to_func(); }
 

--- a/src/device/r4300/cached_interp.h
+++ b/src/device/r4300/cached_interp.h
@@ -42,9 +42,4 @@ void run_cached_interpreter(struct r4300_core* r4300);
 /* Jumps to the given address. This is for the cached interpreter / dynarec. */
 void cached_interpreter_dynarec_jump_to(struct r4300_core* r4300, uint32_t address);
 
-/* Jumps to jump_to_address.
- * Parameterless version of cached_interpreter_dynarec_jump_to to ease usage in dynarec.
- */
-void jump_to_func(void);
-
 #endif /* M64P_DEVICE_R4300_CACHED_INTERP_H */

--- a/src/device/r4300/cp0.c
+++ b/src/device/r4300/cp0.c
@@ -104,12 +104,13 @@ unsigned int* r4300_cp0_next_interrupt(void)
 
 int check_cop1_unusable(void)
 {
+    struct r4300_core* r4300 = &g_dev.r4300;
     uint32_t* cp0_regs = r4300_cp0_regs();
 
     if (!(cp0_regs[CP0_STATUS_REG] & CP0_STATUS_CU1))
     {
         cp0_regs[CP0_CAUSE_REG] = CP0_CAUSE_EXCCODE_CPU | CP0_CAUSE_CE1;
-        exception_general();
+        exception_general(r4300);
         return 1;
     }
     return 0;

--- a/src/device/r4300/cp0.c
+++ b/src/device/r4300/cp0.c
@@ -102,9 +102,8 @@ unsigned int* r4300_cp0_next_interrupt(void)
 }
 
 
-int check_cop1_unusable(void)
+int check_cop1_unusable(struct r4300_core* r4300)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
     uint32_t* cp0_regs = r4300_cp0_regs();
 
     if (!(cp0_regs[CP0_STATUS_REG] & CP0_STATUS_CU1))

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -200,7 +200,7 @@ uint32_t* r4300_cp0_regs(void);
 uint32_t* r4300_cp0_last_addr(void);
 unsigned int* r4300_cp0_next_interrupt(void);
 
-int check_cop1_unusable(void);
+int check_cop1_unusable(struct r4300_core* r4300);
 
 void cp0_update_count(void);
 

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 
-#include "interupt.h"
+#include "interrupt.h"
 #include "tlb.h"
 
 #include "new_dynarec/new_dynarec.h" /* for NEW_DYNAREC_ARM */

--- a/src/device/r4300/exception.c
+++ b/src/device/r4300/exception.c
@@ -127,10 +127,8 @@ void TLB_refill_exception(struct r4300_core* r4300, uint32_t address, int w)
     }
 }
 
-/* XXX: parameterless to ease usage in dynarec */
-void exception_general(void)
+void exception_general(struct r4300_core* r4300)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
     uint32_t* cp0_regs = r4300_cp0_regs();
 
     cp0_update_count();

--- a/src/device/r4300/exception.c
+++ b/src/device/r4300/exception.c
@@ -42,7 +42,7 @@ void TLB_refill_exception(uint32_t address, int w)
    cp0_regs[CP0_ENTRYHI_REG] = address & UINT32_C(0xFFFFE000);
    if (cp0_regs[CP0_STATUS_REG] & CP0_STATUS_EXL)
      {
-    generic_jump_to(UINT32_C(0x80000180));
+    generic_jump_to(&g_dev.r4300, UINT32_C(0x80000180));
     if(g_dev.r4300.delay_slot==1 || g_dev.r4300.delay_slot==3) cp0_regs[CP0_CAUSE_REG] |= CP0_CAUSE_BD;
     else cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
      }
@@ -73,11 +73,11 @@ void TLB_refill_exception(uint32_t address, int w)
       }
     if (usual_handler)
       {
-         generic_jump_to(UINT32_C(0x80000180));
+         generic_jump_to(&g_dev.r4300, UINT32_C(0x80000180));
       }
     else
       {
-         generic_jump_to(UINT32_C(0x80000000));
+         generic_jump_to(&g_dev.r4300, UINT32_C(0x80000000));
       }
      }
    if(g_dev.r4300.delay_slot==1 || g_dev.r4300.delay_slot==3)
@@ -128,7 +128,7 @@ void exception_general(void)
      {
     cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
      }
-   generic_jump_to(UINT32_C(0x80000180));
+   generic_jump_to(&g_dev.r4300, UINT32_C(0x80000180));
    g_dev.r4300.cp0.last_addr = *r4300_pc();
    if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
      {

--- a/src/device/r4300/exception.c
+++ b/src/device/r4300/exception.c
@@ -31,118 +31,138 @@
 
 void TLB_refill_exception(uint32_t address, int w)
 {
-   uint32_t* cp0_regs = r4300_cp0_regs();
-   int usual_handler = 0, i;
+    uint32_t* cp0_regs = r4300_cp0_regs();
+    int usual_handler = 0, i;
 
-   if (g_dev.r4300.emumode != EMUMODE_DYNAREC && w != 2) cp0_update_count();
-   if (w == 1) cp0_regs[CP0_CAUSE_REG] = CP0_CAUSE_EXCCODE_TLBS;
-   else cp0_regs[CP0_CAUSE_REG] = CP0_CAUSE_EXCCODE_TLBL;
-   cp0_regs[CP0_BADVADDR_REG] = address;
-   cp0_regs[CP0_CONTEXT_REG] = (cp0_regs[CP0_CONTEXT_REG] & UINT32_C(0xFF80000F)) | ((address >> 9) & UINT32_C(0x007FFFF0));
-   cp0_regs[CP0_ENTRYHI_REG] = address & UINT32_C(0xFFFFE000);
-   if (cp0_regs[CP0_STATUS_REG] & CP0_STATUS_EXL)
-     {
-    generic_jump_to(&g_dev.r4300, UINT32_C(0x80000180));
-    if(g_dev.r4300.delay_slot==1 || g_dev.r4300.delay_slot==3) cp0_regs[CP0_CAUSE_REG] |= CP0_CAUSE_BD;
-    else cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
-     }
-   else
-     {
-    if (g_dev.r4300.emumode != EMUMODE_PURE_INTERPRETER) 
-      {
-         if (w!=2)
-           cp0_regs[CP0_EPC_REG] = *r4300_pc();
-         else
-           cp0_regs[CP0_EPC_REG] = address;
-      }
-    else cp0_regs[CP0_EPC_REG] = *r4300_pc();
-         
-    cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
-    cp0_regs[CP0_STATUS_REG] |= CP0_STATUS_EXL;
-    
-    if (address >= UINT32_C(0x80000000) && address < UINT32_C(0xc0000000))
-      usual_handler = 1;
-    for (i=0; i<32; i++)
-      {
-         if (/*g_dev.r4300.cp0.tlb.entries[i].v_even &&*/ address >= g_dev.r4300.cp0.tlb.entries[i].start_even &&
-         address <= g_dev.r4300.cp0.tlb.entries[i].end_even)
-           usual_handler = 1;
-         if (/*g_dev.r4300.cp0.tlb.entries[i].v_odd &&*/ address >= g_dev.r4300.cp0.tlb.entries[i].start_odd &&
-         address <= g_dev.r4300.cp0.tlb.entries[i].end_odd)
-           usual_handler = 1;
-      }
-    if (usual_handler)
-      {
-         generic_jump_to(&g_dev.r4300, UINT32_C(0x80000180));
-      }
+    if (g_dev.r4300.emumode != EMUMODE_DYNAREC && w != 2) {
+        cp0_update_count();
+    }
+
+    cp0_regs[CP0_CAUSE_REG] = (w == 1)
+        ? CP0_CAUSE_EXCCODE_TLBS
+        : CP0_CAUSE_EXCCODE_TLBL;
+
+    cp0_regs[CP0_BADVADDR_REG] = address;
+    cp0_regs[CP0_CONTEXT_REG] = (cp0_regs[CP0_CONTEXT_REG] & UINT32_C(0xFF80000F))
+        | ((address >> 9) & UINT32_C(0x007FFFF0));
+    cp0_regs[CP0_ENTRYHI_REG] = address & UINT32_C(0xFFFFE000);
+
+    if (cp0_regs[CP0_STATUS_REG] & CP0_STATUS_EXL)
+    {
+        generic_jump_to(&g_dev.r4300, UINT32_C(0x80000180));
+
+
+        if (g_dev.r4300.delay_slot == 1 || g_dev.r4300.delay_slot == 3) {
+            cp0_regs[CP0_CAUSE_REG] |= CP0_CAUSE_BD;
+        }
+        else {
+            cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
+        }
+    }
     else
-      {
-         generic_jump_to(&g_dev.r4300, UINT32_C(0x80000000));
-      }
-     }
-   if(g_dev.r4300.delay_slot==1 || g_dev.r4300.delay_slot==3)
-     {
-    cp0_regs[CP0_CAUSE_REG] |= CP0_CAUSE_BD;
-    cp0_regs[CP0_EPC_REG]-=4;
-     }
-   else
-     {
-    cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
-     }
-   if(w != 2) cp0_regs[CP0_EPC_REG]-=4;
-   
-   g_dev.r4300.cp0.last_addr = *r4300_pc();
-   
-   if (g_dev.r4300.emumode == EMUMODE_DYNAREC) 
-     {
-    dyna_jump();
-    if (!g_dev.r4300.dyna_interp) g_dev.r4300.delay_slot = 0;
-     }
-   
-   if (g_dev.r4300.emumode != EMUMODE_DYNAREC || g_dev.r4300.dyna_interp)
-     {
-    g_dev.r4300.dyna_interp = 0;
-    if (g_dev.r4300.delay_slot)
-      {
-         g_dev.r4300.skip_jump = *r4300_pc();
-         *r4300_cp0_next_interrupt() = 0;
-      }
-     }
+    {
+        if (g_dev.r4300.emumode != EMUMODE_PURE_INTERPRETER)
+        {
+            cp0_regs[CP0_EPC_REG] = (w != 2)
+                ? *r4300_pc()
+                : address;
+        }
+        else {
+            cp0_regs[CP0_EPC_REG] = *r4300_pc();
+        }
+
+        cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
+        cp0_regs[CP0_STATUS_REG] |= CP0_STATUS_EXL;
+
+        if (address >= UINT32_C(0x80000000) && address < UINT32_C(0xc0000000)) {
+            usual_handler = 1;
+        }
+
+        for (i = 0; i < 32; i++)
+        {
+            if (/*g_dev.r4300.cp0.tlb.entries[i].v_even &&*/ address >= g_dev.r4300.cp0.tlb.entries[i].start_even &&
+                    address <= g_dev.r4300.cp0.tlb.entries[i].end_even) {
+                usual_handler = 1;
+            }
+            if (/*g_dev.r4300.cp0.tlb.entries[i].v_odd &&*/ address >= g_dev.r4300.cp0.tlb.entries[i].start_odd &&
+                    address <= g_dev.r4300.cp0.tlb.entries[i].end_odd) {
+                usual_handler = 1;
+            }
+        }
+
+        generic_jump_to(&g_dev.r4300, (usual_handler)
+                ? UINT32_C(0x80000180)
+                : UINT32_C(0x80000000));
+    }
+
+    if (g_dev.r4300.delay_slot == 1 || g_dev.r4300.delay_slot == 3)
+    {
+        cp0_regs[CP0_CAUSE_REG] |= CP0_CAUSE_BD;
+        cp0_regs[CP0_EPC_REG] -= 4;
+    }
+    else
+    {
+        cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
+    }
+    if (w != 2) {
+        cp0_regs[CP0_EPC_REG] -= 4;
+    }
+
+    g_dev.r4300.cp0.last_addr = *r4300_pc();
+
+    if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
+    {
+        dyna_jump();
+        if (!g_dev.r4300.dyna_interp) { g_dev.r4300.delay_slot = 0; }
+    }
+
+    if (g_dev.r4300.emumode != EMUMODE_DYNAREC || g_dev.r4300.dyna_interp)
+    {
+        g_dev.r4300.dyna_interp = 0;
+        if (g_dev.r4300.delay_slot)
+        {
+            g_dev.r4300.skip_jump = *r4300_pc();
+            *r4300_cp0_next_interrupt() = 0;
+        }
+    }
 }
 
 void exception_general(void)
 {
-   uint32_t* cp0_regs = r4300_cp0_regs();
+    uint32_t* cp0_regs = r4300_cp0_regs();
 
-   cp0_update_count();
-   cp0_regs[CP0_STATUS_REG] |= CP0_STATUS_EXL;
-   
-   cp0_regs[CP0_EPC_REG] = *r4300_pc();
-   
-   if(g_dev.r4300.delay_slot==1 || g_dev.r4300.delay_slot==3)
-     {
-    cp0_regs[CP0_CAUSE_REG] |= CP0_CAUSE_BD;
-    cp0_regs[CP0_EPC_REG]-=4;
-     }
-   else
-     {
-    cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
-     }
-   generic_jump_to(&g_dev.r4300, UINT32_C(0x80000180));
-   g_dev.r4300.cp0.last_addr = *r4300_pc();
-   if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
-     {
-    dyna_jump();
-    if (!g_dev.r4300.dyna_interp) g_dev.r4300.delay_slot = 0;
-     }
-   if (g_dev.r4300.emumode != EMUMODE_DYNAREC || g_dev.r4300.dyna_interp)
-     {
-    g_dev.r4300.dyna_interp = 0;
-    if (g_dev.r4300.delay_slot)
-      {
-         g_dev.r4300.skip_jump = *r4300_pc();
-         *r4300_cp0_next_interrupt() = 0;
-      }
-     }
+    cp0_update_count();
+    cp0_regs[CP0_STATUS_REG] |= CP0_STATUS_EXL;
+
+    cp0_regs[CP0_EPC_REG] = *r4300_pc();
+
+    if (g_dev.r4300.delay_slot == 1 || g_dev.r4300.delay_slot == 3)
+    {
+        cp0_regs[CP0_CAUSE_REG] |= CP0_CAUSE_BD;
+        cp0_regs[CP0_EPC_REG] -= 4;
+    }
+    else
+    {
+        cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_BD;
+    }
+
+    generic_jump_to(&g_dev.r4300, UINT32_C(0x80000180));
+
+    g_dev.r4300.cp0.last_addr = *r4300_pc();
+
+    if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
+    {
+        dyna_jump();
+        if (!g_dev.r4300.dyna_interp) { g_dev.r4300.delay_slot = 0; }
+    }
+    if (g_dev.r4300.emumode != EMUMODE_DYNAREC || g_dev.r4300.dyna_interp)
+    {
+        g_dev.r4300.dyna_interp = 0;
+        if (g_dev.r4300.delay_slot)
+        {
+            g_dev.r4300.skip_jump = *r4300_pc();
+            *r4300_cp0_next_interrupt() = 0;
+        }
+    }
 }
 

--- a/src/device/r4300/exception.h
+++ b/src/device/r4300/exception.h
@@ -24,7 +24,9 @@
 
 #include <stdint.h>
 
-void TLB_refill_exception(uint32_t addresse, int w);
+struct r4300_core;
+
+void TLB_refill_exception(struct r4300_core* r4300, uint32_t address, int w);
 void exception_general(void);
 
 #endif /* M64P_DEVICE_R4300_EXCEPTION_H */

--- a/src/device/r4300/exception.h
+++ b/src/device/r4300/exception.h
@@ -27,7 +27,7 @@
 struct r4300_core;
 
 void TLB_refill_exception(struct r4300_core* r4300, uint32_t address, int w);
-void exception_general(void);
+void exception_general(struct r4300_core* r4300);
 
 #endif /* M64P_DEVICE_R4300_EXCEPTION_H */
 

--- a/src/device/r4300/interpreter_cop0.def
+++ b/src/device/r4300/interpreter_cop0.def
@@ -77,7 +77,7 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_COUNT_REG:
       cp0_update_count();
       g_dev.r4300.cp0.interrupt_unsafe_state = 1;
-      if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interupt();
+      if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
       g_dev.r4300.cp0.interrupt_unsafe_state = 0;
       translate_event_queue(rrt32);
       cp0_regs[CP0_COUNT_REG] = rrt32;
@@ -88,7 +88,7 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_COMPARE_REG:
       cp0_update_count();
       remove_event(COMPARE_INT);
-      add_interupt_event_count(COMPARE_INT, rrt32);
+      add_interrupt_event_count(COMPARE_INT, rrt32);
       cp0_regs[CP0_COMPARE_REG] = rrt32;
       cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_IP7;
       break;
@@ -101,9 +101,9 @@ DECLARE_INSTRUCTION(MTC0)
       cp0_regs[CP0_STATUS_REG] = rrt32;
       cp0_update_count();
       ADD_TO_PC(1);
-      check_interupt();
+      check_interrupt();
       g_dev.r4300.cp0.interrupt_unsafe_state = 1;
-      if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interupt();
+      if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
       g_dev.r4300.cp0.interrupt_unsafe_state = 0;
       ADD_TO_PC(-1);
       break;

--- a/src/device/r4300/interpreter_cop0.def
+++ b/src/device/r4300/interpreter_cop0.def
@@ -87,7 +87,7 @@ DECLARE_INSTRUCTION(MTC0)
       break;
     case CP0_COMPARE_REG:
       cp0_update_count();
-      remove_event(COMPARE_INT);
+      remove_event(&g_dev.r4300.cp0.q, COMPARE_INT);
       add_interrupt_event_count(&g_dev.r4300.cp0, COMPARE_INT, rrt32);
       cp0_regs[CP0_COMPARE_REG] = rrt32;
       cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_IP7;

--- a/src/device/r4300/interpreter_cop0.def
+++ b/src/device/r4300/interpreter_cop0.def
@@ -101,7 +101,7 @@ DECLARE_INSTRUCTION(MTC0)
       cp0_regs[CP0_STATUS_REG] = rrt32;
       cp0_update_count();
       ADD_TO_PC(1);
-      check_interrupt();
+      check_interrupt(&g_dev.r4300);
       g_dev.r4300.cp0.interrupt_unsafe_state = 1;
       if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
       g_dev.r4300.cp0.interrupt_unsafe_state = 0;

--- a/src/device/r4300/interpreter_cop0.def
+++ b/src/device/r4300/interpreter_cop0.def
@@ -79,7 +79,7 @@ DECLARE_INSTRUCTION(MTC0)
       g_dev.r4300.cp0.interrupt_unsafe_state = 1;
       if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
       g_dev.r4300.cp0.interrupt_unsafe_state = 0;
-      translate_event_queue(rrt32);
+      translate_event_queue(&g_dev.r4300.cp0, rrt32);
       cp0_regs[CP0_COUNT_REG] = rrt32;
       break;
     case CP0_ENTRYHI_REG:

--- a/src/device/r4300/interpreter_cop0.def
+++ b/src/device/r4300/interpreter_cop0.def
@@ -88,7 +88,7 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_COMPARE_REG:
       cp0_update_count();
       remove_event(COMPARE_INT);
-      add_interrupt_event_count(COMPARE_INT, rrt32);
+      add_interrupt_event_count(&g_dev.r4300.cp0, COMPARE_INT, rrt32);
       cp0_regs[CP0_COMPARE_REG] = rrt32;
       cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_IP7;
       break;

--- a/src/device/r4300/interpreter_cop1.def
+++ b/src/device/r4300/interpreter_cop1.def
@@ -28,21 +28,21 @@ DECLARE_JUMP(BC1TL, PCADDR + (iimmediate+1)*4, ((*r4300_cp1_fcr31()) & FCR31_CMP
 
 DECLARE_INSTRUCTION(MFC1)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    rrt = SE32(*((int32_t*) (r4300_cp1_regs_simple())[rfs]));
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DMFC1)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    rrt = *((int64_t*) (r4300_cp1_regs_double())[rfs]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CFC1)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (rfs==31)
    {
       rrt32 = SE32((*r4300_cp1_fcr31()));
@@ -56,21 +56,21 @@ DECLARE_INSTRUCTION(CFC1)
 
 DECLARE_INSTRUCTION(MTC1)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    *((int32_t*) (r4300_cp1_regs_simple())[rfs]) = rrt32;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DMTC1)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    *((int64_t*) (r4300_cp1_regs_double())[rfs]) = rrt;
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CTC1)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (rfs==31)
    {
       (*r4300_cp1_fcr31()) = rrt32;
@@ -84,28 +84,28 @@ DECLARE_INSTRUCTION(CTC1)
 // COP1_D
 DECLARE_INSTRUCTION(ADD_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    add_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SUB_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    sub_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MUL_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    mul_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DIV_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if(((*r4300_cp1_fcr31()) & UINT32_C(0x400)) && *(r4300_cp1_regs_double())[cfft] == 0)
    {
       //(*r4300_cp1_fcr31()) |= 0x8020;
@@ -121,161 +121,161 @@ DECLARE_INSTRUCTION(DIV_D)
 
 DECLARE_INSTRUCTION(SQRT_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    sqrt_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ABS_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    abs_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MOV_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    mov_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(NEG_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    neg_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_L_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    round_l_d((r4300_cp1_regs_double())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_L_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    trunc_l_d((r4300_cp1_regs_double())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_L_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    ceil_l_d((r4300_cp1_regs_double())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_L_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    floor_l_d((r4300_cp1_regs_double())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_W_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    round_w_d((r4300_cp1_regs_double())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_W_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    trunc_w_d((r4300_cp1_regs_double())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_W_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    ceil_w_d((r4300_cp1_regs_double())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_W_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    floor_w_d((r4300_cp1_regs_double())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_S_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_s_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_W_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_w_d((r4300_cp1_regs_double())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_L_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_l_d((r4300_cp1_regs_double())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_F_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_f_d();
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_UN_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_un_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_EQ_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_eq_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_UEQ_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_ueq_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_OLT_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_olt_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_ULT_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_ult_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_OLE_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_ole_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_ULE_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_ule_d((r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cfft]);
    ADD_TO_PC(1);
 }
@@ -326,7 +326,7 @@ DECLARE_INSTRUCTION(C_NGL_D)
 
 DECLARE_INSTRUCTION(C_LT_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_double())[cffs]) || isnan(*(r4300_cp1_regs_double())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -338,7 +338,7 @@ DECLARE_INSTRUCTION(C_LT_D)
 
 DECLARE_INSTRUCTION(C_NGE_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_double())[cffs]) || isnan(*(r4300_cp1_regs_double())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -350,7 +350,7 @@ DECLARE_INSTRUCTION(C_NGE_D)
 
 DECLARE_INSTRUCTION(C_LE_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_double())[cffs]) || isnan(*(r4300_cp1_regs_double())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -362,7 +362,7 @@ DECLARE_INSTRUCTION(C_LE_D)
 
 DECLARE_INSTRUCTION(C_NGT_D)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_double())[cffs]) || isnan(*(r4300_cp1_regs_double())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -375,14 +375,14 @@ DECLARE_INSTRUCTION(C_NGT_D)
 // COP1_L
 DECLARE_INSTRUCTION(CVT_S_L)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_s_l((int64_t*) (r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_D_L)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_d_l((int64_t*) (r4300_cp1_regs_double())[cffs], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
@@ -390,28 +390,28 @@ DECLARE_INSTRUCTION(CVT_D_L)
 // COP1_S
 DECLARE_INSTRUCTION(ADD_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    add_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SUB_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    sub_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MUL_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    mul_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DIV_S)
 {  
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if(((*r4300_cp1_fcr31()) & UINT32_C(0x400)) && *(r4300_cp1_regs_simple())[cfft] == 0)
    {
      DebugMessage(M64MSG_ERROR, "DIV_S by 0");
@@ -422,168 +422,168 @@ DECLARE_INSTRUCTION(DIV_S)
 
 DECLARE_INSTRUCTION(SQRT_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    sqrt_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ABS_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    abs_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(MOV_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    mov_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(NEG_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    neg_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_L_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    round_l_s((r4300_cp1_regs_simple())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_L_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    trunc_l_s((r4300_cp1_regs_simple())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_L_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    ceil_l_s((r4300_cp1_regs_simple())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_L_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    floor_l_s((r4300_cp1_regs_simple())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ROUND_W_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    round_w_s((r4300_cp1_regs_simple())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(TRUNC_W_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    trunc_w_s((r4300_cp1_regs_simple())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CEIL_W_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    ceil_w_s((r4300_cp1_regs_simple())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(FLOOR_W_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    floor_w_s((r4300_cp1_regs_simple())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_D_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_d_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_W_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_w_s((r4300_cp1_regs_simple())[cffs], (int32_t*) (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_L_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_l_s((r4300_cp1_regs_simple())[cffs], (int64_t*) (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_F_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_f_s();
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_UN_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_un_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_EQ_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_eq_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_UEQ_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_ueq_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_OLT_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_olt_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_ULT_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_ult_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_OLE_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_ole_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_ULE_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    c_ule_s((r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cfft]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(C_SF_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_simple())[cffs]) || isnan(*(r4300_cp1_regs_simple())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -595,7 +595,7 @@ DECLARE_INSTRUCTION(C_SF_S)
 
 DECLARE_INSTRUCTION(C_NGLE_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_simple())[cffs]) || isnan(*(r4300_cp1_regs_simple())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -607,7 +607,7 @@ DECLARE_INSTRUCTION(C_NGLE_S)
 
 DECLARE_INSTRUCTION(C_SEQ_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_simple())[cffs]) || isnan(*(r4300_cp1_regs_simple())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -619,7 +619,7 @@ DECLARE_INSTRUCTION(C_SEQ_S)
 
 DECLARE_INSTRUCTION(C_NGL_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_simple())[cffs]) || isnan(*(r4300_cp1_regs_simple())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -631,7 +631,7 @@ DECLARE_INSTRUCTION(C_NGL_S)
 
 DECLARE_INSTRUCTION(C_LT_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_simple())[cffs]) || isnan(*(r4300_cp1_regs_simple())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -643,7 +643,7 @@ DECLARE_INSTRUCTION(C_LT_S)
 
 DECLARE_INSTRUCTION(C_NGE_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_simple())[cffs]) || isnan(*(r4300_cp1_regs_simple())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -655,7 +655,7 @@ DECLARE_INSTRUCTION(C_NGE_S)
 
 DECLARE_INSTRUCTION(C_LE_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_simple())[cffs]) || isnan(*(r4300_cp1_regs_simple())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -667,7 +667,7 @@ DECLARE_INSTRUCTION(C_LE_S)
 
 DECLARE_INSTRUCTION(C_NGT_S)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    if (isnan(*(r4300_cp1_regs_simple())[cffs]) || isnan(*(r4300_cp1_regs_simple())[cfft]))
    {
      DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
@@ -680,14 +680,14 @@ DECLARE_INSTRUCTION(C_NGT_S)
 // COP1_W
 DECLARE_INSTRUCTION(CVT_S_W)
 {  
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_s_w((int32_t*) (r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_simple())[cffd]);
    ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(CVT_D_W)
 {
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    cvt_d_w((int32_t*) (r4300_cp1_regs_simple())[cffs], (r4300_cp1_regs_double())[cffd]);
    ADD_TO_PC(1);
 }

--- a/src/device/r4300/interpreter_cop1.def
+++ b/src/device/r4300/interpreter_cop1.def
@@ -111,7 +111,7 @@ DECLARE_INSTRUCTION(DIV_D)
       //(*r4300_cp1_fcr31()) |= 0x8020;
       /*(*r4300_cp1_fcr31()) |= 0x8000;
       Cause = 15 << 2;
-      exception_general();*/
+      exception_general(&g_dev.r4300);*/
       DebugMessage(M64MSG_ERROR, "DIV_D by 0");
       //return;
    }

--- a/src/device/r4300/interpreter_r4300.def
+++ b/src/device/r4300/interpreter_r4300.def
@@ -485,7 +485,7 @@ DECLARE_INSTRUCTION(LWC1)
    const unsigned char lslfft = lfft;
    const uint32_t lslfaddr = (uint32_t) r4300_regs()[lfbase] + lfoffset;
    uint64_t temp;
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    ADD_TO_PC(1);
    *memory_address() = lslfaddr;
    g_dev.mem.rdword = &temp;
@@ -498,7 +498,7 @@ DECLARE_INSTRUCTION(LDC1)
 {
    const unsigned char lslfft = lfft;
    const uint32_t lslfaddr = (uint32_t) r4300_regs()[lfbase] + lfoffset;
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    ADD_TO_PC(1);
    *memory_address() = lslfaddr;
    g_dev.mem.rdword = (uint64_t*) (r4300_cp1_regs_double())[lslfft];
@@ -539,7 +539,7 @@ DECLARE_INSTRUCTION(SWC1)
 {
    const unsigned char lslfft = lfft;
    const uint32_t lslfaddr = (uint32_t) r4300_regs()[lfbase] + lfoffset;
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    ADD_TO_PC(1);
    *memory_address() = lslfaddr;
    *memory_wword() = *((uint32_t*)(r4300_cp1_regs_simple())[lslfft]);
@@ -551,7 +551,7 @@ DECLARE_INSTRUCTION(SDC1)
 {
    const unsigned char lslfft = lfft;
    const uint32_t lslfaddr = (uint32_t) r4300_regs()[lfbase] + lfoffset;
-   if (check_cop1_unusable()) return;
+   if (check_cop1_unusable(&g_dev.r4300)) return;
    ADD_TO_PC(1);
    *memory_address() = lslfaddr;
    *memory_wdword() = *((uint64_t*) (r4300_cp1_regs_double())[lslfft]);

--- a/src/device/r4300/interpreter_special.def
+++ b/src/device/r4300/interpreter_special.def
@@ -68,7 +68,7 @@ DECLARE_INSTRUCTION(SYSCALL)
    uint32_t* cp0_regs = r4300_cp0_regs();
 
    cp0_regs[CP0_CAUSE_REG] = CP0_CAUSE_EXCCODE_SYS;
-   exception_general();
+   exception_general(&g_dev.r4300);
 }
 
 DECLARE_INSTRUCTION(SYNC)

--- a/src/device/r4300/interpreter_tlb.def
+++ b/src/device/r4300/interpreter_tlb.def
@@ -109,7 +109,7 @@ static void TLBWrite(unsigned int idx)
       }
    }
 
-   tlb_unmap(&g_dev.r4300.cp0.tlb.entries[idx]);
+   tlb_unmap(&g_dev.r4300.cp0.tlb, idx);
 
    g_dev.r4300.cp0.tlb.entries[idx].g = (cp0_regs[CP0_ENTRYLO0_REG] & cp0_regs[CP0_ENTRYLO1_REG] & 1);
    g_dev.r4300.cp0.tlb.entries[idx].pfn_even = (cp0_regs[CP0_ENTRYLO0_REG] & UINT32_C(0x3FFFFFC0)) >> 6;
@@ -136,7 +136,7 @@ static void TLBWrite(unsigned int idx)
      (g_dev.r4300.cp0.tlb.entries[idx].mask << 12) + UINT32_C(0xFFF);
    g_dev.r4300.cp0.tlb.entries[idx].phys_odd = g_dev.r4300.cp0.tlb.entries[idx].pfn_odd << 12;
    
-   tlb_map(&g_dev.r4300.cp0.tlb.entries[idx]);
+   tlb_map(&g_dev.r4300.cp0.tlb, idx);
 
    if (g_dev.r4300.emumode != EMUMODE_PURE_INTERPRETER)
    {

--- a/src/device/r4300/interpreter_tlb.def
+++ b/src/device/r4300/interpreter_tlb.def
@@ -253,7 +253,7 @@ DECLARE_INSTRUCTION(ERET)
    else
    {
      cp0_regs[CP0_STATUS_REG] &= ~CP0_STATUS_EXL;
-     generic_jump_to(cp0_regs[CP0_EPC_REG]);
+     generic_jump_to(&g_dev.r4300, cp0_regs[CP0_EPC_REG]);
    }
    g_dev.r4300.llbit = 0;
    check_interupt();

--- a/src/device/r4300/interpreter_tlb.def
+++ b/src/device/r4300/interpreter_tlb.def
@@ -256,7 +256,7 @@ DECLARE_INSTRUCTION(ERET)
      generic_jump_to(&g_dev.r4300, cp0_regs[CP0_EPC_REG]);
    }
    g_dev.r4300.llbit = 0;
-   check_interrupt();
+   check_interrupt(&g_dev.r4300);
    g_dev.r4300.cp0.last_addr = PCADDR;
    if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
 }

--- a/src/device/r4300/interpreter_tlb.def
+++ b/src/device/r4300/interpreter_tlb.def
@@ -256,7 +256,7 @@ DECLARE_INSTRUCTION(ERET)
      generic_jump_to(&g_dev.r4300, cp0_regs[CP0_EPC_REG]);
    }
    g_dev.r4300.llbit = 0;
-   check_interupt();
+   check_interrupt();
    g_dev.r4300.cp0.last_addr = PCADDR;
-   if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interupt();
+   if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
 }

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -510,20 +510,22 @@ static void nmi_int_handler(struct device* dev)
 }
 
 
-static void reset_hard(void)
+static void reset_hard(struct device* dev)
 {
-    poweron_device(&g_dev);
+    struct r4300_core* r4300 = &dev->r4300;
 
-    pifbootrom_hle_execute(&g_dev);
-    g_dev.r4300.cp0.last_addr = UINT32_C(0xa4000040);
+    poweron_device(dev);
+
+    pifbootrom_hle_execute(dev);
+    r4300->cp0.last_addr = UINT32_C(0xa4000040);
     *r4300_cp0_next_interrupt() = 624999;
-    init_interrupt(&g_dev.r4300.cp0);
-    if(g_dev.r4300.emumode != EMUMODE_PURE_INTERPRETER)
+    init_interrupt(&r4300->cp0);
+    if (r4300->emumode != EMUMODE_PURE_INTERPRETER)
     {
-        free_blocks(&g_dev.r4300.cached_interp);
-        init_blocks(&g_dev.r4300.cached_interp);
+        free_blocks(&r4300->cached_interp);
+        init_blocks(&r4300->cached_interp);
     }
-    generic_jump_to(&g_dev.r4300, g_dev.r4300.cp0.last_addr);
+    generic_jump_to(r4300, r4300->cp0.last_addr);
 }
 
 
@@ -548,7 +550,7 @@ void gen_interrupt(void)
 
         if (g_dev.r4300.reset_hard_job)
         {
-            reset_hard();
+            reset_hard(&g_dev);
             return;
         }
     }

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -432,9 +432,8 @@ static void special_int_handler(struct cp0* cp0)
     add_interrupt_event_count(cp0, SPECIAL_INT, 0);
 }
 
-static void compare_int_handler(void)
+static void compare_int_handler(struct r4300_core* r4300)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
     uint32_t* cp0_regs = r4300_cp0_regs();
 
     remove_interrupt_event(&r4300->cp0);
@@ -446,9 +445,8 @@ static void compare_int_handler(void)
     raise_maskable_interrupt(r4300, CP0_CAUSE_IP7);
 }
 
-static void hw2_int_handler(void)
+static void hw2_int_handler(struct r4300_core* r4300)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
     uint32_t* cp0_regs = r4300_cp0_regs();
     // Hardware Interrupt 2 -- remove interrupt event from queue
     remove_interrupt_event(&r4300->cp0);
@@ -583,7 +581,7 @@ void gen_interrupt(void)
             break;
 
         case COMPARE_INT:
-            compare_int_handler();
+            compare_int_handler(r4300);
             break;
 
         case CHECK_INT:
@@ -617,7 +615,7 @@ void gen_interrupt(void)
             break;
 
         case HW2_INT:
-            hw2_int_handler();
+            hw2_int_handler(r4300);
             break;
 
         case NMI_INT:

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -149,7 +149,7 @@ void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count)
         cp0->special_done = 0;
     }
 
-    if (get_event(type)) {
+    if (get_event(&cp0->q, type)) {
         DebugMessage(M64MSG_WARNING, "two events of type 0x%x in interrupt queue", type);
         /* FIXME: hack-fix for freezing in Perfect Dark
          * http://code.google.com/p/mupen64plus/issues/detail?id=553
@@ -220,9 +220,9 @@ static void remove_interrupt_event(void)
         : 0;
 }
 
-unsigned int get_event(int type)
+unsigned int get_event(const struct interrupt_queue* q, int type)
 {
-    struct node* e = g_dev.r4300.cp0.q.first;
+    const struct node* e = q->first;
 
     if (e == NULL) {
         return 0;

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -239,11 +239,11 @@ unsigned int get_event(const struct interrupt_queue* q, int type)
         : 0;
 }
 
-int get_next_event_type(void)
+int get_next_event_type(const struct interrupt_queue* q)
 {
-    return (g_dev.r4300.cp0.q.first == NULL)
+    return (q->first == NULL)
         ? 0
-        : g_dev.r4300.cp0.q.first->data.type;
+        : q->first->data.type;
 }
 
 void remove_event(int type)

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -402,7 +402,7 @@ static void wrapped_exception_general(struct r4300_core* r4300)
 #endif
 }
 
-void raise_maskable_interrupt(uint32_t cause)
+void raise_maskable_interrupt(struct r4300_core* r4300, uint32_t cause)
 {
     uint32_t* cp0_regs = r4300_cp0_regs();
     cp0_regs[CP0_CAUSE_REG] = (cp0_regs[CP0_CAUSE_REG] | cause) & ~CP0_CAUSE_EXCCODE_MASK;
@@ -415,7 +415,7 @@ void raise_maskable_interrupt(uint32_t cause)
         return;
     }
 
-    wrapped_exception_general(&g_dev.r4300);
+    wrapped_exception_general(r4300);
 }
 
 static void special_int_handler(struct cp0* cp0)
@@ -443,7 +443,7 @@ static void compare_int_handler(void)
     add_interrupt_event_count(&r4300->cp0, COMPARE_INT, cp0_regs[CP0_COMPARE_REG]);
     cp0_regs[CP0_COUNT_REG] -= r4300->cp0.count_per_op;
 
-    raise_maskable_interrupt(CP0_CAUSE_IP7);
+    raise_maskable_interrupt(r4300, CP0_CAUSE_IP7);
 }
 
 static void hw2_int_handler(void)

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -418,9 +418,8 @@ void raise_maskable_interrupt(uint32_t cause)
     wrapped_exception_general();
 }
 
-static void special_int_handler(void)
+static void special_int_handler(struct cp0* cp0)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
     const uint32_t* cp0_regs = r4300_cp0_regs();
 
     if (cp0_regs[CP0_COUNT_REG] > UINT32_C(0x10000000)) {
@@ -428,9 +427,9 @@ static void special_int_handler(void)
     }
 
 
-    r4300->cp0.special_done = 1;
-    remove_interrupt_event(&r4300->cp0);
-    add_interrupt_event_count(&r4300->cp0, SPECIAL_INT, 0);
+    cp0->special_done = 1;
+    remove_interrupt_event(cp0);
+    add_interrupt_event_count(cp0, SPECIAL_INT, 0);
 }
 
 static void compare_int_handler(void)
@@ -571,7 +570,7 @@ void gen_interrupt(void)
     switch(g_dev.r4300.cp0.q.first->data.type)
     {
         case SPECIAL_INT:
-            special_int_handler();
+            special_int_handler(&g_dev.r4300.cp0);
             break;
 
         case VI_INT:

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -247,10 +247,10 @@ int get_next_event_type(const struct interrupt_queue* q)
         : q->first->data.type;
 }
 
-void remove_event(int type)
+void remove_event(struct interrupt_queue* q, int type)
 {
     struct node* to_del;
-    struct node* e = g_dev.r4300.cp0.q.first;
+    struct node* e = q->first;
 
     if (e == NULL) {
         return;
@@ -258,8 +258,8 @@ void remove_event(int type)
 
     if (e->data.type == type)
     {
-        g_dev.r4300.cp0.q.first = e->next;
-        free_node(&g_dev.r4300.cp0.q.pool, e);
+        q->first = e->next;
+        free_node(&q->pool, e);
     }
     else
     {
@@ -269,7 +269,7 @@ void remove_event(int type)
         {
             to_del = e->next;
             e->next = to_del->next;
-            free_node(&g_dev.r4300.cp0.q.pool, to_del);
+            free_node(&q->pool, to_del);
         }
     }
 }
@@ -280,8 +280,8 @@ void translate_event_queue(unsigned int base)
     struct r4300_core* r4300 = &g_dev.r4300;
     uint32_t* cp0_regs = r4300_cp0_regs();
 
-    remove_event(COMPARE_INT);
-    remove_event(SPECIAL_INT);
+    remove_event(&r4300->cp0.q, COMPARE_INT);
+    remove_event(&r4300->cp0.q, SPECIAL_INT);
 
     for (e = r4300->cp0.q.first; e != NULL; e = e->next)
     {

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -483,8 +483,8 @@ static void nmi_int_handler(struct device* dev)
     if (r4300->emumode != EMUMODE_PURE_INTERPRETER)
     {
         // clear all the compiled instruction blocks and re-initialize
-        free_blocks(&r4300->cached_interp);
-        init_blocks(&r4300->cached_interp);
+        free_blocks(r4300);
+        init_blocks(r4300);
     }
     // adjust ErrorEPC if we were in a delay slot, and clear the r4300->delay_slot and r4300->dyna_interp flags
     if(r4300->delay_slot==1 || r4300->delay_slot==3)
@@ -522,8 +522,8 @@ static void reset_hard(struct device* dev)
     init_interrupt(&r4300->cp0);
     if (r4300->emumode != EMUMODE_PURE_INTERPRETER)
     {
-        free_blocks(&r4300->cached_interp);
-        init_blocks(&r4300->cached_interp);
+        free_blocks(r4300);
+        init_blocks(r4300);
     }
     generic_jump_to(r4300, r4300->cp0.last_addr);
 }

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -323,17 +323,18 @@ void load_eventqueue_infos(struct cp0* cp0, const char *buf)
     }
 }
 
-void init_interrupt(void)
+void init_interrupt(struct cp0* cp0)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
+    /* XXX: VI doesn't really belongs here */
+    struct vi_controller* vi = &g_dev.vi;
 
-    g_dev.r4300.cp0.special_done = 1;
+    cp0->special_done = 1;
 
-    g_dev.vi.delay = g_dev.vi.next_vi = 5000;
+    vi->delay = vi->next_vi = 5000;
 
-    clear_queue(&r4300->cp0.q);
-    add_interrupt_event_count(&r4300->cp0, VI_INT, g_dev.vi.next_vi);
-    add_interrupt_event_count(&r4300->cp0, SPECIAL_INT, 0);
+    clear_queue(&cp0->q);
+    add_interrupt_event_count(cp0, VI_INT, vi->next_vi);
+    add_interrupt_event_count(cp0, SPECIAL_INT, 0);
 }
 
 void check_interrupt(void)
@@ -473,7 +474,7 @@ static void nmi_int_handler(void)
     // clear all interrupts, reset interrupt counters back to 0
     cp0_regs[CP0_COUNT_REG] = 0;
     g_gs_vi_counter = 0;
-    init_interrupt();
+    init_interrupt(&r4300->cp0);
     // clear the audio status register so that subsequent write_ai() calls will work properly
     g_dev.ai.regs[AI_STATUS_REG] = 0;
     // set ErrorEPC with the last instruction address
@@ -516,7 +517,7 @@ static void reset_hard(void)
     pifbootrom_hle_execute(&g_dev);
     g_dev.r4300.cp0.last_addr = UINT32_C(0xa4000040);
     *r4300_cp0_next_interrupt() = 624999;
-    init_interrupt();
+    init_interrupt(&g_dev.r4300.cp0);
     if(g_dev.r4300.emumode != EMUMODE_PURE_INTERPRETER)
     {
         free_blocks(&g_dev.r4300.cached_interp);

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -290,14 +290,14 @@ void translate_event_queue(struct cp0* cp0, unsigned int base)
     add_interrupt_event_count(cp0, SPECIAL_INT, 0);
 }
 
-int save_eventqueue_infos(char *buf)
+int save_eventqueue_infos(struct cp0* cp0, char *buf)
 {
     int len;
     struct node* e;
 
     len = 0;
 
-    for (e = g_dev.r4300.cp0.q.first; e != NULL; e = e->next)
+    for (e = cp0->q.first; e != NULL; e = e->next)
     {
         memcpy(buf + len    , &e->data.type , 4);
         memcpy(buf + len + 4, &e->data.count, 4);
@@ -308,17 +308,17 @@ int save_eventqueue_infos(char *buf)
     return len+4;
 }
 
-void load_eventqueue_infos(char *buf)
+void load_eventqueue_infos(struct cp0* cp0, const char *buf)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
-
     int len = 0;
-    clear_queue(&r4300->cp0.q);
-    while (*((unsigned int*)&buf[len]) != 0xFFFFFFFF)
+
+    clear_queue(&cp0->q);
+
+    while (*((const unsigned int*)&buf[len]) != 0xFFFFFFFF)
     {
-        int type = *((unsigned int*)&buf[len]);
-        unsigned int count = *((unsigned int*)&buf[len+4]);
-        add_interrupt_event_count(&r4300->cp0, type, count);
+        int type = *((const unsigned int*)&buf[len]);
+        unsigned int count = *((const unsigned int*)&buf[len+4]);
+        add_interrupt_event_count(cp0, type, count);
         len += 8;
     }
 }

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -395,10 +395,10 @@ static void wrapped_exception_general(struct r4300_core* r4300)
         }
         pending_exception=1;
     } else {
-        exception_general();
+        exception_general(r4300);
     }
 #else
-    exception_general();
+    exception_general(r4300);
 #endif
 }
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -274,21 +274,20 @@ void remove_event(struct interrupt_queue* q, int type)
     }
 }
 
-void translate_event_queue(unsigned int base)
+void translate_event_queue(struct cp0* cp0, unsigned int base)
 {
     struct node* e;
-    struct r4300_core* r4300 = &g_dev.r4300;
-    uint32_t* cp0_regs = r4300_cp0_regs();
+    const uint32_t* cp0_regs = r4300_cp0_regs();
 
-    remove_event(&r4300->cp0.q, COMPARE_INT);
-    remove_event(&r4300->cp0.q, SPECIAL_INT);
+    remove_event(&cp0->q, COMPARE_INT);
+    remove_event(&cp0->q, SPECIAL_INT);
 
-    for (e = r4300->cp0.q.first; e != NULL; e = e->next)
+    for (e = cp0->q.first; e != NULL; e = e->next)
     {
         e->data.count = (e->data.count - cp0_regs[CP0_COUNT_REG]) + base;
     }
-    add_interrupt_event_count(&r4300->cp0, COMPARE_INT, cp0_regs[CP0_COMPARE_REG]);
-    add_interrupt_event_count(&r4300->cp0, SPECIAL_INT, 0);
+    add_interrupt_event_count(cp0, COMPARE_INT, cp0_regs[CP0_COMPARE_REG]);
+    add_interrupt_event_count(cp0, SPECIAL_INT, 0);
 }
 
 int save_eventqueue_infos(char *buf)

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -337,10 +337,9 @@ void init_interrupt(struct cp0* cp0)
     add_interrupt_event_count(cp0, SPECIAL_INT, 0);
 }
 
-void check_interrupt(void)
+void check_interrupt(struct r4300_core* r4300)
 {
     struct node* event;
-    struct r4300_core* r4300 = &g_dev.r4300;
     uint32_t* cp0_regs = r4300_cp0_regs();
     unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt();
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -91,10 +91,10 @@ static void clear_pool(struct pool* p)
  * Interrupt Queue
  **************************************************************************/
 
-static void clear_queue(void)
+static void clear_queue(struct interrupt_queue* q)
 {
-    g_dev.r4300.cp0.q.first = NULL;
-    clear_pool(&g_dev.r4300.cp0.q.pool);
+    q->first = NULL;
+    clear_pool(&q->pool);
 }
 
 static int before_event(unsigned int evt1, unsigned int evt2, int type2)
@@ -307,8 +307,10 @@ int save_eventqueue_infos(char *buf)
 
 void load_eventqueue_infos(char *buf)
 {
+    struct r4300_core* r4300 = &g_dev.r4300;
+
     int len = 0;
-    clear_queue();
+    clear_queue(&r4300->cp0.q);
     while (*((unsigned int*)&buf[len]) != 0xFFFFFFFF)
     {
         int type = *((unsigned int*)&buf[len]);
@@ -320,11 +322,13 @@ void load_eventqueue_infos(char *buf)
 
 void init_interrupt(void)
 {
+    struct r4300_core* r4300 = &g_dev.r4300;
+
     g_dev.r4300.cp0.special_done = 1;
 
     g_dev.vi.delay = g_dev.vi.next_vi = 5000;
 
-    clear_queue();
+    clear_queue(&r4300->cp0.q);
     add_interrupt_event_count(VI_INT, g_dev.vi.next_vi);
     add_interrupt_event_count(SPECIAL_INT, 0);
 }

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 
 struct cp0;
+struct interrupt_queue;
 
 void init_interrupt(void);
 
@@ -37,7 +38,7 @@ void translate_event_queue(unsigned int base);
 void remove_event(int type);
 void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count);
 void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);
-unsigned int get_event(int type);
+unsigned int get_event(const struct interrupt_queue* q, int type);
 int get_next_event_type(void);
 
 int save_eventqueue_infos(char *buf);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -27,7 +27,7 @@
 struct cp0;
 struct interrupt_queue;
 
-void init_interrupt(void);
+void init_interrupt(struct cp0* cp0);
 
 void raise_maskable_interrupt(uint32_t cause);
 

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -1,5 +1,5 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus - interupt.h                                              *
+ *   Mupen64plus - interrupt.h                                              *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
  *   Copyright (C) 2002 Hacktarux                                          *
  *                                                                         *
@@ -19,22 +19,22 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef M64P_DEVICE_R4300_INTERUPT_H
-#define M64P_DEVICE_R4300_INTERUPT_H
+#ifndef M64P_DEVICE_R4300_INTERRUPT_H
+#define M64P_DEVICE_R4300_INTERRUPT_H
 
 #include <stdint.h>
 
-void init_interupt(void);
+void init_interrupt(void);
 
 void raise_maskable_interrupt(uint32_t cause);
 
-void gen_interupt(void);
-void check_interupt(void);
+void gen_interrupt(void);
+void check_interrupt(void);
 
 void translate_event_queue(unsigned int base);
 void remove_event(int type);
-void add_interupt_event_count(int type, unsigned int count);
-void add_interupt_event(int type, unsigned int delay);
+void add_interrupt_event_count(int type, unsigned int count);
+void add_interrupt_event(int type, unsigned int delay);
 unsigned int get_event(int type);
 int get_next_event_type(void);
 
@@ -53,4 +53,4 @@ void load_eventqueue_infos(char *buf);
 #define HW2_INT     0x200
 #define NMI_INT     0x400
 
-#endif /* M64P_DEVICE_R4300_INTERUPT_H */
+#endif /* M64P_DEVICE_R4300_INTERRUPT_H */

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -39,7 +39,7 @@ void remove_event(int type);
 void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count);
 void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);
 unsigned int get_event(const struct interrupt_queue* q, int type);
-int get_next_event_type(void);
+int get_next_event_type(const struct interrupt_queue* q);
 
 int save_eventqueue_infos(char *buf);
 void load_eventqueue_infos(char *buf);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -41,8 +41,8 @@ void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);
 unsigned int get_event(const struct interrupt_queue* q, int type);
 int get_next_event_type(const struct interrupt_queue* q);
 
-int save_eventqueue_infos(char *buf);
-void load_eventqueue_infos(char *buf);
+int save_eventqueue_infos(struct cp0* cp0, char *buf);
+void load_eventqueue_infos(struct cp0* cp0, const char *buf);
 
 #define VI_INT      0x001
 #define COMPARE_INT 0x002

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -24,6 +24,8 @@
 
 #include <stdint.h>
 
+struct cp0;
+
 void init_interrupt(void);
 
 void raise_maskable_interrupt(uint32_t cause);
@@ -33,8 +35,8 @@ void check_interrupt(void);
 
 void translate_event_queue(unsigned int base);
 void remove_event(int type);
-void add_interrupt_event_count(int type, unsigned int count);
-void add_interrupt_event(int type, unsigned int delay);
+void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count);
+void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);
 unsigned int get_event(int type);
 int get_next_event_type(void);
 

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -35,7 +35,7 @@ void gen_interrupt(void);
 void check_interrupt(void);
 
 void translate_event_queue(unsigned int base);
-void remove_event(int type);
+void remove_event(struct interrupt_queue* q, int type);
 void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count);
 void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);
 unsigned int get_event(const struct interrupt_queue* q, int type);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -24,6 +24,7 @@
 
 #include <stdint.h>
 
+struct r4300_core;
 struct cp0;
 struct interrupt_queue;
 
@@ -32,7 +33,7 @@ void init_interrupt(struct cp0* cp0);
 void raise_maskable_interrupt(uint32_t cause);
 
 void gen_interrupt(void);
-void check_interrupt(void);
+void check_interrupt(struct r4300_core* r4300);
 
 void translate_event_queue(struct cp0* cp0, unsigned int base);
 void remove_event(struct interrupt_queue* q, int type);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -34,7 +34,7 @@ void raise_maskable_interrupt(uint32_t cause);
 void gen_interrupt(void);
 void check_interrupt(void);
 
-void translate_event_queue(unsigned int base);
+void translate_event_queue(struct cp0* cp0, unsigned int base);
 void remove_event(struct interrupt_queue* q, int type);
 void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count);
 void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -30,7 +30,7 @@ struct interrupt_queue;
 
 void init_interrupt(struct cp0* cp0);
 
-void raise_maskable_interrupt(uint32_t cause);
+void raise_maskable_interrupt(struct r4300_core* r4300, uint32_t cause);
 
 void gen_interrupt(void);
 void check_interrupt(struct r4300_core* r4300);

--- a/src/device/r4300/interupt.c
+++ b/src/device/r4300/interupt.c
@@ -451,8 +451,8 @@ static void nmi_int_handler(void)
     if (g_dev.r4300.emumode != EMUMODE_PURE_INTERPRETER)
     {
         // clear all the compiled instruction blocks and re-initialize
-        free_blocks();
-        init_blocks();
+        free_blocks(&g_dev.r4300.cached_interp);
+        init_blocks(&g_dev.r4300.cached_interp);
     }
     // adjust ErrorEPC if we were in a delay slot, and clear the g_dev.r4300.delay_slot and g_dev.r4300.dyna_interp flags
     if(g_dev.r4300.delay_slot==1 || g_dev.r4300.delay_slot==3)
@@ -488,8 +488,8 @@ static void reset_hard(void)
     init_interupt();
     if(g_dev.r4300.emumode != EMUMODE_PURE_INTERPRETER)
     {
-        free_blocks();
-        init_blocks();
+        free_blocks(&g_dev.r4300.cached_interp);
+        init_blocks(&g_dev.r4300.cached_interp);
     }
     generic_jump_to(&g_dev.r4300, g_dev.r4300.cp0.last_addr);
 }

--- a/src/device/r4300/interupt.c
+++ b/src/device/r4300/interupt.c
@@ -463,7 +463,7 @@ static void nmi_int_handler(void)
     g_dev.r4300.dyna_interp = 0;
     // set next instruction address to reset vector
     g_dev.r4300.cp0.last_addr = UINT32_C(0xa4000040);
-    generic_jump_to(UINT32_C(0xa4000040));
+    generic_jump_to(&g_dev.r4300, UINT32_C(0xa4000040));
 
 #ifdef NEW_DYNAREC
     if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
@@ -491,7 +491,7 @@ static void reset_hard(void)
         free_blocks();
         init_blocks();
     }
-    generic_jump_to(g_dev.r4300.cp0.last_addr);
+    generic_jump_to(&g_dev.r4300, g_dev.r4300.cp0.last_addr);
 }
 
 
@@ -532,7 +532,7 @@ void gen_interupt(void)
             : 0;
 
         g_dev.r4300.cp0.last_addr = dest;
-        generic_jump_to(dest);
+        generic_jump_to(&g_dev.r4300, dest);
         return;
     } 
 

--- a/src/device/r4300/mi_controller.c
+++ b/src/device/r4300/mi_controller.c
@@ -101,7 +101,7 @@ int write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     case MI_INTR_MASK_REG:
         update_mi_intr_mask(&r4300->mi.regs[MI_INTR_MASK_REG], value & mask);
 
-        check_interrupt();
+        check_interrupt(r4300);
         cp0_update_count();
         if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
         break;
@@ -123,12 +123,12 @@ void raise_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr)
 void signal_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr)
 {
     r4300->mi.regs[MI_INTR_REG] |= mi_intr;
-    check_interrupt();
+    check_interrupt(r4300);
 }
 
 void clear_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr)
 {
     r4300->mi.regs[MI_INTR_REG] &= ~mi_intr;
-    check_interrupt();
+    check_interrupt(r4300);
 }
 

--- a/src/device/r4300/mi_controller.c
+++ b/src/device/r4300/mi_controller.c
@@ -24,7 +24,7 @@
 #include <string.h>
 
 #include "cp0.h"
-#include "interupt.h"
+#include "interrupt.h"
 #include "r4300_core.h"
 
 static int update_mi_init_mode(uint32_t* mi_init_mode, uint32_t w)
@@ -101,9 +101,9 @@ int write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     case MI_INTR_MASK_REG:
         update_mi_intr_mask(&r4300->mi.regs[MI_INTR_MASK_REG], value & mask);
 
-        check_interupt();
+        check_interrupt();
         cp0_update_count();
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interupt();
+        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
         break;
     }
 
@@ -123,12 +123,12 @@ void raise_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr)
 void signal_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr)
 {
     r4300->mi.regs[MI_INTR_REG] |= mi_intr;
-    check_interupt();
+    check_interrupt();
 }
 
 void clear_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr)
 {
     r4300->mi.regs[MI_INTR_REG] &= ~mi_intr;
-    check_interupt();
+    check_interrupt();
 }
 

--- a/src/device/r4300/mi_controller.c
+++ b/src/device/r4300/mi_controller.c
@@ -116,7 +116,7 @@ void raise_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr)
     r4300->mi.regs[MI_INTR_REG] |= mi_intr;
 
     if (r4300->mi.regs[MI_INTR_REG] & r4300->mi.regs[MI_INTR_MASK_REG])
-        raise_maskable_interrupt(CP0_CAUSE_IP2);
+        raise_maskable_interrupt(r4300, CP0_CAUSE_IP2);
 }
 
 /* interrupt execution is scheduled (if not masked) */

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -290,7 +290,7 @@ GLOBAL_FUNCTION(cc_interrupt):
     tst    r4, r4
     bne    .E4
 .E1:
-    bl     gen_interupt
+    bl     gen_interrupt
     mov    lr, r10
     ldr    r10, [fp, #g_dev_r4300_cp0_regs+36-dynarec_local] /* Count */
     ldr    r0, [fp, #g_dev_r4300_cp0_next_interrupt-dynarec_local]
@@ -379,7 +379,7 @@ GLOBAL_FUNCTION(jump_eret):
     add    r10, r0, r10
     str    r1, [fp, #g_dev_r4300_cp0_regs+48-dynarec_local] /* Status */
     str    r10, [fp, #g_dev_r4300_cp0_regs+36-dynarec_local] /* Count */
-    bl     check_interupt
+    bl     check_interrupt
     ldr    r1, [fp, #g_dev_r4300_cp0_next_interrupt-dynarec_local]
     ldr    r0, [fp, #g_dev_r4300_cp0_regs+56-dynarec_local] /* EPC */
     str    r1, [fp, #last_count-dynarec_local]

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -379,7 +379,7 @@ GLOBAL_FUNCTION(jump_eret):
     add    r10, r0, r10
     str    r1, [fp, #g_dev_r4300_cp0_regs+48-dynarec_local] /* Status */
     str    r10, [fp, #g_dev_r4300_cp0_regs+36-dynarec_local] /* Count */
-    bl     check_interrupt
+    bl     new_dynarec_check_interrupt
     ldr    r1, [fp, #g_dev_r4300_cp0_next_interrupt-dynarec_local]
     ldr    r0, [fp, #g_dev_r4300_cp0_regs+56-dynarec_local] /* EPC */
     str    r1, [fp, #last_count-dynarec_local]

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -2273,7 +2273,7 @@ void invalidate_block(u_int block)
   #endif
 }
 
-void invalidate_cached_code_new_dynarec(uint32_t address, size_t size)
+void invalidate_cached_code_new_dynarec(struct r4300_core* r4300, uint32_t address, size_t size)
 {
     size_t i;
     size_t begin;

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -36,7 +36,7 @@
 #include "device/rsp/rsp_core.h"
 #include "device/r4300/cached_interp.h"
 #include "device/r4300/cp1.h"
-#include "device/r4300/interupt.h"
+#include "device/r4300/interrupt.h"
 #include "device/r4300/ops.h"
 #include "device/r4300/recomp.h"
 #include "device/r4300/tlb.h"
@@ -5989,7 +5989,7 @@ static void do_ccstub(int n)
   emit_readword((int)&last_count,ECX);
   emit_add(HOST_CCREG,ECX,EAX);
   emit_writeword(EAX,(int)&r4300_cp0_regs()[CP0_COUNT_REG]);
-  emit_call((int)gen_interupt);
+  emit_call((int)gen_interrupt);
   emit_readword((int)&r4300_cp0_regs()[CP0_COUNT_REG],HOST_CCREG);
   emit_readword((int)&g_dev.r4300.cp0.next_interrupt,EAX);
   emit_readword((int)&pending_exception,EBX);

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -11159,3 +11159,9 @@ static void TLBWR_new(void)
   }
 }
 
+/* used in assembler files */
+void new_dynarec_check_interrupt(void)
+{
+    check_interrupt(&g_dev.r4300);
+}
+

--- a/src/device/r4300/new_dynarec/new_dynarec.h
+++ b/src/device/r4300/new_dynarec/new_dynarec.h
@@ -29,6 +29,8 @@
 #define NEW_DYNAREC_AMD64 2
 #define NEW_DYNAREC_ARM 3
 
+struct r4300_core;
+
 extern int pcaddr;
 extern int pending_exception;
 extern unsigned int stop_after_jal;
@@ -58,7 +60,7 @@ extern uint32_t g_dev_r4300_cp1_fcr31;
 #endif
 
 void invalidate_all_pages(void);
-void invalidate_cached_code_new_dynarec(uint32_t address, size_t size);
+void invalidate_cached_code_new_dynarec(struct r4300_core* r4300, uint32_t address, size_t size);
 void new_dynarec_init(void);
 void new_dyna_start(void);
 void new_dynarec_cleanup(void);

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -119,13 +119,13 @@ cextern branch_target
 cextern memory_map
 cextern pending_exception
 cextern restore_candidate
-cextern gen_interupt
+cextern gen_interrupt
 cextern last_count
 cextern pcaddr
 cextern clean_blocks
 cextern invalidate_block
 cextern readmem_dword
-cextern check_interupt
+cextern check_interrupt
 cextern get_addr_32
 cextern write_mi
 cextern write_mib
@@ -257,7 +257,7 @@ cc_interrupt:
     cmp     DWORD [find_local_data(restore_candidate+esi)],    0
     jne     _E4
 _E1:
-    call    gen_interupt
+    call    gen_interrupt
     mov     esi,    [find_local_data(g_dev_r4300_cp0_regs+36)]
     mov     eax,    [find_local_data(g_dev_r4300_cp0_next_interrupt)]
     mov     edx,    [find_local_data(pending_exception)]
@@ -360,7 +360,7 @@ jump_eret:
     and     ecx,    0FFFFFFFDh
     mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi        ;Count
     mov     [find_local_data(g_dev_r4300_cp0_regs+48)],    ecx        ;Status
-    call    check_interupt
+    call    check_interrupt
     mov     eax,    [find_local_data(g_dev_r4300_cp0_next_interrupt)]
     mov     esi,    [find_local_data(g_dev_r4300_cp0_regs+36)]
     mov     [find_local_data(last_count)],    eax

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -125,7 +125,7 @@ cextern pcaddr
 cextern clean_blocks
 cextern invalidate_block
 cextern readmem_dword
-cextern check_interrupt
+cextern new_dynarec_check_interrupt
 cextern get_addr_32
 cextern write_mi
 cextern write_mib
@@ -360,7 +360,7 @@ jump_eret:
     and     ecx,    0FFFFFFFDh
     mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi        ;Count
     mov     [find_local_data(g_dev_r4300_cp0_regs+48)],    ecx        ;Status
-    call    check_interrupt
+    call    new_dynarec_check_interrupt
     mov     eax,    [find_local_data(g_dev_r4300_cp0_next_interrupt)]
     mov     esi,    [find_local_data(g_dev_r4300_cp0_regs+36)]
     mov     [find_local_data(last_count)],    eax

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -55,7 +55,7 @@ static void InterpretOpcode(void);
       const int take_jump = (condition); \
       const uint32_t jump_target = (destination); \
       int64_t *link_register = (link); \
-      if (cop1 && check_cop1_unusable()) return; \
+      if (cop1 && check_cop1_unusable(&g_dev.r4300)) return; \
       if (link_register != &r4300_regs()[0]) \
       { \
           *link_register = SE32(g_dev.r4300.interp_PC.addr + 8); \
@@ -85,7 +85,7 @@ static void InterpretOpcode(void);
       uint32_t* cp0_regs = r4300_cp0_regs(); \
       const int take_jump = (condition); \
       int skip; \
-      if (cop1 && check_cop1_unusable()) return; \
+      if (cop1 && check_cop1_unusable(&g_dev.r4300)) return; \
       if (take_jump) \
       { \
          cp0_update_count(); \

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -720,11 +720,11 @@ void InterpretOpcode()
 	} /* switch ((op >> 26) & 0x3F) */
 }
 
-void pure_interpreter(void)
+void run_pure_interpreter(struct r4300_core* r4300)
 {
    *r4300_stop() = 0;
-   *r4300_pc_struct() = &g_dev.r4300.interp_PC;
-   *r4300_pc() = g_dev.r4300.cp0.last_addr = 0xa4000040;
+   *r4300_pc_struct() = &r4300->interp_PC;
+   *r4300_pc() = r4300->cp0.last_addr = 0xa4000040;
 
    while (!*r4300_stop())
    {

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -33,7 +33,7 @@
 #include "device/r4300/cached_interp.h"
 #include "device/r4300/cp1.h"
 #include "device/r4300/exception.h"
-#include "device/r4300/interupt.h"
+#include "device/r4300/interrupt.h"
 #include "device/r4300/tlb.h"
 #include "main/main.h"
 #include "osal/preproc.h"
@@ -78,7 +78,7 @@ static void InterpretOpcode(void);
          cp0_update_count(); \
       } \
       g_dev.r4300.cp0.last_addr = g_dev.r4300.interp_PC.addr; \
-      if (*r4300_cp0_next_interrupt() <= r4300_cp0_regs()[CP0_COUNT_REG]) gen_interupt(); \
+      if (*r4300_cp0_next_interrupt() <= r4300_cp0_regs()[CP0_COUNT_REG]) gen_interrupt(); \
    } \
    static void name##_IDLE(uint32_t op) \
    { \

--- a/src/device/r4300/pure_interp.h
+++ b/src/device/r4300/pure_interp.h
@@ -22,6 +22,8 @@
 #ifndef M64P_DEVICE_R4300_PURE_INTERP_H
 #define M64P_DEVICE_R4300_PURE_INTERP_H
 
-void pure_interpreter(void);
+struct r4300_core;
+
+void run_pure_interpreter(struct r4300_core* r4300);
 
 #endif /* M64P_DEVICE_R4300_PURE_INTERP_H */

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -152,7 +152,7 @@ void run_r4300(struct r4300_core* r4300)
     {
         DebugMessage(M64MSG_INFO, "Starting R4300 emulator: Dynamic Recompiler");
         r4300->emumode = EMUMODE_DYNAREC;
-        init_blocks();
+        init_blocks(&r4300->cached_interp);
 
 #ifdef NEW_DYNAREC
         new_dynarec_init();
@@ -165,14 +165,14 @@ void run_r4300(struct r4300_core* r4300)
 #if defined(PROFILE_R4300)
         profile_write_end_of_code_blocks(r4300);
 #endif
-        free_blocks();
+        free_blocks(&r4300->cached_interp);
     }
 #endif
     else /* if (r4300->emumode == EMUMODE_INTERPRETER) */
     {
         DebugMessage(M64MSG_INFO, "Starting R4300 emulator: Cached Interpreter");
         r4300->emumode = EMUMODE_INTERPRETER;
-        init_blocks();
+        init_blocks(&r4300->cached_interp);
         jump_to(UINT32_C(0xa4000040));
 
         /* Prevent segfault on failed jump_to */
@@ -183,7 +183,7 @@ void run_r4300(struct r4300_core* r4300)
 
         run_cached_interpreter(r4300);
 
-        free_blocks();
+        free_blocks(&r4300->cached_interp);
     }
 
     DebugMessage(M64MSG_INFO, "R4300 emulator finished.");

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -154,7 +154,7 @@ void run_r4300(struct r4300_core* r4300)
     {
         DebugMessage(M64MSG_INFO, "Starting R4300 emulator: Dynamic Recompiler");
         r4300->emumode = EMUMODE_DYNAREC;
-        init_blocks(&r4300->cached_interp);
+        init_blocks(r4300);
 
 #ifdef NEW_DYNAREC
         new_dynarec_init();
@@ -167,14 +167,14 @@ void run_r4300(struct r4300_core* r4300)
 #if defined(PROFILE_R4300)
         profile_write_end_of_code_blocks(r4300);
 #endif
-        free_blocks(&r4300->cached_interp);
+        free_blocks(r4300);
     }
 #endif
     else /* if (r4300->emumode == EMUMODE_INTERPRETER) */
     {
         DebugMessage(M64MSG_INFO, "Starting R4300 emulator: Cached Interpreter");
         r4300->emumode = EMUMODE_INTERPRETER;
-        init_blocks(&r4300->cached_interp);
+        init_blocks(r4300);
         cached_interpreter_dynarec_jump_to(r4300, UINT32_C(0xa4000040));
 
         /* Prevent segfault on failed cached_interpreter_dynarec_jump_to */
@@ -186,7 +186,7 @@ void run_r4300(struct r4300_core* r4300)
 
         run_cached_interpreter(r4300);
 
-        free_blocks(&r4300->cached_interp);
+        free_blocks(r4300);
     }
 
     DebugMessage(M64MSG_INFO, "R4300 emulator finished.");

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -141,7 +141,7 @@ void run_r4300(struct r4300_core* r4300)
     /* XXX: might go to r4300_poweron / soft_reset ? */
     r4300->cp0.last_addr = 0xa4000040;
     *r4300_cp0_next_interrupt() = 624999;
-    init_interrupt();
+    init_interrupt(&r4300->cp0);
 
     if (r4300->emumode == EMUMODE_PURE_INTERPRETER)
     {

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -149,7 +149,7 @@ void run_r4300(void)
     {
         DebugMessage(M64MSG_INFO, "Starting R4300 emulator: Pure Interpreter");
         g_dev.r4300.emumode = EMUMODE_PURE_INTERPRETER;
-        pure_interpreter();
+        run_pure_interpreter(&g_dev.r4300);
     }
 #if defined(DYNAREC)
     else if (g_dev.r4300.emumode >= 2)

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -141,7 +141,7 @@ void run_r4300(struct r4300_core* r4300)
     /* XXX: might go to r4300_poweron / soft_reset ? */
     r4300->cp0.last_addr = 0xa4000040;
     *r4300_cp0_next_interrupt() = 624999;
-    init_interupt();
+    init_interrupt();
 
     if (r4300->emumode == EMUMODE_PURE_INTERPRETER)
     {

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -126,10 +126,6 @@ static void dynarec_setup_code(void)
 
 void run_r4300(void)
 {
-#if (defined(DYNAREC) && defined(PROFILE_R4300))
-    unsigned int i;
-#endif
-
     g_dev.r4300.current_instruction_table = cached_interpreter_table;
 
     *r4300_stop() = 0;
@@ -167,21 +163,7 @@ void run_r4300(void)
         (*r4300_pc_struct())++;
 #endif
 #if defined(PROFILE_R4300)
-        g_dev.r4300.recomp.pfProfile = fopen("instructionaddrs.dat", "ab");
-        for (i=0; i<0x100000; i++)
-            if (g_dev.r4300.cached_interp.invalid_code[i] == 0 && g_dev.r4300.cached_interp.blocks[i] != NULL && g_dev.r4300.cached_interp.blocks[i]->code != NULL && g_dev.r4300.cached_interp.blocks[i]->block != NULL)
-            {
-                unsigned char *x86addr;
-                int mipsop;
-                // store final code length for this block
-                mipsop = -1; /* -1 == end of x86 code block */
-                x86addr = g_dev.r4300.cached_interp.blocks[i]->code + g_dev.r4300.cached_interp.blocks[i]->code_length;
-                if (fwrite(&mipsop, 1, 4, g_dev.r4300.recomp.pfProfile) != 4 ||
-                    fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *))
-                    DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
-            }
-        fclose(g_dev.r4300.recomp.pfProfile);
-        g_dev.r4300.recomp.pfProfile = NULL;
+        profile_write_end_of_code_blocks(&g_dev.r4300);
 #endif
         free_blocks();
     }

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -198,18 +198,8 @@ void run_r4300(void)
             return;
 
         g_dev.r4300.cp0.last_addr = *r4300_pc();
-        while (!*r4300_stop())
-        {
-#ifdef COMPARE_CORE
-            if ((*r4300_pc_struct())->ops == cached_interpreter_table.FIN_BLOCK && ((*r4300_pc_struct())->addr < 0x80000000 || (*r4300_pc_struct())->addr >= 0xc0000000))
-                virtual_to_physical_address(&g_dev.r4300.cp0.tlb, (*r4300_pc_struct())->addr, 2);
-            CoreCompareCallback();
-#endif
-#ifdef DBG
-            if (g_DebuggerActive) update_debugger((*r4300_pc_struct())->addr);
-#endif
-            (*r4300_pc_struct())->ops();
-        }
+
+        run_cached_interpreter(&g_dev.r4300);
 
         free_blocks();
     }

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -268,19 +268,19 @@ unsigned int get_r4300_emumode(struct r4300_core* r4300)
 
 
 
-void invalidate_r4300_cached_code(uint32_t address, size_t size)
+void invalidate_r4300_cached_code(struct r4300_core* r4300, uint32_t address, size_t size)
 {
-    if (g_dev.r4300.emumode != EMUMODE_PURE_INTERPRETER)
+    if (r4300->emumode != EMUMODE_PURE_INTERPRETER)
     {
 #ifdef NEW_DYNAREC
-        if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
+        if (r4300->emumode == EMUMODE_DYNAREC)
         {
-            invalidate_cached_code_new_dynarec(address, size);
+            invalidate_cached_code_new_dynarec(r4300, address, size);
         }
         else
 #endif
         {
-            invalidate_cached_code_hacktarux(address, size);
+            invalidate_cached_code_hacktarux(r4300, address, size);
         }
     }
 }
@@ -317,6 +317,6 @@ void savestates_load_set_pc(uint32_t pc)
 #endif
     {
         generic_jump_to(pc);
-        invalidate_r4300_cached_code(0,0);
+        invalidate_r4300_cached_code(&g_dev.r4300, 0, 0);
     }
 }

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -261,9 +261,9 @@ int* r4300_stop(void)
 #endif
 }
 
-unsigned int get_r4300_emumode(void)
+unsigned int get_r4300_emumode(struct r4300_core* r4300)
 {
-    return g_dev.r4300.emumode;
+    return r4300->emumode;
 }
 
 

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -307,10 +307,10 @@ void generic_jump_to(struct r4300_core* r4300, uint32_t address)
 
 
 /* XXX: not really a good interface but it gets the job done... */
-void savestates_load_set_pc(uint32_t pc)
+void savestates_load_set_pc(struct r4300_core* r4300, uint32_t pc)
 {
 #ifdef NEW_DYNAREC
-    if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
+    if (r4300->emumode == EMUMODE_DYNAREC)
     {
         pcaddr = pc;
         pending_exception = 1;
@@ -319,7 +319,7 @@ void savestates_load_set_pc(uint32_t pc)
     else
 #endif
     {
-        generic_jump_to(&g_dev.r4300, pc);
-        invalidate_r4300_cached_code(&g_dev.r4300, 0, 0);
+        generic_jump_to(r4300, pc);
+        invalidate_r4300_cached_code(r4300, 0, 0);
     }
 }

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -286,20 +286,23 @@ void invalidate_r4300_cached_code(struct r4300_core* r4300, uint32_t address, si
 }
 
 
-void generic_jump_to(uint32_t address)
+void generic_jump_to(struct r4300_core* r4300, uint32_t address)
 {
-   if (g_dev.r4300.emumode == EMUMODE_PURE_INTERPRETER)
-      *r4300_pc() = address;
-   else {
+    if (r4300->emumode == EMUMODE_PURE_INTERPRETER) {
+        *r4300_pc() = address;
+    }
+    else {
 #ifdef NEW_DYNAREC
-      if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
-         g_dev.r4300.cp0.last_addr = pcaddr;
-      else
-         jump_to(address);
+        if (r4300->emumode == EMUMODE_DYNAREC) {
+            r4300->cp0.last_addr = pcaddr;
+        }
+        else {
+            jump_to(address);
+        }
 #else
-      jump_to(address);
+        jump_to(address);
 #endif
-   }
+    }
 }
 
 
@@ -316,7 +319,7 @@ void savestates_load_set_pc(uint32_t pc)
     else
 #endif
     {
-        generic_jump_to(pc);
+        generic_jump_to(&g_dev.r4300, pc);
         invalidate_r4300_cached_code(&g_dev.r4300, 0, 0);
     }
 }

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -202,7 +202,7 @@ void run_r4300(void)
         {
 #ifdef COMPARE_CORE
             if ((*r4300_pc_struct())->ops == cached_interpreter_table.FIN_BLOCK && ((*r4300_pc_struct())->addr < 0x80000000 || (*r4300_pc_struct())->addr >= 0xc0000000))
-                virtual_to_physical_address((*r4300_pc_struct())->addr, 2);
+                virtual_to_physical_address(&g_dev.r4300.cp0.tlb, (*r4300_pc_struct())->addr, 2);
             CoreCompareCallback();
 #endif
 #ifdef DBG

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -195,6 +195,6 @@ void invalidate_r4300_cached_code(struct r4300_core* r4300, uint32_t address, si
  * Use this for common code which can be executed from any r4300 emulator. */
 void generic_jump_to(struct r4300_core* r4300, unsigned int address);
 
-void savestates_load_set_pc(uint32_t pc);
+void savestates_load_set_pc(struct r4300_core* r4300, uint32_t pc);
 
 #endif

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -180,7 +180,7 @@ uint32_t* r4300_pc(void);
 struct precomp_instr** r4300_pc_struct(void);
 int* r4300_stop(void);
 
-unsigned int get_r4300_emumode(void);
+unsigned int get_r4300_emumode(struct r4300_core* r4300);
 
 /* Allow cached/dynarec r4300 implementations to invalidate
  * their cached code at [address, address+size]

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -188,7 +188,7 @@ unsigned int get_r4300_emumode(struct r4300_core* r4300);
  * If size == 0, r4300 implementation should invalidate
  * all cached code.
  */
-void invalidate_r4300_cached_code(uint32_t address, size_t size);
+void invalidate_r4300_cached_code(struct r4300_core* r4300, uint32_t address, size_t size);
 
 
 /* Jump to the given address. This works for all r4300 emulator, but is slower.

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -170,7 +170,7 @@ struct r4300_core
 void init_r4300(struct r4300_core* r4300, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump);
 void poweron_r4300(struct r4300_core* r4300);
 
-void run_r4300(void);
+void run_r4300(struct r4300_core* r4300);
 
 int64_t* r4300_regs(void);
 int64_t* r4300_mult_hi(void);

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -193,7 +193,7 @@ void invalidate_r4300_cached_code(struct r4300_core* r4300, uint32_t address, si
 
 /* Jump to the given address. This works for all r4300 emulator, but is slower.
  * Use this for common code which can be executed from any r4300 emulator. */
-void generic_jump_to(unsigned int address);
+void generic_jump_to(struct r4300_core* r4300, unsigned int address);
 
 void savestates_load_set_pc(uint32_t pc);
 

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -44,7 +44,6 @@ struct cached_interp
     char invalid_code[0x100000];
     struct precomp_block* blocks[0x100000];
     struct precomp_block* actual;
-    unsigned int jump_to_address;
 };
 
 enum {
@@ -140,6 +139,8 @@ struct r4300_core
         const uint32_t *SRC;                /* currently recompiled instruction in the input stream */
         int check_nop;                      /* next instruction is nop ? */
         int delay_slot_compiled;
+
+        uint32_t jump_to_address;
 
 #if defined(PROFILE_R4300)
         FILE* pfProfile;

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -37,6 +37,7 @@
 #include "api/m64p_types.h"
 #include "device/memory/memory.h"
 #include "device/r4300/cached_interp.h"
+#include "device/r4300/exception.h"
 #include "device/r4300/ops.h"
 #include "device/r4300/recomp.h"
 #include "device/r4300/recomph.h" //include for function prototypes
@@ -2619,6 +2620,12 @@ void profile_write_end_of_code_blocks(struct r4300_core* r4300)
 void dynarec_jump_to_address(void)
 {
     cached_interpreter_dynarec_jump_to(&g_dev.r4300, g_dev.r4300.recomp.jump_to_address);
+}
+
+/* Parameterless version of exception_general to ease usage in dynarec. */
+void dynarec_exception_general(void)
+{
+    exception_general(&g_dev.r4300);
 }
 
 

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2265,7 +2265,7 @@ void init_block(struct precomp_block *block)
   g_dev.r4300.cached_interp.invalid_code[block->start>>12] = 0;
   if (block->end < UINT32_C(0x80000000) || block->start >= UINT32_C(0xc0000000))
   { 
-    uint32_t paddr = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, block->start, 2);
+    uint32_t paddr = virtual_to_physical_address(&g_dev.r4300, block->start, 2);
     g_dev.r4300.cached_interp.invalid_code[paddr>>12] = 0;
     if (!g_dev.r4300.cached_interp.blocks[paddr>>12])
     {
@@ -2363,7 +2363,7 @@ void recompile_block(const uint32_t *source, struct precomp_block *block, uint32
     if(block->start < UINT32_C(0x80000000) || UINT32_C(block->start >= 0xc0000000))
       {
           uint32_t address2 =
-           virtual_to_physical_address(&g_dev.r4300.cp0.tlb, block->start + i*4, 0);
+           virtual_to_physical_address(&g_dev.r4300, block->start + i*4, 0);
          if(g_dev.r4300.cached_interp.blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops == g_dev.r4300.current_instruction_table.NOTCOMPILED)
            g_dev.r4300.cached_interp.blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops = g_dev.r4300.current_instruction_table.NOTCOMPILED2;
       }

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2599,6 +2599,14 @@ void profile_write_end_of_code_blocks(struct r4300_core* r4300)
 }
 #endif
 
+
+/* Parameterless version of cached_interpreter_dynarec_jump_to to ease usage in dynarec. */
+void dynarec_jump_to_address(void)
+{
+    cached_interpreter_dynarec_jump_to(&g_dev.r4300, g_dev.r4300.recomp.jump_to_address);
+}
+
+
 /**********************************************************************
  ************** allocate memory with executable bit set ***************
  **********************************************************************/

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2315,15 +2315,17 @@ void init_block(struct r4300_core* r4300, struct precomp_block* block)
     timed_section_end(TIMED_SECTION_COMPILER);
 }
 
-void free_block(struct precomp_block *block)
+void free_block(struct r4300_core* r4300, struct precomp_block* block)
 {
     size_t memsize = get_block_memsize(block);
 
     if (block->block) {
-        if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
+        if (r4300->emumode == EMUMODE_DYNAREC) {
             free_exec(block->block, memsize);
-        else
+        }
+        else {
             free(block->block);
+        }
         block->block = NULL;
     }
     if (block->code) { free_exec(block->code, block->max_code_length); block->code = NULL; }

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -49,54 +49,54 @@ static void free_exec(void *ptr, size_t length);
 
 static void RSV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.RESERVED;
-   g_dev.r4300.recomp.recomp_func = genreserved;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.RESERVED;
+    g_dev.r4300.recomp.recomp_func = genreserved;
 }
 
 static void RFIN_BLOCK(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FIN_BLOCK;
-   g_dev.r4300.recomp.recomp_func = genfin_block;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FIN_BLOCK;
+    g_dev.r4300.recomp.recomp_func = genfin_block;
 }
 
 static void RNOTCOMPILED(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NOTCOMPILED;
-   g_dev.r4300.recomp.recomp_func = gennotcompiled;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NOTCOMPILED;
+    g_dev.r4300.recomp.recomp_func = gennotcompiled;
 }
 
 static void recompile_standard_i_type(void)
 {
-   g_dev.r4300.recomp.dst->f.i.rs = r4300_regs() + ((g_dev.r4300.recomp.src >> 21) & 0x1F);
-   g_dev.r4300.recomp.dst->f.i.rt = r4300_regs() + ((g_dev.r4300.recomp.src >> 16) & 0x1F);
-   g_dev.r4300.recomp.dst->f.i.immediate = (int16_t) g_dev.r4300.recomp.src;
+    g_dev.r4300.recomp.dst->f.i.rs = r4300_regs() + ((g_dev.r4300.recomp.src >> 21) & 0x1F);
+    g_dev.r4300.recomp.dst->f.i.rt = r4300_regs() + ((g_dev.r4300.recomp.src >> 16) & 0x1F);
+    g_dev.r4300.recomp.dst->f.i.immediate = (int16_t) g_dev.r4300.recomp.src;
 }
 
 static void recompile_standard_j_type(void)
 {
-   g_dev.r4300.recomp.dst->f.j.inst_index = g_dev.r4300.recomp.src & UINT32_C(0x3FFFFFF);
+    g_dev.r4300.recomp.dst->f.j.inst_index = g_dev.r4300.recomp.src & UINT32_C(0x3FFFFFF);
 }
 
 static void recompile_standard_r_type(void)
 {
-   g_dev.r4300.recomp.dst->f.r.rs = r4300_regs() + ((g_dev.r4300.recomp.src >> 21) & 0x1F);
-   g_dev.r4300.recomp.dst->f.r.rt = r4300_regs() + ((g_dev.r4300.recomp.src >> 16) & 0x1F);
-   g_dev.r4300.recomp.dst->f.r.rd = r4300_regs() + ((g_dev.r4300.recomp.src >> 11) & 0x1F);
-   g_dev.r4300.recomp.dst->f.r.sa = (g_dev.r4300.recomp.src >>  6) & 0x1F;
+    g_dev.r4300.recomp.dst->f.r.rs = r4300_regs() + ((g_dev.r4300.recomp.src >> 21) & 0x1F);
+    g_dev.r4300.recomp.dst->f.r.rt = r4300_regs() + ((g_dev.r4300.recomp.src >> 16) & 0x1F);
+    g_dev.r4300.recomp.dst->f.r.rd = r4300_regs() + ((g_dev.r4300.recomp.src >> 11) & 0x1F);
+    g_dev.r4300.recomp.dst->f.r.sa = (g_dev.r4300.recomp.src >>  6) & 0x1F;
 }
 
 static void recompile_standard_lf_type(void)
 {
-   g_dev.r4300.recomp.dst->f.lf.base = (g_dev.r4300.recomp.src >> 21) & 0x1F;
-   g_dev.r4300.recomp.dst->f.lf.ft = (g_dev.r4300.recomp.src >> 16) & 0x1F;
-   g_dev.r4300.recomp.dst->f.lf.offset = g_dev.r4300.recomp.src & 0xFFFF;
+    g_dev.r4300.recomp.dst->f.lf.base = (g_dev.r4300.recomp.src >> 21) & 0x1F;
+    g_dev.r4300.recomp.dst->f.lf.ft = (g_dev.r4300.recomp.src >> 16) & 0x1F;
+    g_dev.r4300.recomp.dst->f.lf.offset = g_dev.r4300.recomp.src & 0xFFFF;
 }
 
 static void recompile_standard_cf_type(void)
 {
-   g_dev.r4300.recomp.dst->f.cf.ft = (g_dev.r4300.recomp.src >> 16) & 0x1F;
-   g_dev.r4300.recomp.dst->f.cf.fs = (g_dev.r4300.recomp.src >> 11) & 0x1F;
-   g_dev.r4300.recomp.dst->f.cf.fd = (g_dev.r4300.recomp.src >>  6) & 0x1F;
+    g_dev.r4300.recomp.dst->f.cf.ft = (g_dev.r4300.recomp.src >> 16) & 0x1F;
+    g_dev.r4300.recomp.dst->f.cf.fs = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    g_dev.r4300.recomp.dst->f.cf.fd = (g_dev.r4300.recomp.src >>  6) & 0x1F;
 }
 
 //-------------------------------------------------------------------------
@@ -105,407 +105,407 @@ static void recompile_standard_cf_type(void)
 
 static void RNOP(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NOP;
-   g_dev.r4300.recomp.recomp_func = gennop;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NOP;
+    g_dev.r4300.recomp.recomp_func = gennop;
 }
 
 static void RSLL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLL;
-   g_dev.r4300.recomp.recomp_func = gensll;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLL;
+    g_dev.r4300.recomp.recomp_func = gensll;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSRL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SRL;
-   g_dev.r4300.recomp.recomp_func = gensrl;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SRL;
+    g_dev.r4300.recomp.recomp_func = gensrl;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSRA(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SRA;
-   g_dev.r4300.recomp.recomp_func = gensra;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SRA;
+    g_dev.r4300.recomp.recomp_func = gensra;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSLLV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLLV;
-   g_dev.r4300.recomp.recomp_func = gensllv;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLLV;
+    g_dev.r4300.recomp.recomp_func = gensllv;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSRLV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SRLV;
-   g_dev.r4300.recomp.recomp_func = gensrlv;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SRLV;
+    g_dev.r4300.recomp.recomp_func = gensrlv;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSRAV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SRAV;
-   g_dev.r4300.recomp.recomp_func = gensrav;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SRAV;
+    g_dev.r4300.recomp.recomp_func = gensrav;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RJR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JR;
-   g_dev.r4300.recomp.recomp_func = genjr;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JR;
+    g_dev.r4300.recomp.recomp_func = genjr;
+    recompile_standard_i_type();
 }
 
 static void RJALR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JALR;
-   g_dev.r4300.recomp.recomp_func = genjalr;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JALR;
+    g_dev.r4300.recomp.recomp_func = genjalr;
+    recompile_standard_r_type();
 }
 
 static void RSYSCALL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SYSCALL;
-   g_dev.r4300.recomp.recomp_func = gensyscall;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SYSCALL;
+    g_dev.r4300.recomp.recomp_func = gensyscall;
 }
 
 static void RBREAK(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RSYNC(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SYNC;
-   g_dev.r4300.recomp.recomp_func = gensync;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SYNC;
+    g_dev.r4300.recomp.recomp_func = gensync;
 }
 
 static void RMFHI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MFHI;
-   g_dev.r4300.recomp.recomp_func = genmfhi;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MFHI;
+    g_dev.r4300.recomp.recomp_func = genmfhi;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RMTHI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MTHI;
-   g_dev.r4300.recomp.recomp_func = genmthi;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MTHI;
+    g_dev.r4300.recomp.recomp_func = genmthi;
+    recompile_standard_r_type();
 }
 
 static void RMFLO(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MFLO;
-   g_dev.r4300.recomp.recomp_func = genmflo;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MFLO;
+    g_dev.r4300.recomp.recomp_func = genmflo;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RMTLO(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MTLO;
-   g_dev.r4300.recomp.recomp_func = genmtlo;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MTLO;
+    g_dev.r4300.recomp.recomp_func = genmtlo;
+    recompile_standard_r_type();
 }
 
 static void RDSLLV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSLLV;
-   g_dev.r4300.recomp.recomp_func = gendsllv;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSLLV;
+    g_dev.r4300.recomp.recomp_func = gendsllv;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSRLV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRLV;
-   g_dev.r4300.recomp.recomp_func = gendsrlv;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRLV;
+    g_dev.r4300.recomp.recomp_func = gendsrlv;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSRAV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRAV;
-   g_dev.r4300.recomp.recomp_func = gendsrav;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRAV;
+    g_dev.r4300.recomp.recomp_func = gendsrav;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RMULT(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MULT;
-   g_dev.r4300.recomp.recomp_func = genmult;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MULT;
+    g_dev.r4300.recomp.recomp_func = genmult;
+    recompile_standard_r_type();
 }
 
 static void RMULTU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MULTU;
-   g_dev.r4300.recomp.recomp_func = genmultu;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MULTU;
+    g_dev.r4300.recomp.recomp_func = genmultu;
+    recompile_standard_r_type();
 }
 
 static void RDIV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DIV;
-   g_dev.r4300.recomp.recomp_func = gendiv;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DIV;
+    g_dev.r4300.recomp.recomp_func = gendiv;
+    recompile_standard_r_type();
 }
 
 static void RDIVU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DIVU;
-   g_dev.r4300.recomp.recomp_func = gendivu;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DIVU;
+    g_dev.r4300.recomp.recomp_func = gendivu;
+    recompile_standard_r_type();
 }
 
 static void RDMULT(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DMULT;
-   g_dev.r4300.recomp.recomp_func = gendmult;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DMULT;
+    g_dev.r4300.recomp.recomp_func = gendmult;
+    recompile_standard_r_type();
 }
 
 static void RDMULTU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DMULTU;
-   g_dev.r4300.recomp.recomp_func = gendmultu;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DMULTU;
+    g_dev.r4300.recomp.recomp_func = gendmultu;
+    recompile_standard_r_type();
 }
 
 static void RDDIV(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DDIV;
-   g_dev.r4300.recomp.recomp_func = genddiv;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DDIV;
+    g_dev.r4300.recomp.recomp_func = genddiv;
+    recompile_standard_r_type();
 }
 
 static void RDDIVU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DDIVU;
-   g_dev.r4300.recomp.recomp_func = genddivu;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DDIVU;
+    g_dev.r4300.recomp.recomp_func = genddivu;
+    recompile_standard_r_type();
 }
 
 static void RADD(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADD;
-   g_dev.r4300.recomp.recomp_func = genadd;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADD;
+    g_dev.r4300.recomp.recomp_func = genadd;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RADDU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADDU;
-   g_dev.r4300.recomp.recomp_func = genaddu;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADDU;
+    g_dev.r4300.recomp.recomp_func = genaddu;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSUB(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SUB;
-   g_dev.r4300.recomp.recomp_func = gensub;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SUB;
+    g_dev.r4300.recomp.recomp_func = gensub;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSUBU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SUBU;
-   g_dev.r4300.recomp.recomp_func = gensubu;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SUBU;
+    g_dev.r4300.recomp.recomp_func = gensubu;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RAND(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.AND;
-   g_dev.r4300.recomp.recomp_func = genand;
-   recompile_standard_r_type();
-   if(g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.AND;
+    g_dev.r4300.recomp.recomp_func = genand;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void ROR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.OR;
-   g_dev.r4300.recomp.recomp_func = genor;
-   recompile_standard_r_type();
-   if(g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.OR;
+    g_dev.r4300.recomp.recomp_func = genor;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RXOR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.XOR;
-   g_dev.r4300.recomp.recomp_func = genxor;
-   recompile_standard_r_type();
-   if(g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.XOR;
+    g_dev.r4300.recomp.recomp_func = genxor;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RNOR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NOR;
-   g_dev.r4300.recomp.recomp_func = gennor;
-   recompile_standard_r_type();
-   if(g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NOR;
+    g_dev.r4300.recomp.recomp_func = gennor;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSLT(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLT;
-   g_dev.r4300.recomp.recomp_func = genslt;
-   recompile_standard_r_type();
-   if(g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLT;
+    g_dev.r4300.recomp.recomp_func = genslt;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RSLTU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLTU;
-   g_dev.r4300.recomp.recomp_func = gensltu;
-   recompile_standard_r_type();
-   if(g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLTU;
+    g_dev.r4300.recomp.recomp_func = gensltu;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDADD(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DADD;
-   g_dev.r4300.recomp.recomp_func = gendadd;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DADD;
+    g_dev.r4300.recomp.recomp_func = gendadd;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDADDU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DADDU;
-   g_dev.r4300.recomp.recomp_func = gendaddu;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DADDU;
+    g_dev.r4300.recomp.recomp_func = gendaddu;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSUB(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSUB;
-   g_dev.r4300.recomp.recomp_func = gendsub;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSUB;
+    g_dev.r4300.recomp.recomp_func = gendsub;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSUBU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSUBU;
-   g_dev.r4300.recomp.recomp_func = gendsubu;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSUBU;
+    g_dev.r4300.recomp.recomp_func = gendsubu;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RTGE(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTGEU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTLT(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTLTU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTEQ(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TEQ;
-   g_dev.r4300.recomp.recomp_func = genteq;
-   recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TEQ;
+    g_dev.r4300.recomp.recomp_func = genteq;
+    recompile_standard_r_type();
 }
 
 static void RTNE(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RDSLL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSLL;
-   g_dev.r4300.recomp.recomp_func = gendsll;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSLL;
+    g_dev.r4300.recomp.recomp_func = gendsll;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSRL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRL;
-   g_dev.r4300.recomp.recomp_func = gendsrl;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRL;
+    g_dev.r4300.recomp.recomp_func = gendsrl;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSRA(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRA;
-   g_dev.r4300.recomp.recomp_func = gendsra;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRA;
+    g_dev.r4300.recomp.recomp_func = gendsra;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSLL32(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSLL32;
-   g_dev.r4300.recomp.recomp_func = gendsll32;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSLL32;
+    g_dev.r4300.recomp.recomp_func = gendsll32;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSRL32(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRL32;
-   g_dev.r4300.recomp.recomp_func = gendsrl32;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRL32;
+    g_dev.r4300.recomp.recomp_func = gendsrl32;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void RDSRA32(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRA32;
-   g_dev.r4300.recomp.recomp_func = gendsra32;
-   recompile_standard_r_type();
-   if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DSRA32;
+    g_dev.r4300.recomp.recomp_func = gendsra32;
+    recompile_standard_r_type();
+    if (g_dev.r4300.recomp.dst->f.r.rd == r4300_regs()) RNOP();
 }
 
 static void (*const recomp_special[64])(void) =
 {
-   RSLL , RSV   , RSRL , RSRA , RSLLV   , RSV    , RSRLV  , RSRAV  ,
-   RJR  , RJALR , RSV  , RSV  , RSYSCALL, RBREAK , RSV    , RSYNC  ,
-   RMFHI, RMTHI , RMFLO, RMTLO, RDSLLV  , RSV    , RDSRLV , RDSRAV ,
-   RMULT, RMULTU, RDIV , RDIVU, RDMULT  , RDMULTU, RDDIV  , RDDIVU ,
-   RADD , RADDU , RSUB , RSUBU, RAND    , ROR    , RXOR   , RNOR   ,
-   RSV  , RSV   , RSLT , RSLTU, RDADD   , RDADDU , RDSUB  , RDSUBU ,
-   RTGE , RTGEU , RTLT , RTLTU, RTEQ    , RSV    , RTNE   , RSV    ,
-   RDSLL, RSV   , RDSRL, RDSRA, RDSLL32 , RSV    , RDSRL32, RDSRA32
+    RSLL , RSV   , RSRL , RSRA , RSLLV   , RSV    , RSRLV  , RSRAV  ,
+    RJR  , RJALR , RSV  , RSV  , RSYSCALL, RBREAK , RSV    , RSYNC  ,
+    RMFHI, RMTHI , RMFLO, RMTLO, RDSLLV  , RSV    , RDSRLV , RDSRAV ,
+    RMULT, RMULTU, RDIV , RDIVU, RDMULT  , RDMULTU, RDDIV  , RDDIVU ,
+    RADD , RADDU , RSUB , RSUBU, RAND    , ROR    , RXOR   , RNOR   ,
+    RSV  , RSV   , RSLT , RSLTU, RDADD   , RDADDU , RDSUB  , RDSUBU ,
+    RTGE , RTGEU , RTLT , RTLTU, RTEQ    , RSV    , RTNE   , RSV    ,
+    RDSLL, RSV   , RDSRL, RDSRA, RDSLL32 , RSV    , RDSRL32, RDSRA32
 };
 
 //-------------------------------------------------------------------------
@@ -514,222 +514,222 @@ static void (*const recomp_special[64])(void) =
 
 static void RBLTZ(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZ;
-   g_dev.r4300.recomp.recomp_func = genbltz;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZ_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbltz_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZ_OUT;
-      g_dev.r4300.recomp.recomp_func = genbltz_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZ;
+    g_dev.r4300.recomp.recomp_func = genbltz;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZ_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbltz_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZ_OUT;
+        g_dev.r4300.recomp.recomp_func = genbltz_out;
+    }
 }
 
 static void RBGEZ(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZ;
-   g_dev.r4300.recomp.recomp_func = genbgez;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZ_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbgez_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZ_OUT;
-      g_dev.r4300.recomp.recomp_func = genbgez_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZ;
+    g_dev.r4300.recomp.recomp_func = genbgez;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZ_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbgez_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZ_OUT;
+        g_dev.r4300.recomp.recomp_func = genbgez_out;
+    }
 }
 
 static void RBLTZL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZL;
-   g_dev.r4300.recomp.recomp_func = genbltzl;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbltzl_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbltzl_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZL;
+    g_dev.r4300.recomp.recomp_func = genbltzl;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbltzl_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbltzl_out;
+    }
 }
 
 static void RBGEZL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZL;
-   g_dev.r4300.recomp.recomp_func = genbgezl;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbgezl_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbgezl_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZL;
+    g_dev.r4300.recomp.recomp_func = genbgezl;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbgezl_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbgezl_out;
+    }
 }
 
 static void RTGEI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTGEIU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTLTI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTLTIU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTEQI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RTNEI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
 }
 
 static void RBLTZAL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZAL;
-   g_dev.r4300.recomp.recomp_func = genbltzal;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZAL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbltzal_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZAL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbltzal_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZAL;
+    g_dev.r4300.recomp.recomp_func = genbltzal;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZAL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbltzal_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZAL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbltzal_out;
+    }
 }
 
 static void RBGEZAL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZAL;
-   g_dev.r4300.recomp.recomp_func = genbgezal;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZAL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbgezal_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZAL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbgezal_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZAL;
+    g_dev.r4300.recomp.recomp_func = genbgezal;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZAL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbgezal_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZAL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbgezal_out;
+    }
 }
 
 static void RBLTZALL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZALL;
-   g_dev.r4300.recomp.recomp_func = genbltzall;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZALL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbltzall_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZALL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbltzall_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZALL;
+    g_dev.r4300.recomp.recomp_func = genbltzall;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZALL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbltzall_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLTZALL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbltzall_out;
+    }
 }
 
 static void RBGEZALL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZALL;
-   g_dev.r4300.recomp.recomp_func = genbgezall;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZALL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbgezall_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZALL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbgezall_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZALL;
+    g_dev.r4300.recomp.recomp_func = genbgezall;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZALL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbgezall_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGEZALL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbgezall_out;
+    }
 }
 
 static void (*const recomp_regimm[32])(void) =
 {
-   RBLTZ  , RBGEZ  , RBLTZL  , RBGEZL  , RSV  , RSV, RSV  , RSV,
-   RTGEI  , RTGEIU , RTLTI   , RTLTIU  , RTEQI, RSV, RTNEI, RSV,
-   RBLTZAL, RBGEZAL, RBLTZALL, RBGEZALL, RSV  , RSV, RSV  , RSV,
-   RSV    , RSV    , RSV     , RSV     , RSV  , RSV, RSV  , RSV
+    RBLTZ  , RBGEZ  , RBLTZL  , RBGEZL  , RSV  , RSV, RSV  , RSV,
+    RTGEI  , RTGEIU , RTLTI   , RTLTIU  , RTEQI, RSV, RTNEI, RSV,
+    RBLTZAL, RBGEZAL, RBLTZALL, RBGEZALL, RSV  , RSV, RSV  , RSV,
+    RSV    , RSV    , RSV     , RSV     , RSV  , RSV, RSV  , RSV
 };
 
 //-------------------------------------------------------------------------
@@ -738,44 +738,44 @@ static void (*const recomp_regimm[32])(void) =
 
 static void RTLBR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TLBR;
-   g_dev.r4300.recomp.recomp_func = gentlbr;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TLBR;
+    g_dev.r4300.recomp.recomp_func = gentlbr;
 }
 
 static void RTLBWI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TLBWI;
-   g_dev.r4300.recomp.recomp_func = gentlbwi;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TLBWI;
+    g_dev.r4300.recomp.recomp_func = gentlbwi;
 }
 
 static void RTLBWR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TLBWR;
-   g_dev.r4300.recomp.recomp_func = gentlbwr;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TLBWR;
+    g_dev.r4300.recomp.recomp_func = gentlbwr;
 }
 
 static void RTLBP(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TLBP;
-   g_dev.r4300.recomp.recomp_func = gentlbp;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TLBP;
+    g_dev.r4300.recomp.recomp_func = gentlbp;
 }
 
 static void RERET(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ERET;
-   g_dev.r4300.recomp.recomp_func = generet;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ERET;
+    g_dev.r4300.recomp.recomp_func = generet;
 }
 
 static void (*const recomp_tlb[64])(void) =
 {
-   RSV  , RTLBR, RTLBWI, RSV, RSV, RSV, RTLBWR, RSV, 
-   RTLBP, RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
-   RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
-   RERET, RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
-   RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
-   RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
-   RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
-   RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV
+    RSV  , RTLBR, RTLBWI, RSV, RSV, RSV, RTLBWR, RSV, 
+    RTLBP, RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
+    RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
+    RERET, RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
+    RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
+    RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
+    RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV, 
+    RSV  , RSV  , RSV   , RSV, RSV, RSV, RSV   , RSV
 };
 
 //-------------------------------------------------------------------------
@@ -784,33 +784,33 @@ static void (*const recomp_tlb[64])(void) =
 
 static void RMFC0(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MFC0;
-   g_dev.r4300.recomp.recomp_func = genmfc0;
-   recompile_standard_r_type();
-   g_dev.r4300.recomp.dst->f.r.rd = (int64_t*) (r4300_cp0_regs() + ((g_dev.r4300.recomp.src >> 11) & 0x1F));
-   g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
-   if (g_dev.r4300.recomp.dst->f.r.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MFC0;
+    g_dev.r4300.recomp.recomp_func = genmfc0;
+    recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->f.r.rd = (int64_t*) (r4300_cp0_regs() + ((g_dev.r4300.recomp.src >> 11) & 0x1F));
+    g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    if (g_dev.r4300.recomp.dst->f.r.rt == r4300_regs()) RNOP();
 }
 
 static void RMTC0(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MTC0;
-   g_dev.r4300.recomp.recomp_func = genmtc0;
-   recompile_standard_r_type();
-   g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MTC0;
+    g_dev.r4300.recomp.recomp_func = genmtc0;
+    recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
 }
 
 static void RTLB(void)
 {
-   recomp_tlb[(g_dev.r4300.recomp.src & 0x3F)]();
+    recomp_tlb[(g_dev.r4300.recomp.src & 0x3F)]();
 }
 
 static void (*const recomp_cop0[32])(void) =
 {
-   RMFC0, RSV, RSV, RSV, RMTC0, RSV, RSV, RSV,
-   RSV  , RSV, RSV, RSV, RSV  , RSV, RSV, RSV,
-   RTLB , RSV, RSV, RSV, RSV  , RSV, RSV, RSV,
-   RSV  , RSV, RSV, RSV, RSV  , RSV, RSV, RSV
+    RMFC0, RSV, RSV, RSV, RMTC0, RSV, RSV, RSV,
+    RSV  , RSV, RSV, RSV, RSV  , RSV, RSV, RSV,
+    RTLB , RSV, RSV, RSV, RSV  , RSV, RSV, RSV,
+    RSV  , RSV, RSV, RSV, RSV  , RSV, RSV, RSV
 };
 
 //-------------------------------------------------------------------------
@@ -819,96 +819,96 @@ static void (*const recomp_cop0[32])(void) =
 
 static void RBC1F(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1F;
-   g_dev.r4300.recomp.recomp_func = genbc1f;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1F_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbc1f_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1F_OUT;
-      g_dev.r4300.recomp.recomp_func = genbc1f_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1F;
+    g_dev.r4300.recomp.recomp_func = genbc1f;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1F_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbc1f_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1F_OUT;
+        g_dev.r4300.recomp.recomp_func = genbc1f_out;
+    }
 }
 
 static void RBC1T(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1T;
-   g_dev.r4300.recomp.recomp_func = genbc1t;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1T_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbc1t_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1T_OUT;
-      g_dev.r4300.recomp.recomp_func = genbc1t_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1T;
+    g_dev.r4300.recomp.recomp_func = genbc1t;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1T_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbc1t_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1T_OUT;
+        g_dev.r4300.recomp.recomp_func = genbc1t_out;
+    }
 }
 
 static void RBC1FL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1FL;
-   g_dev.r4300.recomp.recomp_func = genbc1fl;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1FL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbc1fl_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1FL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbc1fl_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1FL;
+    g_dev.r4300.recomp.recomp_func = genbc1fl;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1FL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbc1fl_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1FL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbc1fl_out;
+    }
 }
 
 static void RBC1TL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1TL;
-   g_dev.r4300.recomp.recomp_func = genbc1tl;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1TL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbc1tl_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1TL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbc1tl_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1TL;
+    g_dev.r4300.recomp.recomp_func = genbc1tl;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1TL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbc1tl_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BC1TL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbc1tl_out;
+    }
 }
 
 static void (*const recomp_bc[4])(void) =
 {
-   RBC1F , RBC1T ,
-   RBC1FL, RBC1TL
+    RBC1F , RBC1T ,
+    RBC1FL, RBC1TL
 };
 
 //-------------------------------------------------------------------------
@@ -917,259 +917,259 @@ static void (*const recomp_bc[4])(void) =
 
 static void RADD_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADD_S;
-   g_dev.r4300.recomp.recomp_func = genadd_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADD_S;
+    g_dev.r4300.recomp.recomp_func = genadd_s;
+    recompile_standard_cf_type();
 }
 
 static void RSUB_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SUB_S;
-   g_dev.r4300.recomp.recomp_func = gensub_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SUB_S;
+    g_dev.r4300.recomp.recomp_func = gensub_s;
+    recompile_standard_cf_type();
 }
 
 static void RMUL_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MUL_S;
-   g_dev.r4300.recomp.recomp_func = genmul_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MUL_S;
+    g_dev.r4300.recomp.recomp_func = genmul_s;
+    recompile_standard_cf_type();
 }
 
 static void RDIV_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DIV_S;
-   g_dev.r4300.recomp.recomp_func = gendiv_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DIV_S;
+    g_dev.r4300.recomp.recomp_func = gendiv_s;
+    recompile_standard_cf_type();
 }
 
 static void RSQRT_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SQRT_S;
-   g_dev.r4300.recomp.recomp_func = gensqrt_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SQRT_S;
+    g_dev.r4300.recomp.recomp_func = gensqrt_s;
+    recompile_standard_cf_type();
 }
 
 static void RABS_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ABS_S;
-   g_dev.r4300.recomp.recomp_func = genabs_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ABS_S;
+    g_dev.r4300.recomp.recomp_func = genabs_s;
+    recompile_standard_cf_type();
 }
 
 static void RMOV_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MOV_S;
-   g_dev.r4300.recomp.recomp_func = genmov_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MOV_S;
+    g_dev.r4300.recomp.recomp_func = genmov_s;
+    recompile_standard_cf_type();
 }
 
 static void RNEG_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NEG_S;
-   g_dev.r4300.recomp.recomp_func = genneg_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NEG_S;
+    g_dev.r4300.recomp.recomp_func = genneg_s;
+    recompile_standard_cf_type();
 }
 
 static void RROUND_L_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ROUND_L_S;
-   g_dev.r4300.recomp.recomp_func = genround_l_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ROUND_L_S;
+    g_dev.r4300.recomp.recomp_func = genround_l_s;
+    recompile_standard_cf_type();
 }
 
 static void RTRUNC_L_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TRUNC_L_S;
-   g_dev.r4300.recomp.recomp_func = gentrunc_l_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TRUNC_L_S;
+    g_dev.r4300.recomp.recomp_func = gentrunc_l_s;
+    recompile_standard_cf_type();
 }
 
 static void RCEIL_L_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CEIL_L_S;
-   g_dev.r4300.recomp.recomp_func = genceil_l_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CEIL_L_S;
+    g_dev.r4300.recomp.recomp_func = genceil_l_s;
+    recompile_standard_cf_type();
 }
 
 static void RFLOOR_L_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FLOOR_L_S;
-   g_dev.r4300.recomp.recomp_func = genfloor_l_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FLOOR_L_S;
+    g_dev.r4300.recomp.recomp_func = genfloor_l_s;
+    recompile_standard_cf_type();
 }
 
 static void RROUND_W_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ROUND_W_S;
-   g_dev.r4300.recomp.recomp_func = genround_w_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ROUND_W_S;
+    g_dev.r4300.recomp.recomp_func = genround_w_s;
+    recompile_standard_cf_type();
 }
 
 static void RTRUNC_W_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TRUNC_W_S;
-   g_dev.r4300.recomp.recomp_func = gentrunc_w_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TRUNC_W_S;
+    g_dev.r4300.recomp.recomp_func = gentrunc_w_s;
+    recompile_standard_cf_type();
 }
 
 static void RCEIL_W_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CEIL_W_S;
-   g_dev.r4300.recomp.recomp_func = genceil_w_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CEIL_W_S;
+    g_dev.r4300.recomp.recomp_func = genceil_w_s;
+    recompile_standard_cf_type();
 }
 
 static void RFLOOR_W_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FLOOR_W_S;
-   g_dev.r4300.recomp.recomp_func = genfloor_w_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FLOOR_W_S;
+    g_dev.r4300.recomp.recomp_func = genfloor_w_s;
+    recompile_standard_cf_type();
 }
 
 static void RCVT_D_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_D_S;
-   g_dev.r4300.recomp.recomp_func = gencvt_d_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_D_S;
+    g_dev.r4300.recomp.recomp_func = gencvt_d_s;
+    recompile_standard_cf_type();
 }
 
 static void RCVT_W_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_W_S;
-   g_dev.r4300.recomp.recomp_func = gencvt_w_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_W_S;
+    g_dev.r4300.recomp.recomp_func = gencvt_w_s;
+    recompile_standard_cf_type();
 }
 
 static void RCVT_L_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_L_S;
-   g_dev.r4300.recomp.recomp_func = gencvt_l_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_L_S;
+    g_dev.r4300.recomp.recomp_func = gencvt_l_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_F_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_F_S;
-   g_dev.r4300.recomp.recomp_func = genc_f_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_F_S;
+    g_dev.r4300.recomp.recomp_func = genc_f_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_UN_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_UN_S;
-   g_dev.r4300.recomp.recomp_func = genc_un_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_UN_S;
+    g_dev.r4300.recomp.recomp_func = genc_un_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_EQ_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_EQ_S;
-   g_dev.r4300.recomp.recomp_func = genc_eq_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_EQ_S;
+    g_dev.r4300.recomp.recomp_func = genc_eq_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_UEQ_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_UEQ_S;
-   g_dev.r4300.recomp.recomp_func = genc_ueq_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_UEQ_S;
+    g_dev.r4300.recomp.recomp_func = genc_ueq_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_OLT_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_OLT_S;
-   g_dev.r4300.recomp.recomp_func = genc_olt_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_OLT_S;
+    g_dev.r4300.recomp.recomp_func = genc_olt_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_ULT_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_ULT_S;
-   g_dev.r4300.recomp.recomp_func = genc_ult_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_ULT_S;
+    g_dev.r4300.recomp.recomp_func = genc_ult_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_OLE_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_OLE_S;
-   g_dev.r4300.recomp.recomp_func = genc_ole_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_OLE_S;
+    g_dev.r4300.recomp.recomp_func = genc_ole_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_ULE_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_ULE_S;
-   g_dev.r4300.recomp.recomp_func = genc_ule_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_ULE_S;
+    g_dev.r4300.recomp.recomp_func = genc_ule_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_SF_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_SF_S;
-   g_dev.r4300.recomp.recomp_func = genc_sf_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_SF_S;
+    g_dev.r4300.recomp.recomp_func = genc_sf_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_NGLE_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGLE_S;
-   g_dev.r4300.recomp.recomp_func = genc_ngle_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGLE_S;
+    g_dev.r4300.recomp.recomp_func = genc_ngle_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_SEQ_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_SEQ_S;
-   g_dev.r4300.recomp.recomp_func = genc_seq_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_SEQ_S;
+    g_dev.r4300.recomp.recomp_func = genc_seq_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_NGL_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGL_S;
-   g_dev.r4300.recomp.recomp_func = genc_ngl_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGL_S;
+    g_dev.r4300.recomp.recomp_func = genc_ngl_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_LT_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_LT_S;
-   g_dev.r4300.recomp.recomp_func = genc_lt_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_LT_S;
+    g_dev.r4300.recomp.recomp_func = genc_lt_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_NGE_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGE_S;
-   g_dev.r4300.recomp.recomp_func = genc_nge_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGE_S;
+    g_dev.r4300.recomp.recomp_func = genc_nge_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_LE_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_LE_S;
-   g_dev.r4300.recomp.recomp_func = genc_le_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_LE_S;
+    g_dev.r4300.recomp.recomp_func = genc_le_s;
+    recompile_standard_cf_type();
 }
 
 static void RC_NGT_S(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGT_S;
-   g_dev.r4300.recomp.recomp_func = genc_ngt_s;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGT_S;
+    g_dev.r4300.recomp.recomp_func = genc_ngt_s;
+    recompile_standard_cf_type();
 }
 
 static void (*const recomp_s[64])(void) =
 {
-   RADD_S    , RSUB_S    , RMUL_S   , RDIV_S    , RSQRT_S   , RABS_S    , RMOV_S   , RNEG_S    , 
-   RROUND_L_S, RTRUNC_L_S, RCEIL_L_S, RFLOOR_L_S, RROUND_W_S, RTRUNC_W_S, RCEIL_W_S, RFLOOR_W_S, 
-   RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       , 
-   RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       , 
-   RSV       , RCVT_D_S  , RSV      , RSV       , RCVT_W_S  , RCVT_L_S  , RSV      , RSV       , 
-   RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       , 
-   RC_F_S    , RC_UN_S   , RC_EQ_S  , RC_UEQ_S  , RC_OLT_S  , RC_ULT_S  , RC_OLE_S , RC_ULE_S  , 
-   RC_SF_S   , RC_NGLE_S , RC_SEQ_S , RC_NGL_S  , RC_LT_S   , RC_NGE_S  , RC_LE_S  , RC_NGT_S
+    RADD_S    , RSUB_S    , RMUL_S   , RDIV_S    , RSQRT_S   , RABS_S    , RMOV_S   , RNEG_S    , 
+    RROUND_L_S, RTRUNC_L_S, RCEIL_L_S, RFLOOR_L_S, RROUND_W_S, RTRUNC_W_S, RCEIL_W_S, RFLOOR_W_S, 
+    RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       , 
+    RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       , 
+    RSV       , RCVT_D_S  , RSV      , RSV       , RCVT_W_S  , RCVT_L_S  , RSV      , RSV       , 
+    RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       , 
+    RC_F_S    , RC_UN_S   , RC_EQ_S  , RC_UEQ_S  , RC_OLT_S  , RC_ULT_S  , RC_OLE_S , RC_ULE_S  , 
+    RC_SF_S   , RC_NGLE_S , RC_SEQ_S , RC_NGL_S  , RC_LT_S   , RC_NGE_S  , RC_LE_S  , RC_NGT_S
 };
 
 //-------------------------------------------------------------------------
@@ -1178,259 +1178,259 @@ static void (*const recomp_s[64])(void) =
 
 static void RADD_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADD_D;
-   g_dev.r4300.recomp.recomp_func = genadd_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADD_D;
+    g_dev.r4300.recomp.recomp_func = genadd_d;
+    recompile_standard_cf_type();
 }
 
 static void RSUB_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SUB_D;
-   g_dev.r4300.recomp.recomp_func = gensub_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SUB_D;
+    g_dev.r4300.recomp.recomp_func = gensub_d;
+    recompile_standard_cf_type();
 }
 
 static void RMUL_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MUL_D;
-   g_dev.r4300.recomp.recomp_func = genmul_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MUL_D;
+    g_dev.r4300.recomp.recomp_func = genmul_d;
+    recompile_standard_cf_type();
 }
 
 static void RDIV_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DIV_D;
-   g_dev.r4300.recomp.recomp_func = gendiv_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DIV_D;
+    g_dev.r4300.recomp.recomp_func = gendiv_d;
+    recompile_standard_cf_type();
 }
 
 static void RSQRT_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SQRT_D;
-   g_dev.r4300.recomp.recomp_func = gensqrt_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SQRT_D;
+    g_dev.r4300.recomp.recomp_func = gensqrt_d;
+    recompile_standard_cf_type();
 }
 
 static void RABS_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ABS_D;
-   g_dev.r4300.recomp.recomp_func = genabs_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ABS_D;
+    g_dev.r4300.recomp.recomp_func = genabs_d;
+    recompile_standard_cf_type();
 }
 
 static void RMOV_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MOV_D;
-   g_dev.r4300.recomp.recomp_func = genmov_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MOV_D;
+    g_dev.r4300.recomp.recomp_func = genmov_d;
+    recompile_standard_cf_type();
 }
 
 static void RNEG_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NEG_D;
-   g_dev.r4300.recomp.recomp_func = genneg_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NEG_D;
+    g_dev.r4300.recomp.recomp_func = genneg_d;
+    recompile_standard_cf_type();
 }
 
 static void RROUND_L_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ROUND_L_D;
-   g_dev.r4300.recomp.recomp_func = genround_l_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ROUND_L_D;
+    g_dev.r4300.recomp.recomp_func = genround_l_d;
+    recompile_standard_cf_type();
 }
 
 static void RTRUNC_L_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TRUNC_L_D;
-   g_dev.r4300.recomp.recomp_func = gentrunc_l_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TRUNC_L_D;
+    g_dev.r4300.recomp.recomp_func = gentrunc_l_d;
+    recompile_standard_cf_type();
 }
 
 static void RCEIL_L_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CEIL_L_D;
-   g_dev.r4300.recomp.recomp_func = genceil_l_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CEIL_L_D;
+    g_dev.r4300.recomp.recomp_func = genceil_l_d;
+    recompile_standard_cf_type();
 }
 
 static void RFLOOR_L_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FLOOR_L_D;
-   g_dev.r4300.recomp.recomp_func = genfloor_l_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FLOOR_L_D;
+    g_dev.r4300.recomp.recomp_func = genfloor_l_d;
+    recompile_standard_cf_type();
 }
 
 static void RROUND_W_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ROUND_W_D;
-   g_dev.r4300.recomp.recomp_func = genround_w_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ROUND_W_D;
+    g_dev.r4300.recomp.recomp_func = genround_w_d;
+    recompile_standard_cf_type();
 }
 
 static void RTRUNC_W_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TRUNC_W_D;
-   g_dev.r4300.recomp.recomp_func = gentrunc_w_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.TRUNC_W_D;
+    g_dev.r4300.recomp.recomp_func = gentrunc_w_d;
+    recompile_standard_cf_type();
 }
 
 static void RCEIL_W_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CEIL_W_D;
-   g_dev.r4300.recomp.recomp_func = genceil_w_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CEIL_W_D;
+    g_dev.r4300.recomp.recomp_func = genceil_w_d;
+    recompile_standard_cf_type();
 }
 
 static void RFLOOR_W_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FLOOR_W_D;
-   g_dev.r4300.recomp.recomp_func = genfloor_w_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.FLOOR_W_D;
+    g_dev.r4300.recomp.recomp_func = genfloor_w_d;
+    recompile_standard_cf_type();
 }
 
 static void RCVT_S_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_S_D;
-   g_dev.r4300.recomp.recomp_func = gencvt_s_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_S_D;
+    g_dev.r4300.recomp.recomp_func = gencvt_s_d;
+    recompile_standard_cf_type();
 }
 
 static void RCVT_W_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_W_D;
-   g_dev.r4300.recomp.recomp_func = gencvt_w_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_W_D;
+    g_dev.r4300.recomp.recomp_func = gencvt_w_d;
+    recompile_standard_cf_type();
 }
 
 static void RCVT_L_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_L_D;
-   g_dev.r4300.recomp.recomp_func = gencvt_l_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_L_D;
+    g_dev.r4300.recomp.recomp_func = gencvt_l_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_F_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_F_D;
-   g_dev.r4300.recomp.recomp_func = genc_f_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_F_D;
+    g_dev.r4300.recomp.recomp_func = genc_f_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_UN_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_UN_D;
-   g_dev.r4300.recomp.recomp_func = genc_un_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_UN_D;
+    g_dev.r4300.recomp.recomp_func = genc_un_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_EQ_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_EQ_D;
-   g_dev.r4300.recomp.recomp_func = genc_eq_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_EQ_D;
+    g_dev.r4300.recomp.recomp_func = genc_eq_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_UEQ_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_UEQ_D;
-   g_dev.r4300.recomp.recomp_func = genc_ueq_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_UEQ_D;
+    g_dev.r4300.recomp.recomp_func = genc_ueq_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_OLT_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_OLT_D;
-   g_dev.r4300.recomp.recomp_func = genc_olt_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_OLT_D;
+    g_dev.r4300.recomp.recomp_func = genc_olt_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_ULT_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_ULT_D;
-   g_dev.r4300.recomp.recomp_func = genc_ult_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_ULT_D;
+    g_dev.r4300.recomp.recomp_func = genc_ult_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_OLE_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_OLE_D;
-   g_dev.r4300.recomp.recomp_func = genc_ole_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_OLE_D;
+    g_dev.r4300.recomp.recomp_func = genc_ole_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_ULE_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_ULE_D;
-   g_dev.r4300.recomp.recomp_func = genc_ule_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_ULE_D;
+    g_dev.r4300.recomp.recomp_func = genc_ule_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_SF_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_SF_D;
-   g_dev.r4300.recomp.recomp_func = genc_sf_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_SF_D;
+    g_dev.r4300.recomp.recomp_func = genc_sf_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_NGLE_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGLE_D;
-   g_dev.r4300.recomp.recomp_func = genc_ngle_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGLE_D;
+    g_dev.r4300.recomp.recomp_func = genc_ngle_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_SEQ_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_SEQ_D;
-   g_dev.r4300.recomp.recomp_func = genc_seq_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_SEQ_D;
+    g_dev.r4300.recomp.recomp_func = genc_seq_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_NGL_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGL_D;
-   g_dev.r4300.recomp.recomp_func = genc_ngl_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGL_D;
+    g_dev.r4300.recomp.recomp_func = genc_ngl_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_LT_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_LT_D;
-   g_dev.r4300.recomp.recomp_func = genc_lt_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_LT_D;
+    g_dev.r4300.recomp.recomp_func = genc_lt_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_NGE_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGE_D;
-   g_dev.r4300.recomp.recomp_func = genc_nge_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGE_D;
+    g_dev.r4300.recomp.recomp_func = genc_nge_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_LE_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_LE_D;
-   g_dev.r4300.recomp.recomp_func = genc_le_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_LE_D;
+    g_dev.r4300.recomp.recomp_func = genc_le_d;
+    recompile_standard_cf_type();
 }
 
 static void RC_NGT_D(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGT_D;
-   g_dev.r4300.recomp.recomp_func = genc_ngt_d;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.C_NGT_D;
+    g_dev.r4300.recomp.recomp_func = genc_ngt_d;
+    recompile_standard_cf_type();
 }
 
 static void (*const recomp_d[64])(void) =
 {
-   RADD_D    , RSUB_D    , RMUL_D   , RDIV_D    , RSQRT_D   , RABS_D    , RMOV_D   , RNEG_D    ,
-   RROUND_L_D, RTRUNC_L_D, RCEIL_L_D, RFLOOR_L_D, RROUND_W_D, RTRUNC_W_D, RCEIL_W_D, RFLOOR_W_D,
-   RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       ,
-   RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       ,
-   RCVT_S_D  , RSV       , RSV      , RSV       , RCVT_W_D  , RCVT_L_D  , RSV      , RSV       ,
-   RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       ,
-   RC_F_D    , RC_UN_D   , RC_EQ_D  , RC_UEQ_D  , RC_OLT_D  , RC_ULT_D  , RC_OLE_D , RC_ULE_D  ,
-   RC_SF_D   , RC_NGLE_D , RC_SEQ_D , RC_NGL_D  , RC_LT_D   , RC_NGE_D  , RC_LE_D  , RC_NGT_D
+    RADD_D    , RSUB_D    , RMUL_D   , RDIV_D    , RSQRT_D   , RABS_D    , RMOV_D   , RNEG_D    ,
+    RROUND_L_D, RTRUNC_L_D, RCEIL_L_D, RFLOOR_L_D, RROUND_W_D, RTRUNC_W_D, RCEIL_W_D, RFLOOR_W_D,
+    RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       ,
+    RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       ,
+    RCVT_S_D  , RSV       , RSV      , RSV       , RCVT_W_D  , RCVT_L_D  , RSV      , RSV       ,
+    RSV       , RSV       , RSV      , RSV       , RSV       , RSV       , RSV      , RSV       ,
+    RC_F_D    , RC_UN_D   , RC_EQ_D  , RC_UEQ_D  , RC_OLT_D  , RC_ULT_D  , RC_OLE_D , RC_ULE_D  ,
+    RC_SF_D   , RC_NGLE_D , RC_SEQ_D , RC_NGL_D  , RC_LT_D   , RC_NGE_D  , RC_LE_D  , RC_NGT_D
 };
 
 //-------------------------------------------------------------------------
@@ -1439,28 +1439,28 @@ static void (*const recomp_d[64])(void) =
 
 static void RCVT_S_W(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_S_W;
-   g_dev.r4300.recomp.recomp_func = gencvt_s_w;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_S_W;
+    g_dev.r4300.recomp.recomp_func = gencvt_s_w;
+    recompile_standard_cf_type();
 }
 
 static void RCVT_D_W(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_D_W;
-   g_dev.r4300.recomp.recomp_func = gencvt_d_w;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_D_W;
+    g_dev.r4300.recomp.recomp_func = gencvt_d_w;
+    recompile_standard_cf_type();
 }
 
 static void (*const recomp_w[64])(void) =
 {
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RCVT_S_W, RCVT_D_W, RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RCVT_S_W, RCVT_D_W, RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV
 };
 
 //-------------------------------------------------------------------------
@@ -1469,28 +1469,28 @@ static void (*const recomp_w[64])(void) =
 
 static void RCVT_S_L(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_S_L;
-   g_dev.r4300.recomp.recomp_func = gencvt_s_l;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_S_L;
+    g_dev.r4300.recomp.recomp_func = gencvt_s_l;
+    recompile_standard_cf_type();
 }
 
 static void RCVT_D_L(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_D_L;
-   g_dev.r4300.recomp.recomp_func = gencvt_d_l;
-   recompile_standard_cf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CVT_D_L;
+    g_dev.r4300.recomp.recomp_func = gencvt_d_l;
+    recompile_standard_cf_type();
 }
 
 static void (*const recomp_l[64])(void) =
 {
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV,
-   RCVT_S_L, RCVT_D_L, RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
-   RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV,
+    RCVT_S_L, RCVT_D_L, RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
+    RSV     , RSV     , RSV, RSV, RSV, RSV, RSV, RSV, 
 };
 
 //-------------------------------------------------------------------------
@@ -1499,86 +1499,86 @@ static void (*const recomp_l[64])(void) =
 
 static void RMFC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MFC1;
-   g_dev.r4300.recomp.recomp_func = genmfc1;
-   recompile_standard_r_type();
-   g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
-   if (g_dev.r4300.recomp.dst->f.r.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MFC1;
+    g_dev.r4300.recomp.recomp_func = genmfc1;
+    recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    if (g_dev.r4300.recomp.dst->f.r.rt == r4300_regs()) RNOP();
 }
 
 static void RDMFC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DMFC1;
-   g_dev.r4300.recomp.recomp_func = gendmfc1;
-   recompile_standard_r_type();
-   g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
-   if (g_dev.r4300.recomp.dst->f.r.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DMFC1;
+    g_dev.r4300.recomp.recomp_func = gendmfc1;
+    recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    if (g_dev.r4300.recomp.dst->f.r.rt == r4300_regs()) RNOP();
 }
 
 static void RCFC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CFC1;
-   g_dev.r4300.recomp.recomp_func = gencfc1;
-   recompile_standard_r_type();
-   g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
-   if (g_dev.r4300.recomp.dst->f.r.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CFC1;
+    g_dev.r4300.recomp.recomp_func = gencfc1;
+    recompile_standard_r_type();
+    g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    if (g_dev.r4300.recomp.dst->f.r.rt == r4300_regs()) RNOP();
 }
 
 static void RMTC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MTC1;
-   recompile_standard_r_type();
-   g_dev.r4300.recomp.recomp_func = genmtc1;
-   g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.MTC1;
+    recompile_standard_r_type();
+    g_dev.r4300.recomp.recomp_func = genmtc1;
+    g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
 }
 
 static void RDMTC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DMTC1;
-   recompile_standard_r_type();
-   g_dev.r4300.recomp.recomp_func = gendmtc1;
-   g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DMTC1;
+    recompile_standard_r_type();
+    g_dev.r4300.recomp.recomp_func = gendmtc1;
+    g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
 }
 
 static void RCTC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CTC1;
-   recompile_standard_r_type();
-   g_dev.r4300.recomp.recomp_func = genctc1;
-   g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CTC1;
+    recompile_standard_r_type();
+    g_dev.r4300.recomp.recomp_func = genctc1;
+    g_dev.r4300.recomp.dst->f.r.nrd = (g_dev.r4300.recomp.src >> 11) & 0x1F;
 }
 
 static void RBC(void)
 {
-   recomp_bc[((g_dev.r4300.recomp.src >> 16) & 3)]();
+    recomp_bc[((g_dev.r4300.recomp.src >> 16) & 3)]();
 }
 
 static void RS(void)
 {
-   recomp_s[(g_dev.r4300.recomp.src & 0x3F)]();
+    recomp_s[(g_dev.r4300.recomp.src & 0x3F)]();
 }
 
 static void RD(void)
 {
-   recomp_d[(g_dev.r4300.recomp.src & 0x3F)]();
+    recomp_d[(g_dev.r4300.recomp.src & 0x3F)]();
 }
 
 static void RW(void)
 {
-   recomp_w[(g_dev.r4300.recomp.src & 0x3F)]();
+    recomp_w[(g_dev.r4300.recomp.src & 0x3F)]();
 }
 
 static void RL(void)
 {
-   recomp_l[(g_dev.r4300.recomp.src & 0x3F)]();
+    recomp_l[(g_dev.r4300.recomp.src & 0x3F)]();
 }
 
 static void (*const recomp_cop1[32])(void) =
 {
-   RMFC1, RDMFC1, RCFC1, RSV, RMTC1, RDMTC1, RCTC1, RSV,
-   RBC  , RSV   , RSV  , RSV, RSV  , RSV   , RSV  , RSV,
-   RS   , RD    , RSV  , RSV, RW   , RL    , RSV  , RSV,
-   RSV  , RSV   , RSV  , RSV, RSV  , RSV   , RSV  , RSV
+    RMFC1, RDMFC1, RCFC1, RSV, RMTC1, RDMTC1, RCTC1, RSV,
+    RBC  , RSV   , RSV  , RSV, RSV  , RSV   , RSV  , RSV,
+    RS   , RD    , RSV  , RSV, RW   , RL    , RSV  , RSV,
+    RSV  , RSV   , RSV  , RSV, RSV  , RSV   , RSV  , RSV
 };
 
 //-------------------------------------------------------------------------
@@ -1587,553 +1587,553 @@ static void (*const recomp_cop1[32])(void) =
 
 static void RSPECIAL(void)
 {
-   recomp_special[(g_dev.r4300.recomp.src & 0x3F)]();
+    recomp_special[(g_dev.r4300.recomp.src & 0x3F)]();
 }
 
 static void RREGIMM(void)
 {
-   recomp_regimm[((g_dev.r4300.recomp.src >> 16) & 0x1F)]();
+    recomp_regimm[((g_dev.r4300.recomp.src >> 16) & 0x1F)]();
 }
 
 static void RJ(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.J;
-   g_dev.r4300.recomp.recomp_func = genj;
-   recompile_standard_j_type();
-   target = (g_dev.r4300.recomp.dst->f.j.inst_index<<2) | (g_dev.r4300.recomp.dst->addr & UINT32_C(0xF0000000));
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.J_IDLE;
-         g_dev.r4300.recomp.recomp_func = genj_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.J_OUT;
-      g_dev.r4300.recomp.recomp_func = genj_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.J;
+    g_dev.r4300.recomp.recomp_func = genj;
+    recompile_standard_j_type();
+    target = (g_dev.r4300.recomp.dst->f.j.inst_index<<2) | (g_dev.r4300.recomp.dst->addr & UINT32_C(0xF0000000));
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.J_IDLE;
+            g_dev.r4300.recomp.recomp_func = genj_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.J_OUT;
+        g_dev.r4300.recomp.recomp_func = genj_out;
+    }
 }
 
 static void RJAL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JAL;
-   g_dev.r4300.recomp.recomp_func = genjal;
-   recompile_standard_j_type();
-   target = (g_dev.r4300.recomp.dst->f.j.inst_index<<2) | (g_dev.r4300.recomp.dst->addr & UINT32_C(0xF0000000));
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JAL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genjal_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JAL_OUT;
-      g_dev.r4300.recomp.recomp_func = genjal_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JAL;
+    g_dev.r4300.recomp.recomp_func = genjal;
+    recompile_standard_j_type();
+    target = (g_dev.r4300.recomp.dst->f.j.inst_index<<2) | (g_dev.r4300.recomp.dst->addr & UINT32_C(0xF0000000));
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JAL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genjal_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.JAL_OUT;
+        g_dev.r4300.recomp.recomp_func = genjal_out;
+    }
 }
 
 static void RBEQ(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQ;
-   g_dev.r4300.recomp.recomp_func = genbeq;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQ_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbeq_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQ_OUT;
-      g_dev.r4300.recomp.recomp_func = genbeq_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQ;
+    g_dev.r4300.recomp.recomp_func = genbeq;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQ_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbeq_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQ_OUT;
+        g_dev.r4300.recomp.recomp_func = genbeq_out;
+    }
 }
 
 static void RBNE(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNE;
-   g_dev.r4300.recomp.recomp_func = genbne;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNE_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbne_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNE_OUT;
-      g_dev.r4300.recomp.recomp_func = genbne_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNE;
+    g_dev.r4300.recomp.recomp_func = genbne;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNE_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbne_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNE_OUT;
+        g_dev.r4300.recomp.recomp_func = genbne_out;
+    }
 }
 
 static void RBLEZ(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZ;
-   g_dev.r4300.recomp.recomp_func = genblez;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZ_IDLE;
-         g_dev.r4300.recomp.recomp_func = genblez_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZ_OUT;
-      g_dev.r4300.recomp.recomp_func = genblez_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZ;
+    g_dev.r4300.recomp.recomp_func = genblez;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZ_IDLE;
+            g_dev.r4300.recomp.recomp_func = genblez_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZ_OUT;
+        g_dev.r4300.recomp.recomp_func = genblez_out;
+    }
 }
 
 static void RBGTZ(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZ;
-   g_dev.r4300.recomp.recomp_func = genbgtz;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZ_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbgtz_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZ_OUT;
-      g_dev.r4300.recomp.recomp_func = genbgtz_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZ;
+    g_dev.r4300.recomp.recomp_func = genbgtz;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZ_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbgtz_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZ_OUT;
+        g_dev.r4300.recomp.recomp_func = genbgtz_out;
+    }
 }
 
 static void RADDI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADDI;
-   g_dev.r4300.recomp.recomp_func = genaddi;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADDI;
+    g_dev.r4300.recomp.recomp_func = genaddi;
+    recompile_standard_i_type();
+    if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RADDIU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADDIU;
-   g_dev.r4300.recomp.recomp_func = genaddiu;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ADDIU;
+    g_dev.r4300.recomp.recomp_func = genaddiu;
+    recompile_standard_i_type();
+    if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RSLTI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLTI;
-   g_dev.r4300.recomp.recomp_func = genslti;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLTI;
+    g_dev.r4300.recomp.recomp_func = genslti;
+    recompile_standard_i_type();
+    if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RSLTIU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLTIU;
-   g_dev.r4300.recomp.recomp_func = gensltiu;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SLTIU;
+    g_dev.r4300.recomp.recomp_func = gensltiu;
+    recompile_standard_i_type();
+    if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RANDI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ANDI;
-   g_dev.r4300.recomp.recomp_func = genandi;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ANDI;
+    g_dev.r4300.recomp.recomp_func = genandi;
+    recompile_standard_i_type();
+    if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RORI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ORI;
-   g_dev.r4300.recomp.recomp_func = genori;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.ORI;
+    g_dev.r4300.recomp.recomp_func = genori;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RXORI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.XORI;
-   g_dev.r4300.recomp.recomp_func = genxori;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.XORI;
+    g_dev.r4300.recomp.recomp_func = genxori;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLUI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LUI;
-   g_dev.r4300.recomp.recomp_func = genlui;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LUI;
+    g_dev.r4300.recomp.recomp_func = genlui;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RCOP0(void)
 {
-   recomp_cop0[((g_dev.r4300.recomp.src >> 21) & 0x1F)]();
+    recomp_cop0[((g_dev.r4300.recomp.src >> 21) & 0x1F)]();
 }
 
 static void RCOP1(void)
 {
-   recomp_cop1[((g_dev.r4300.recomp.src >> 21) & 0x1F)]();
+    recomp_cop1[((g_dev.r4300.recomp.src >> 21) & 0x1F)]();
 }
 
 static void RBEQL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQL;
-   g_dev.r4300.recomp.recomp_func = genbeql;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbeql_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbeql_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQL;
+    g_dev.r4300.recomp.recomp_func = genbeql;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbeql_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BEQL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbeql_out;
+    }
 }
 
 static void RBNEL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNEL;
-   g_dev.r4300.recomp.recomp_func = genbnel;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNEL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbnel_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNEL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbnel_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNEL;
+    g_dev.r4300.recomp.recomp_func = genbnel;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNEL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbnel_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BNEL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbnel_out;
+    }
 }
 
 static void RBLEZL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZL;
-   g_dev.r4300.recomp.recomp_func = genblezl;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genblezl_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZL_OUT;
-      g_dev.r4300.recomp.recomp_func = genblezl_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZL;
+    g_dev.r4300.recomp.recomp_func = genblezl;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genblezl_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BLEZL_OUT;
+        g_dev.r4300.recomp.recomp_func = genblezl_out;
+    }
 }
 
 static void RBGTZL(void)
 {
-   uint32_t target;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZL;
-   g_dev.r4300.recomp.recomp_func = genbgtzl;
-   recompile_standard_i_type();
-   target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
-   if (target == g_dev.r4300.recomp.dst->addr)
-   {
-      if (g_dev.r4300.recomp.check_nop)
-      {
-         g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZL_IDLE;
-         g_dev.r4300.recomp.recomp_func = genbgtzl_idle;
-      }
-   }
-   else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
-   {
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZL_OUT;
-      g_dev.r4300.recomp.recomp_func = genbgtzl_out;
-   }
+    uint32_t target;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZL;
+    g_dev.r4300.recomp.recomp_func = genbgtzl;
+    recompile_standard_i_type();
+    target = g_dev.r4300.recomp.dst->addr + g_dev.r4300.recomp.dst->f.i.immediate*4 + 4;
+    if (target == g_dev.r4300.recomp.dst->addr)
+    {
+        if (g_dev.r4300.recomp.check_nop)
+        {
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZL_IDLE;
+            g_dev.r4300.recomp.recomp_func = genbgtzl_idle;
+        }
+    }
+    else if (target < g_dev.r4300.recomp.dst_block->start || target >= g_dev.r4300.recomp.dst_block->end || g_dev.r4300.recomp.dst->addr == (g_dev.r4300.recomp.dst_block->end-4))
+    {
+        g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.BGTZL_OUT;
+        g_dev.r4300.recomp.recomp_func = genbgtzl_out;
+    }
 }
 
 static void RDADDI(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DADDI;
-   g_dev.r4300.recomp.recomp_func = gendaddi;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DADDI;
+    g_dev.r4300.recomp.recomp_func = gendaddi;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RDADDIU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DADDIU;
-   g_dev.r4300.recomp.recomp_func = gendaddiu;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.DADDIU;
+    g_dev.r4300.recomp.recomp_func = gendaddiu;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLDL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LDL;
-   g_dev.r4300.recomp.recomp_func = genldl;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LDL;
+    g_dev.r4300.recomp.recomp_func = genldl;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLDR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LDR;
-   g_dev.r4300.recomp.recomp_func = genldr;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LDR;
+    g_dev.r4300.recomp.recomp_func = genldr;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLB(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LB;
-   g_dev.r4300.recomp.recomp_func = genlb;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LB;
+    g_dev.r4300.recomp.recomp_func = genlb;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLH(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LH;
-   g_dev.r4300.recomp.recomp_func = genlh;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LH;
+    g_dev.r4300.recomp.recomp_func = genlh;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLWL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LWL;
-   g_dev.r4300.recomp.recomp_func = genlwl;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LWL;
+    g_dev.r4300.recomp.recomp_func = genlwl;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLW(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LW;
-   g_dev.r4300.recomp.recomp_func = genlw;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LW;
+    g_dev.r4300.recomp.recomp_func = genlw;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLBU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LBU;
-   g_dev.r4300.recomp.recomp_func = genlbu;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LBU;
+    g_dev.r4300.recomp.recomp_func = genlbu;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLHU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LHU;
-   g_dev.r4300.recomp.recomp_func = genlhu;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LHU;
+    g_dev.r4300.recomp.recomp_func = genlhu;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLWR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LWR;
-   g_dev.r4300.recomp.recomp_func = genlwr;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LWR;
+    g_dev.r4300.recomp.recomp_func = genlwr;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLWU(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LWU;
-   g_dev.r4300.recomp.recomp_func = genlwu;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LWU;
+    g_dev.r4300.recomp.recomp_func = genlwu;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RSB(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SB;
-   g_dev.r4300.recomp.recomp_func = gensb;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SB;
+    g_dev.r4300.recomp.recomp_func = gensb;
+    recompile_standard_i_type();
 }
 
 static void RSH(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SH;
-   g_dev.r4300.recomp.recomp_func = gensh;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SH;
+    g_dev.r4300.recomp.recomp_func = gensh;
+    recompile_standard_i_type();
 }
 
 static void RSWL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SWL;
-   g_dev.r4300.recomp.recomp_func = genswl;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SWL;
+    g_dev.r4300.recomp.recomp_func = genswl;
+    recompile_standard_i_type();
 }
 
 static void RSW(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SW;
-   g_dev.r4300.recomp.recomp_func = gensw;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SW;
+    g_dev.r4300.recomp.recomp_func = gensw;
+    recompile_standard_i_type();
 }
 
 static void RSDL(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SDL;
-   g_dev.r4300.recomp.recomp_func = gensdl;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SDL;
+    g_dev.r4300.recomp.recomp_func = gensdl;
+    recompile_standard_i_type();
 }
 
 static void RSDR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SDR;
-   g_dev.r4300.recomp.recomp_func = gensdr;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SDR;
+    g_dev.r4300.recomp.recomp_func = gensdr;
+    recompile_standard_i_type();
 }
 
 static void RSWR(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SWR;
-   g_dev.r4300.recomp.recomp_func = genswr;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SWR;
+    g_dev.r4300.recomp.recomp_func = genswr;
+    recompile_standard_i_type();
 }
 
 static void RCACHE(void)
 {
-   g_dev.r4300.recomp.recomp_func = gencache;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CACHE;
+    g_dev.r4300.recomp.recomp_func = gencache;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.CACHE;
 }
 
 static void RLL(void)
 {
-   g_dev.r4300.recomp.recomp_func = genll;
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LL;
-   recompile_standard_i_type();
-   if(g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.recomp_func = genll;
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LL;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RLWC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LWC1;
-   g_dev.r4300.recomp.recomp_func = genlwc1;
-   recompile_standard_lf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LWC1;
+    g_dev.r4300.recomp.recomp_func = genlwc1;
+    recompile_standard_lf_type();
 }
 
 static void RLLD(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
+    recompile_standard_i_type();
 }
 
 static void RLDC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LDC1;
-   g_dev.r4300.recomp.recomp_func = genldc1;
-   recompile_standard_lf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LDC1;
+    g_dev.r4300.recomp.recomp_func = genldc1;
+    recompile_standard_lf_type();
 }
 
 static void RLD(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LD;
-   g_dev.r4300.recomp.recomp_func = genld;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.LD;
+    g_dev.r4300.recomp.recomp_func = genld;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RSC(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SC;
-   g_dev.r4300.recomp.recomp_func = gensc;
-   recompile_standard_i_type();
-   if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SC;
+    g_dev.r4300.recomp.recomp_func = gensc;
+    recompile_standard_i_type();
+    if (g_dev.r4300.recomp.dst->f.i.rt == r4300_regs()) RNOP();
 }
 
 static void RSWC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SWC1;
-   g_dev.r4300.recomp.recomp_func = genswc1;
-   recompile_standard_lf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SWC1;
+    g_dev.r4300.recomp.recomp_func = genswc1;
+    recompile_standard_lf_type();
 }
 
 static void RSCD(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
-   g_dev.r4300.recomp.recomp_func = genni;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NI;
+    g_dev.r4300.recomp.recomp_func = genni;
+    recompile_standard_i_type();
 }
 
 static void RSDC1(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SDC1;
-   g_dev.r4300.recomp.recomp_func = gensdc1;
-   recompile_standard_lf_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SDC1;
+    g_dev.r4300.recomp.recomp_func = gensdc1;
+    recompile_standard_lf_type();
 }
 
 static void RSD(void)
 {
-   g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SD;
-   g_dev.r4300.recomp.recomp_func = gensd;
-   recompile_standard_i_type();
+    g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.SD;
+    g_dev.r4300.recomp.recomp_func = gensd;
+    recompile_standard_i_type();
 }
 
 static void (*const recomp_ops[64])(void) =
 {
-   RSPECIAL, RREGIMM, RJ   , RJAL  , RBEQ , RBNE , RBLEZ , RBGTZ ,
-   RADDI   , RADDIU , RSLTI, RSLTIU, RANDI, RORI , RXORI , RLUI  ,
-   RCOP0   , RCOP1  , RSV  , RSV   , RBEQL, RBNEL, RBLEZL, RBGTZL,
-   RDADDI  , RDADDIU, RLDL , RLDR  , RSV  , RSV  , RSV   , RSV   ,
-   RLB     , RLH    , RLWL , RLW   , RLBU , RLHU , RLWR  , RLWU  ,
-   RSB     , RSH    , RSWL , RSW   , RSDL , RSDR , RSWR  , RCACHE,
-   RLL     , RLWC1  , RSV  , RSV   , RLLD , RLDC1, RSV   , RLD   ,
-   RSC     , RSWC1  , RSV  , RSV   , RSCD , RSDC1, RSV   , RSD
+    RSPECIAL, RREGIMM, RJ   , RJAL  , RBEQ , RBNE , RBLEZ , RBGTZ ,
+    RADDI   , RADDIU , RSLTI, RSLTIU, RANDI, RORI , RXORI , RLUI  ,
+    RCOP0   , RCOP1  , RSV  , RSV   , RBEQL, RBNEL, RBLEZL, RBGTZL,
+    RDADDI  , RDADDIU, RLDL , RLDR  , RSV  , RSV  , RSV   , RSV   ,
+    RLB     , RLH    , RLWL , RLW   , RLBU , RLHU , RLWR  , RLWU  ,
+    RSB     , RSH    , RSWL , RSW   , RSDL , RSDR , RSWR  , RCACHE,
+    RLL     , RLWC1  , RSV  , RSV   , RLLD , RLDC1, RSV   , RLD   ,
+    RSC     , RSWC1  , RSV  , RSV   , RSCD , RSDC1, RSV   , RSD
 };
 
 static int get_block_length(const struct precomp_block *block)
 {
-  return (block->end-block->start)/4;
+    return (block->end-block->start)/4;
 }
 
 static size_t get_block_memsize(const struct precomp_block *block)
 {
-  int length = get_block_length(block);
-  return ((length+1)+(length>>2)) * sizeof(struct precomp_instr);
+    int length = get_block_length(block);
+    return ((length+1)+(length>>2)) * sizeof(struct precomp_instr);
 }
 
 /**********************************************************************
@@ -2141,178 +2141,178 @@ static size_t get_block_memsize(const struct precomp_block *block)
  **********************************************************************/
 void init_block(struct precomp_block *block)
 {
-  int i, length, already_exist = 1;
-  timed_section_start(TIMED_SECTION_COMPILER);
+    int i, length, already_exist = 1;
+    timed_section_start(TIMED_SECTION_COMPILER);
 #ifdef DBG
-  DebugMessage(M64MSG_INFO, "init block %" PRIX32 " - %" PRIX32, block->start, block->end);
+    DebugMessage(M64MSG_INFO, "init block %" PRIX32 " - %" PRIX32, block->start, block->end);
 #endif
 
-  length = get_block_length(block);
-   
-  if (!block->block)
-  {
-    size_t memsize = get_block_memsize(block);
-    if (g_dev.r4300.emumode == EMUMODE_DYNAREC) {
-        block->block = (struct precomp_instr *) malloc_exec(memsize);
-        if (!block->block) {
-            DebugMessage(M64MSG_ERROR, "Memory error: couldn't allocate executable memory for dynamic recompiler. Try to use an interpreter mode.");
-            return;
+    length = get_block_length(block);
+
+    if (!block->block)
+    {
+        size_t memsize = get_block_memsize(block);
+        if (g_dev.r4300.emumode == EMUMODE_DYNAREC) {
+            block->block = (struct precomp_instr *) malloc_exec(memsize);
+            if (!block->block) {
+                DebugMessage(M64MSG_ERROR, "Memory error: couldn't allocate executable memory for dynamic recompiler. Try to use an interpreter mode.");
+                return;
+            }
         }
-    }
-    else {
-        block->block = (struct precomp_instr *) malloc(memsize);
-        if (!block->block) {
-            DebugMessage(M64MSG_ERROR, "Memory error: couldn't allocate memory for cached interpreter.");
-            return;
+        else {
+            block->block = (struct precomp_instr *) malloc(memsize);
+            if (!block->block) {
+                DebugMessage(M64MSG_ERROR, "Memory error: couldn't allocate memory for cached interpreter.");
+                return;
+            }
         }
+
+        memset(block->block, 0, memsize);
+        already_exist = 0;
     }
 
-    memset(block->block, 0, memsize);
-    already_exist = 0;
-  }
+    if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
+    {
+        if (!block->code)
+        {
+#if defined(PROFILE_R4300)
+            g_dev.r4300.recomp.max_code_length = 524288; /* allocate so much code space that we'll never have to realloc(), because this may */
+            /* cause instruction locations to move, and break our profiling data                */
+#else
+            g_dev.r4300.recomp.max_code_length = 32768;
+#endif
+            block->code = (unsigned char *) malloc_exec(g_dev.r4300.recomp.max_code_length);
+        }
+        else
+        {
+            g_dev.r4300.recomp.max_code_length = block->max_code_length;
+        }
+        g_dev.r4300.recomp.code_length = 0;
+        g_dev.r4300.recomp.inst_pointer = &block->code;
 
-  if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
-  {
-    if (!block->code)
+        if (block->jumps_table)
+        {
+            free(block->jumps_table);
+            block->jumps_table = NULL;
+        }
+        if (block->riprel_table)
+        {
+            free(block->riprel_table);
+            block->riprel_table = NULL;
+        }
+        init_assembler(NULL, 0, NULL, 0);
+        init_cache(block->block);
+    }
+
+    if (!already_exist)
     {
 #if defined(PROFILE_R4300)
-      g_dev.r4300.recomp.max_code_length = 524288; /* allocate so much code space that we'll never have to realloc(), because this may */
-                                /* cause instruction locations to move, and break our profiling data                */
-#else
-      g_dev.r4300.recomp.max_code_length = 32768;
+        g_dev.r4300.recomp.pfProfile = fopen("instructionaddrs.dat", "ab");
+        long x86addr = (long) block->code;
+        int mipsop = -2; /* -2 == NOTCOMPILED block at beginning of x86 code */
+        if (fwrite(&mipsop, 1, 4, g_dev.r4300.recomp.pfProfile) != 4 || // write 4-byte MIPS opcode
+                fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *)) // write pointer to dynamically generated x86 code for this MIPS instruction
+            DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
 #endif
-      block->code = (unsigned char *) malloc_exec(g_dev.r4300.recomp.max_code_length);
+
+        for (i=0; i<length; i++)
+        {
+            g_dev.r4300.recomp.dst = block->block + i;
+            g_dev.r4300.recomp.dst->addr = block->start + i*4;
+            g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
+            g_dev.r4300.recomp.dst->local_addr = g_dev.r4300.recomp.code_length;
+#ifdef COMPARE_CORE
+            if (g_dev.r4300.emumode == EMUMODE_DYNAREC) gendebug();
+#endif
+            RNOTCOMPILED();
+            if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
+        }
+#if defined(PROFILE_R4300)
+        fclose(g_dev.r4300.recomp.pfProfile);
+        g_dev.r4300.recomp.pfProfile = NULL;
+#endif
+        g_dev.r4300.recomp.init_length = g_dev.r4300.recomp.code_length;
     }
     else
     {
-      g_dev.r4300.recomp.max_code_length = block->max_code_length;
-    }
-    g_dev.r4300.recomp.code_length = 0;
-    g_dev.r4300.recomp.inst_pointer = &block->code;
-    
-    if (block->jumps_table)
-    {
-      free(block->jumps_table);
-      block->jumps_table = NULL;
-    }
-    if (block->riprel_table)
-    {
-      free(block->riprel_table);
-      block->riprel_table = NULL;
-    }
-    init_assembler(NULL, 0, NULL, 0);
-    init_cache(block->block);
-  }
-   
-  if (!already_exist)
-  {
 #if defined(PROFILE_R4300)
-    g_dev.r4300.recomp.pfProfile = fopen("instructionaddrs.dat", "ab");
-    long x86addr = (long) block->code;
-    int mipsop = -2; /* -2 == NOTCOMPILED block at beginning of x86 code */
-    if (fwrite(&mipsop, 1, 4, g_dev.r4300.recomp.pfProfile) != 4 || // write 4-byte MIPS opcode
-        fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *)) // write pointer to dynamically generated x86 code for this MIPS instruction
-        DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
-#endif
-
-    for (i=0; i<length; i++)
-    {
-      g_dev.r4300.recomp.dst = block->block + i;
-      g_dev.r4300.recomp.dst->addr = block->start + i*4;
-      g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
-      g_dev.r4300.recomp.dst->local_addr = g_dev.r4300.recomp.code_length;
-#ifdef COMPARE_CORE
-      if (g_dev.r4300.emumode == EMUMODE_DYNAREC) gendebug();
-#endif
-      RNOTCOMPILED();
-      if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
-    }
-#if defined(PROFILE_R4300)
-  fclose(g_dev.r4300.recomp.pfProfile);
-  g_dev.r4300.recomp.pfProfile = NULL;
-#endif
-  g_dev.r4300.recomp.init_length = g_dev.r4300.recomp.code_length;
-  }
-  else
-  {
-#if defined(PROFILE_R4300)
-    g_dev.r4300.recomp.code_length = block->code_length; /* leave old instructions in their place */
+        g_dev.r4300.recomp.code_length = block->code_length; /* leave old instructions in their place */
 #else
-    g_dev.r4300.recomp.code_length = g_dev.r4300.recomp.init_length; /* recompile everything, overwrite old recompiled instructions */
+        g_dev.r4300.recomp.code_length = g_dev.r4300.recomp.init_length; /* recompile everything, overwrite old recompiled instructions */
 #endif
-    for (i=0; i<length; i++)
-    {
-      g_dev.r4300.recomp.dst = block->block + i;
-      g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
-      g_dev.r4300.recomp.dst->local_addr = i * (g_dev.r4300.recomp.init_length / length);
-      g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NOTCOMPILED;
+        for (i=0; i<length; i++)
+        {
+            g_dev.r4300.recomp.dst = block->block + i;
+            g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
+            g_dev.r4300.recomp.dst->local_addr = i * (g_dev.r4300.recomp.init_length / length);
+            g_dev.r4300.recomp.dst->ops = g_dev.r4300.current_instruction_table.NOTCOMPILED;
+        }
     }
-  }
-   
-  if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
-  {
-    free_all_registers();
-    /* calling pass2 of the assembler is not necessary here because all of the code emitted by
-       gennotcompiled() and gendebug() is position-independent and contains no jumps . */
-    block->code_length = g_dev.r4300.recomp.code_length;
-    block->max_code_length = g_dev.r4300.recomp.max_code_length;
-    free_assembler(&block->jumps_table, &block->jumps_number, &block->riprel_table, &block->riprel_number);
-  }
-   
-  /* here we're marking the block as a valid code even if it's not compiled
-   * yet as the game should have already set up the code correctly.
-   */
-  g_dev.r4300.cached_interp.invalid_code[block->start>>12] = 0;
-  if (block->end < UINT32_C(0x80000000) || block->start >= UINT32_C(0xc0000000))
-  { 
-    uint32_t paddr = virtual_to_physical_address(&g_dev.r4300, block->start, 2);
-    g_dev.r4300.cached_interp.invalid_code[paddr>>12] = 0;
-    if (!g_dev.r4300.cached_interp.blocks[paddr>>12])
-    {
-      g_dev.r4300.cached_interp.blocks[paddr>>12] = (struct precomp_block *) malloc(sizeof(struct precomp_block));
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->code = NULL;
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->block = NULL;
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->jumps_table = NULL;
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->riprel_table = NULL;
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->start = paddr & ~UINT32_C(0xFFF);
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->end = (paddr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
-    }
-    init_block(g_dev.r4300.cached_interp.blocks[paddr>>12]);
-    
-    paddr += block->end - block->start - 4;
-    g_dev.r4300.cached_interp.invalid_code[paddr>>12] = 0;
-    if (!g_dev.r4300.cached_interp.blocks[paddr>>12])
-    {
-      g_dev.r4300.cached_interp.blocks[paddr>>12] = (struct precomp_block *) malloc(sizeof(struct precomp_block));
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->code = NULL;
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->block = NULL;
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->jumps_table = NULL;
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->riprel_table = NULL;
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->start = paddr & ~UINT32_C(0xFFF);
-      g_dev.r4300.cached_interp.blocks[paddr>>12]->end = (paddr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
-    }
-    init_block(g_dev.r4300.cached_interp.blocks[paddr>>12]);
-  }
-  else
-  {
-    uint32_t alt_addr = block->start ^ UINT32_C(0x20000000);
 
-    if (g_dev.r4300.cached_interp.invalid_code[alt_addr>>12])
+    if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
     {
-      if (!g_dev.r4300.cached_interp.blocks[alt_addr>>12])
-      {
-        g_dev.r4300.cached_interp.blocks[alt_addr>>12] = (struct precomp_block *) malloc(sizeof(struct precomp_block));
-        g_dev.r4300.cached_interp.blocks[alt_addr>>12]->code = NULL;
-        g_dev.r4300.cached_interp.blocks[alt_addr>>12]->block = NULL;
-        g_dev.r4300.cached_interp.blocks[alt_addr>>12]->jumps_table = NULL;
-        g_dev.r4300.cached_interp.blocks[alt_addr>>12]->riprel_table = NULL;
-        g_dev.r4300.cached_interp.blocks[alt_addr>>12]->start = alt_addr & ~UINT32_C(0xFFF);
-        g_dev.r4300.cached_interp.blocks[alt_addr>>12]->end = (alt_addr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
-      }
-      init_block(g_dev.r4300.cached_interp.blocks[alt_addr>>12]);
+        free_all_registers();
+        /* calling pass2 of the assembler is not necessary here because all of the code emitted by
+           gennotcompiled() and gendebug() is position-independent and contains no jumps . */
+        block->code_length = g_dev.r4300.recomp.code_length;
+        block->max_code_length = g_dev.r4300.recomp.max_code_length;
+        free_assembler(&block->jumps_table, &block->jumps_number, &block->riprel_table, &block->riprel_number);
     }
-  }
-  timed_section_end(TIMED_SECTION_COMPILER);
+
+    /* here we're marking the block as a valid code even if it's not compiled
+     * yet as the game should have already set up the code correctly.
+     */
+    g_dev.r4300.cached_interp.invalid_code[block->start>>12] = 0;
+    if (block->end < UINT32_C(0x80000000) || block->start >= UINT32_C(0xc0000000))
+    {
+        uint32_t paddr = virtual_to_physical_address(&g_dev.r4300, block->start, 2);
+        g_dev.r4300.cached_interp.invalid_code[paddr>>12] = 0;
+        if (!g_dev.r4300.cached_interp.blocks[paddr>>12])
+        {
+            g_dev.r4300.cached_interp.blocks[paddr>>12] = (struct precomp_block *) malloc(sizeof(struct precomp_block));
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->code = NULL;
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->block = NULL;
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->jumps_table = NULL;
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->riprel_table = NULL;
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->start = paddr & ~UINT32_C(0xFFF);
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->end = (paddr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
+        }
+        init_block(g_dev.r4300.cached_interp.blocks[paddr>>12]);
+
+        paddr += block->end - block->start - 4;
+        g_dev.r4300.cached_interp.invalid_code[paddr>>12] = 0;
+        if (!g_dev.r4300.cached_interp.blocks[paddr>>12])
+        {
+            g_dev.r4300.cached_interp.blocks[paddr>>12] = (struct precomp_block *) malloc(sizeof(struct precomp_block));
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->code = NULL;
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->block = NULL;
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->jumps_table = NULL;
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->riprel_table = NULL;
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->start = paddr & ~UINT32_C(0xFFF);
+            g_dev.r4300.cached_interp.blocks[paddr>>12]->end = (paddr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
+        }
+        init_block(g_dev.r4300.cached_interp.blocks[paddr>>12]);
+    }
+    else
+    {
+        uint32_t alt_addr = block->start ^ UINT32_C(0x20000000);
+
+        if (g_dev.r4300.cached_interp.invalid_code[alt_addr>>12])
+        {
+            if (!g_dev.r4300.cached_interp.blocks[alt_addr>>12])
+            {
+                g_dev.r4300.cached_interp.blocks[alt_addr>>12] = (struct precomp_block *) malloc(sizeof(struct precomp_block));
+                g_dev.r4300.cached_interp.blocks[alt_addr>>12]->code = NULL;
+                g_dev.r4300.cached_interp.blocks[alt_addr>>12]->block = NULL;
+                g_dev.r4300.cached_interp.blocks[alt_addr>>12]->jumps_table = NULL;
+                g_dev.r4300.cached_interp.blocks[alt_addr>>12]->riprel_table = NULL;
+                g_dev.r4300.cached_interp.blocks[alt_addr>>12]->start = alt_addr & ~UINT32_C(0xFFF);
+                g_dev.r4300.cached_interp.blocks[alt_addr>>12]->end = (alt_addr & ~UINT32_C(0xFFF)) + UINT32_C(0x1000);
+            }
+            init_block(g_dev.r4300.cached_interp.blocks[alt_addr>>12]);
+        }
+    }
+    timed_section_end(TIMED_SECTION_COMPILER);
 }
 
 void free_block(struct precomp_block *block)
@@ -2336,211 +2336,211 @@ void free_block(struct precomp_block *block)
  **********************************************************************/
 void recompile_block(const uint32_t *source, struct precomp_block *block, uint32_t func)
 {
-   uint32_t i;
-   int length, finished=0;
-   timed_section_start(TIMED_SECTION_COMPILER);
-   length = (block->end-block->start)/4;
-   g_dev.r4300.recomp.dst_block = block;
-   
-   //for (i=0; i<16; i++) block->md5[i] = 0;
-   block->adler32 = 0;
-   
-   if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
-     {
-    g_dev.r4300.recomp.code_length = block->code_length;
-    g_dev.r4300.recomp.max_code_length = block->max_code_length;
-    g_dev.r4300.recomp.inst_pointer = &block->code;
-    init_assembler(block->jumps_table, block->jumps_number, block->riprel_table, block->riprel_number);
-    init_cache(block->block + (func & 0xFFF) / 4);
-     }
+    uint32_t i;
+    int length, finished=0;
+    timed_section_start(TIMED_SECTION_COMPILER);
+    length = (block->end-block->start)/4;
+    g_dev.r4300.recomp.dst_block = block;
+
+    //for (i=0; i<16; i++) block->md5[i] = 0;
+    block->adler32 = 0;
+
+    if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
+    {
+        g_dev.r4300.recomp.code_length = block->code_length;
+        g_dev.r4300.recomp.max_code_length = block->max_code_length;
+        g_dev.r4300.recomp.inst_pointer = &block->code;
+        init_assembler(block->jumps_table, block->jumps_number, block->riprel_table, block->riprel_number);
+        init_cache(block->block + (func & 0xFFF) / 4);
+    }
 
 #if defined(PROFILE_R4300)
-   g_dev.r4300.recomp.pfProfile = fopen("instructionaddrs.dat", "ab");
+    g_dev.r4300.recomp.pfProfile = fopen("instructionaddrs.dat", "ab");
 #endif
 
-   for (i = (func & 0xFFF) / 4; finished != 2; i++)
-     {
-    if(block->start < UINT32_C(0x80000000) || UINT32_C(block->start >= 0xc0000000))
-      {
-          uint32_t address2 =
-           virtual_to_physical_address(&g_dev.r4300, block->start + i*4, 0);
-         if(g_dev.r4300.cached_interp.blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops == g_dev.r4300.current_instruction_table.NOTCOMPILED)
-           g_dev.r4300.cached_interp.blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops = g_dev.r4300.current_instruction_table.NOTCOMPILED2;
-      }
-    
-    g_dev.r4300.recomp.SRC = source + i;
-    g_dev.r4300.recomp.src = source[i];
-    g_dev.r4300.recomp.check_nop = source[i+1] == 0;
-    g_dev.r4300.recomp.dst = block->block + i;
-    g_dev.r4300.recomp.dst->addr = block->start + i*4;
-    g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
-    g_dev.r4300.recomp.dst->local_addr = g_dev.r4300.recomp.code_length;
+    for (i = (func & 0xFFF) / 4; finished != 2; i++)
+    {
+        if(block->start < UINT32_C(0x80000000) || UINT32_C(block->start >= 0xc0000000))
+        {
+            uint32_t address2 =
+                virtual_to_physical_address(&g_dev.r4300, block->start + i*4, 0);
+            if(g_dev.r4300.cached_interp.blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops == g_dev.r4300.current_instruction_table.NOTCOMPILED)
+                g_dev.r4300.cached_interp.blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops = g_dev.r4300.current_instruction_table.NOTCOMPILED2;
+        }
+
+        g_dev.r4300.recomp.SRC = source + i;
+        g_dev.r4300.recomp.src = source[i];
+        g_dev.r4300.recomp.check_nop = source[i+1] == 0;
+        g_dev.r4300.recomp.dst = block->block + i;
+        g_dev.r4300.recomp.dst->addr = block->start + i*4;
+        g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
+        g_dev.r4300.recomp.dst->local_addr = g_dev.r4300.recomp.code_length;
 #ifdef COMPARE_CORE
-    if (g_dev.r4300.emumode == EMUMODE_DYNAREC) gendebug();
+        if (g_dev.r4300.emumode == EMUMODE_DYNAREC) gendebug();
 #endif
 #if defined(PROFILE_R4300)
-    long x86addr = (long) (block->code + block->block[i].local_addr);
-    if (fwrite(source + i, 1, 4, g_dev.r4300.recomp.pfProfile) != 4 || // write 4-byte MIPS opcode
-        fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *)) // write pointer to dynamically generated x86 code for this MIPS instruction
-        DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
+        long x86addr = (long) (block->code + block->block[i].local_addr);
+        if (fwrite(source + i, 1, 4, g_dev.r4300.recomp.pfProfile) != 4 || // write 4-byte MIPS opcode
+                fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *)) // write pointer to dynamically generated x86 code for this MIPS instruction
+            DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
 #endif
-    g_dev.r4300.recomp.recomp_func = NULL;
-    recomp_ops[((g_dev.r4300.recomp.src >> 26) & 0x3F)]();
-    if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
-    g_dev.r4300.recomp.dst = block->block + i;
+        g_dev.r4300.recomp.recomp_func = NULL;
+        recomp_ops[((g_dev.r4300.recomp.src >> 26) & 0x3F)]();
+        if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
+        g_dev.r4300.recomp.dst = block->block + i;
 
-    /*if ((g_dev.r4300.recomp.dst+1)->ops != NOTCOMPILED && !g_dev.r4300.recomp.delay_slot_compiled &&
-        i < length)
-      {
-         if (g_dev.r4300.emumode == EMUMODE_DYNAREC) genlink_subblock();
-         finished = 2;
-      }*/
-    if (g_dev.r4300.recomp.delay_slot_compiled) 
-      {
-         g_dev.r4300.recomp.delay_slot_compiled--;
-         free_all_registers();
-      }
-    
-    if (i >= length-2+(length>>2)) finished = 2;
-    if (i >= (length-1) && (block->start == UINT32_C(0xa4000000) ||
-                block->start >= UINT32_C(0xc0000000) ||
-                block->end   <  UINT32_C(0x80000000))) finished = 2;
-    if (g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.ERET || finished == 1) finished = 2;
-    if (/*i >= length &&*/ 
-        (g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JR) &&
-        !(i >= (length-1) && (block->start >= UINT32_C(0xc0000000) ||
-                  block->end   <  UINT32_C(0x80000000))))
-      finished = 1;
-     }
+        /*if ((g_dev.r4300.recomp.dst+1)->ops != NOTCOMPILED && !g_dev.r4300.recomp.delay_slot_compiled &&
+          i < length)
+          {
+          if (g_dev.r4300.emumode == EMUMODE_DYNAREC) genlink_subblock();
+          finished = 2;
+          }*/
+        if (g_dev.r4300.recomp.delay_slot_compiled) 
+        {
+            g_dev.r4300.recomp.delay_slot_compiled--;
+            free_all_registers();
+        }
+
+        if (i >= length-2+(length>>2)) finished = 2;
+        if (i >= (length-1) && (block->start == UINT32_C(0xa4000000) ||
+                    block->start >= UINT32_C(0xc0000000) ||
+                    block->end   <  UINT32_C(0x80000000))) finished = 2;
+        if (g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.ERET || finished == 1) finished = 2;
+        if (/*i >= length &&*/ 
+                (g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J ||
+                 g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J_OUT ||
+                 g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JR) &&
+                !(i >= (length-1) && (block->start >= UINT32_C(0xc0000000) ||
+                        block->end   <  UINT32_C(0x80000000))))
+            finished = 1;
+    }
 
 #if defined(PROFILE_R4300)
     long x86addr = (long) (block->code + g_dev.r4300.recomp.code_length);
     int mipsop = -3; /* -3 == block-postfix */
     if (fwrite(&mipsop, 1, 4, g_dev.r4300.recomp.pfProfile) != 4 || // write 4-byte MIPS opcode
-        fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *)) // write pointer to dynamically generated x86 code for this MIPS instruction
+            fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *)) // write pointer to dynamically generated x86 code for this MIPS instruction
         DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
 #endif
 
-   if (i >= length)
-     {
-    g_dev.r4300.recomp.dst = block->block + i;
-    g_dev.r4300.recomp.dst->addr = block->start + i*4;
-    g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
-    g_dev.r4300.recomp.dst->local_addr = g_dev.r4300.recomp.code_length;
+    if (i >= length)
+    {
+        g_dev.r4300.recomp.dst = block->block + i;
+        g_dev.r4300.recomp.dst->addr = block->start + i*4;
+        g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
+        g_dev.r4300.recomp.dst->local_addr = g_dev.r4300.recomp.code_length;
 #ifdef COMPARE_CORE
-    if (g_dev.r4300.emumode == EMUMODE_DYNAREC) gendebug();
+        if (g_dev.r4300.emumode == EMUMODE_DYNAREC) gendebug();
 #endif
-    RFIN_BLOCK();
-    if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
-    i++;
-    if (i < length-1+(length>>2)) // useful when last opcode is a jump
-      {
-         g_dev.r4300.recomp.dst = block->block + i;
-         g_dev.r4300.recomp.dst->addr = block->start + i*4;
-         g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
-         g_dev.r4300.recomp.dst->local_addr = g_dev.r4300.recomp.code_length;
+        RFIN_BLOCK();
+        if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
+        i++;
+        if (i < length-1+(length>>2)) // useful when last opcode is a jump
+        {
+            g_dev.r4300.recomp.dst = block->block + i;
+            g_dev.r4300.recomp.dst->addr = block->start + i*4;
+            g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
+            g_dev.r4300.recomp.dst->local_addr = g_dev.r4300.recomp.code_length;
 #ifdef COMPARE_CORE
-         if (g_dev.r4300.emumode == EMUMODE_DYNAREC) gendebug();
+            if (g_dev.r4300.emumode == EMUMODE_DYNAREC) gendebug();
 #endif
-         RFIN_BLOCK();
-         if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
-         i++;
-      }
-     }
-   else if (g_dev.r4300.emumode == EMUMODE_DYNAREC) genlink_subblock();
+            RFIN_BLOCK();
+            if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
+            i++;
+        }
+    }
+    else if (g_dev.r4300.emumode == EMUMODE_DYNAREC) genlink_subblock();
 
-   if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
-     {
-    free_all_registers();
-    passe2(block->block, (func&0xFFF)/4, i, block);
-    block->code_length = g_dev.r4300.recomp.code_length;
-    block->max_code_length = g_dev.r4300.recomp.max_code_length;
-    free_assembler(&block->jumps_table, &block->jumps_number, &block->riprel_table, &block->riprel_number);
-     }
+    if (g_dev.r4300.emumode == EMUMODE_DYNAREC)
+    {
+        free_all_registers();
+        passe2(block->block, (func&0xFFF)/4, i, block);
+        block->code_length = g_dev.r4300.recomp.code_length;
+        block->max_code_length = g_dev.r4300.recomp.max_code_length;
+        free_assembler(&block->jumps_table, &block->jumps_number, &block->riprel_table, &block->riprel_number);
+    }
 #ifdef DBG
-   DebugMessage(M64MSG_INFO, "block recompiled (%" PRIX32 "-%" PRIX32 ")", func, block->start+i*4);
+    DebugMessage(M64MSG_INFO, "block recompiled (%" PRIX32 "-%" PRIX32 ")", func, block->start+i*4);
 #endif
 #if defined(PROFILE_R4300)
-   fclose(g_dev.r4300.recomp.pfProfile);
-   g_dev.r4300.recomp.pfProfile = NULL;
+    fclose(g_dev.r4300.recomp.pfProfile);
+    g_dev.r4300.recomp.pfProfile = NULL;
 #endif
-   timed_section_end(TIMED_SECTION_COMPILER);
+    timed_section_end(TIMED_SECTION_COMPILER);
 }
 
 static int is_jump(void)
 {
-   recomp_ops[((g_dev.r4300.recomp.src >> 26) & 0x3F)]();
-   return
-      (g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JR ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JALR ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL_IDLE ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL_OUT ||
-       g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL_IDLE);
+    recomp_ops[((g_dev.r4300.recomp.src >> 26) & 0x3F)]();
+    return
+        (g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JR ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JALR ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL_IDLE ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL_OUT ||
+         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL_IDLE);
 }
 
 /**********************************************************************
@@ -2548,29 +2548,29 @@ static int is_jump(void)
  **********************************************************************/
 void recompile_opcode(void)
 {
-   g_dev.r4300.recomp.SRC++;
-   g_dev.r4300.recomp.src = *g_dev.r4300.recomp.SRC;
-   g_dev.r4300.recomp.dst++;
-   g_dev.r4300.recomp.dst->addr = (g_dev.r4300.recomp.dst-1)->addr + 4;
-   g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
-   if(!is_jump())
-   {
+    g_dev.r4300.recomp.SRC++;
+    g_dev.r4300.recomp.src = *g_dev.r4300.recomp.SRC;
+    g_dev.r4300.recomp.dst++;
+    g_dev.r4300.recomp.dst->addr = (g_dev.r4300.recomp.dst-1)->addr + 4;
+    g_dev.r4300.recomp.dst->reg_cache_infos.need_map = 0;
+    if(!is_jump())
+    {
 #if defined(PROFILE_R4300)
-     long x86addr = (long) ((*g_dev.r4300.recomp.inst_pointer) + g_dev.r4300.recomp.code_length);
-     if (fwrite(&g_dev.r4300.recomp.src, 1, 4, g_dev.r4300.recomp.pfProfile) != 4 || // write 4-byte MIPS opcode
-         fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *)) // write pointer to dynamically generated x86 code for this MIPS instruction
-        DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
+        long x86addr = (long) ((*g_dev.r4300.recomp.inst_pointer) + g_dev.r4300.recomp.code_length);
+        if (fwrite(&g_dev.r4300.recomp.src, 1, 4, g_dev.r4300.recomp.pfProfile) != 4 || // write 4-byte MIPS opcode
+                fwrite(&x86addr, 1, sizeof(char *), g_dev.r4300.recomp.pfProfile) != sizeof(char *)) // write pointer to dynamically generated x86 code for this MIPS instruction
+            DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
 #endif
-     g_dev.r4300.recomp.recomp_func = NULL;
-     recomp_ops[((g_dev.r4300.recomp.src >> 26) & 0x3F)]();
-     if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
-   }
-   else
-   {
-     RNOP();
-     if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
-   }
-   g_dev.r4300.recomp.delay_slot_compiled = 2;
+        g_dev.r4300.recomp.recomp_func = NULL;
+        recomp_ops[((g_dev.r4300.recomp.src >> 26) & 0x3F)]();
+        if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
+    }
+    else
+    {
+        RNOP();
+        if (g_dev.r4300.emumode == EMUMODE_DYNAREC) g_dev.r4300.recomp.recomp_func();
+    }
+    g_dev.r4300.recomp.delay_slot_compiled = 2;
 }
 
 #if defined(PROFILE_R4300)
@@ -2589,7 +2589,7 @@ void profile_write_end_of_code_blocks(struct r4300_core* r4300)
             mipsop = -1; /* -1 == end of x86 code block */
             x86addr = r4300->cached_interp.blocks[i]->code + r4300->cached_interp.blocks[i]->code_length;
             if (fwrite(&mipsop, 1, 4, r4300->recomp.pfProfile) != 4 ||
-                fwrite(&x86addr, 1, sizeof(char *), r4300->recomp.pfProfile) != sizeof(char *))
+                    fwrite(&x86addr, 1, sizeof(char *), r4300->recomp.pfProfile) != sizeof(char *))
                 DebugMessage(M64MSG_ERROR, "Error writing R4300 instruction address profiling data");
         }
     }
@@ -2605,22 +2605,22 @@ void profile_write_end_of_code_blocks(struct r4300_core* r4300)
 static void *malloc_exec(size_t size)
 {
 #if defined(WIN32)
-   return VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+    return VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
 #elif defined(__GNUC__)
 
-   #ifndef  MAP_ANONYMOUS
-      #ifdef MAP_ANON
-         #define MAP_ANONYMOUS MAP_ANON
-      #endif
-   #endif
+#ifndef  MAP_ANONYMOUS
+#ifdef MAP_ANON
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#endif
 
-   void *block = mmap(NULL, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-   if (block == MAP_FAILED)
-       { DebugMessage(M64MSG_ERROR, "Memory error: couldn't allocate %zi byte block of aligned RWX memory.", size); return NULL; }
+    void *block = mmap(NULL, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (block == MAP_FAILED)
+    { DebugMessage(M64MSG_ERROR, "Memory error: couldn't allocate %zi byte block of aligned RWX memory.", size); return NULL; }
 
-   return block;
+    return block;
 #else
-   return malloc(size);
+    return malloc(size);
 #endif
 }
 
@@ -2629,18 +2629,17 @@ static void *malloc_exec(size_t size)
  **********************************************************************/
 void *realloc_exec(void *ptr, size_t oldsize, size_t newsize)
 {
-   void* block = malloc_exec(newsize);
-   if (block != NULL)
-   {
-      size_t copysize;
-      if (oldsize < newsize)
-         copysize = oldsize;
-      else
-         copysize = newsize;
-      memcpy(block, ptr, copysize);
-   }
-   free_exec(ptr, oldsize);
-   return block;
+    void* block = malloc_exec(newsize);
+    if (block != NULL)
+    {
+        size_t copysize;
+        copysize = (oldsize < newsize)
+            ? oldsize
+            : newsize;
+        memcpy(block, ptr, copysize);
+    }
+    free_exec(ptr, oldsize);
+    return block;
 }
 
 /**********************************************************************
@@ -2649,10 +2648,10 @@ void *realloc_exec(void *ptr, size_t oldsize, size_t newsize)
 static void free_exec(void *ptr, size_t length)
 {
 #if defined(WIN32)
-   VirtualFree(ptr, 0, MEM_RELEASE);
+    VirtualFree(ptr, 0, MEM_RELEASE);
 #elif defined(__GNUC__)
-   munmap(ptr, length);
+    munmap(ptr, length);
 #else
-   free(ptr);
+    free(ptr);
 #endif
 }

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2628,6 +2628,11 @@ void dynarec_exception_general(void)
     exception_general(&g_dev.r4300);
 }
 
+/* Parameterless version of check_cop1_unusable to ease usage in dynarec. */
+int dynarec_check_cop1_unusable(void)
+{
+    return check_cop1_unusable(&g_dev.r4300);
+}
 
 /**********************************************************************
  ************** allocate memory with executable bit set ***************

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2265,7 +2265,7 @@ void init_block(struct precomp_block *block)
   g_dev.r4300.cached_interp.invalid_code[block->start>>12] = 0;
   if (block->end < UINT32_C(0x80000000) || block->start >= UINT32_C(0xc0000000))
   { 
-    uint32_t paddr = virtual_to_physical_address(block->start, 2);
+    uint32_t paddr = virtual_to_physical_address(&g_dev.r4300.cp0.tlb, block->start, 2);
     g_dev.r4300.cached_interp.invalid_code[paddr>>12] = 0;
     if (!g_dev.r4300.cached_interp.blocks[paddr>>12])
     {
@@ -2363,7 +2363,7 @@ void recompile_block(const uint32_t *source, struct precomp_block *block, uint32
     if(block->start < UINT32_C(0x80000000) || UINT32_C(block->start >= 0xc0000000))
       {
           uint32_t address2 =
-           virtual_to_physical_address(block->start + i*4, 0);
+           virtual_to_physical_address(&g_dev.r4300.cp0.tlb, block->start + i*4, 0);
          if(g_dev.r4300.cached_interp.blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops == g_dev.r4300.current_instruction_table.NOTCOMPILED)
            g_dev.r4300.cached_interp.blocks[address2>>12]->block[(address2&UINT32_C(0xFFF))/4].ops = g_dev.r4300.current_instruction_table.NOTCOMPILED2;
       }

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2469,78 +2469,77 @@ void recompile_block(const uint32_t *source, struct precomp_block *block, uint32
     timed_section_end(TIMED_SECTION_COMPILER);
 }
 
-static int is_jump(void)
+static int is_jump(const struct r4300_core* r4300)
 {
-    recomp_ops[((g_dev.r4300.recomp.src >> 26) & 0x3F)]();
     return
-        (g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.J_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JAL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQ_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNE_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZ_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZ_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BEQL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BNEL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLEZL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGTZL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JR ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.JALR ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZ_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZ_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZAL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZAL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BLTZALL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BGEZALL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1F_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1T_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1FL_IDLE ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL_OUT ||
-         g_dev.r4300.recomp.dst->ops == g_dev.r4300.current_instruction_table.BC1TL_IDLE);
+        (r4300->recomp.dst->ops == r4300->current_instruction_table.J ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.J_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.J_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.JAL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.JAL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.JAL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BEQ ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BEQ_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BEQ_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BNE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BNE_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BNE_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLEZ ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLEZ_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLEZ_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGTZ ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGTZ_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGTZ_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BEQL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BEQL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BEQL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BNEL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BNEL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BNEL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLEZL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLEZL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLEZL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGTZL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGTZL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGTZL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.JR ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.JALR ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZ ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZ_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZ_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZ ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZ_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZ_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZAL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZAL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZAL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZAL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZAL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZAL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZALL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZALL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BLTZALL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZALL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZALL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BGEZALL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1F ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1F_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1F_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1T ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1T_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1T_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1FL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1FL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1FL_IDLE ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1TL ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1TL_OUT ||
+         r4300->recomp.dst->ops == r4300->current_instruction_table.BC1TL_IDLE);
 }
 
 /**********************************************************************
@@ -2554,7 +2553,8 @@ void recompile_opcode(struct r4300_core* r4300)
     r4300->recomp.dst->addr = (r4300->recomp.dst-1)->addr + 4;
     r4300->recomp.dst->reg_cache_infos.need_map = 0;
 
-    if (!is_jump())
+    recomp_ops[((r4300->recomp.src >> 26) & 0x3F)]();
+    if (!is_jump(r4300))
     {
 #if defined(PROFILE_R4300)
         long x86addr = (long) ((*r4300->recomp.inst_pointer) + r4300->recomp.code_length);

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -27,6 +27,8 @@
 
 #include "recomp_types.h"
 
+struct r4300_core;
+
 void recompile_block(const uint32_t *source, struct precomp_block* block, uint32_t func);
 void init_block(struct precomp_block* block);
 void free_block(struct precomp_block* block);
@@ -35,6 +37,10 @@ void dyna_jump(void);
 void dyna_start(void *code);
 void dyna_stop(void);
 void *realloc_exec(void *ptr, size_t oldsize, size_t newsize);
+
+#if defined(PROFILE_R4300)
+void profile_write_end_of_code_blocks(struct r4300_core* r4300);
+#endif
 
 #if defined(__x86_64__)
   #include "x86_64/assemble.h"

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -29,7 +29,7 @@
 
 struct r4300_core;
 
-void recompile_block(const uint32_t *source, struct precomp_block* block, uint32_t func);
+void recompile_block(struct r4300_core* r4300, const uint32_t* source, struct precomp_block* block, uint32_t func);
 void init_block(struct r4300_core* r4300, struct precomp_block* block);
 void free_block(struct r4300_core* r4300, struct precomp_block* block);
 void recompile_opcode(struct r4300_core* r4300);

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -32,7 +32,7 @@ struct r4300_core;
 void recompile_block(const uint32_t *source, struct precomp_block* block, uint32_t func);
 void init_block(struct precomp_block* block);
 void free_block(struct precomp_block* block);
-void recompile_opcode(void);
+void recompile_opcode(struct r4300_core* r4300);
 void dyna_jump(void);
 void dyna_start(void *code);
 void dyna_stop(void);

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -41,6 +41,7 @@ void *realloc_exec(void *ptr, size_t oldsize, size_t newsize);
 
 void dynarec_jump_to_address(void);
 void dynarec_exception_general(void);
+int dynarec_check_cop1_unusable(void);
 
 
 #if defined(PROFILE_R4300)

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -31,7 +31,7 @@ struct r4300_core;
 
 void recompile_block(const uint32_t *source, struct precomp_block* block, uint32_t func);
 void init_block(struct r4300_core* r4300, struct precomp_block* block);
-void free_block(struct precomp_block* block);
+void free_block(struct r4300_core* r4300, struct precomp_block* block);
 void recompile_opcode(struct r4300_core* r4300);
 void dyna_jump(void);
 void dyna_start(void *code);

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -30,7 +30,7 @@
 struct r4300_core;
 
 void recompile_block(const uint32_t *source, struct precomp_block* block, uint32_t func);
-void init_block(struct precomp_block* block);
+void init_block(struct r4300_core* r4300, struct precomp_block* block);
 void free_block(struct precomp_block* block);
 void recompile_opcode(struct r4300_core* r4300);
 void dyna_jump(void);

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -38,6 +38,10 @@ void dyna_start(void *code);
 void dyna_stop(void);
 void *realloc_exec(void *ptr, size_t oldsize, size_t newsize);
 
+
+void dynarec_jump_to_address(void);
+
+
 #if defined(PROFILE_R4300)
 void profile_write_end_of_code_blocks(struct r4300_core* r4300);
 #endif

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -40,6 +40,7 @@ void *realloc_exec(void *ptr, size_t oldsize, size_t newsize);
 
 
 void dynarec_jump_to_address(void);
+void dynarec_exception_general(void);
 
 
 #if defined(PROFILE_R4300)

--- a/src/device/r4300/recomph.h
+++ b/src/device/r4300/recomph.h
@@ -273,7 +273,7 @@ void gensdl(void);
 void gensdr(void);
 void genlink_subblock(void);
 void gendelayslot(void);
-void gencheck_interupt_reg(void);
+void gencheck_interrupt_reg(void);
 void gentest(void);
 void gentest_out(void);
 void gentest_idle(void);

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -26,6 +26,7 @@
 #include "main/main.h"
 #include "main/rom.h"
 
+#include <assert.h>
 #include <string.h>
 
 void poweron_tlb(struct tlb* tlb)
@@ -36,64 +37,66 @@ void poweron_tlb(struct tlb* tlb)
     memset(tlb->LUT_w, 0, 0x100000 * sizeof(tlb->LUT_w[0]));
 }
 
-void tlb_unmap(struct tlb_entry* entry)
+void tlb_unmap(struct tlb* tlb, size_t entry)
 {
     unsigned int i;
+    const struct tlb_entry* e;
 
-    /* FIXME! avoid g_dev usage */
-    struct tlb* tlb = &g_dev.r4300.cp0.tlb;
+    assert(entry < 32);
+    e = &tlb->entries[entry];
 
-    if (entry->v_even)
+    if (e->v_even)
     {
-        for (i=entry->start_even; i<entry->end_even; i += 0x1000)
+        for (i=e->start_even; i<e->end_even; i += 0x1000)
             tlb->LUT_r[i>>12] = 0;
-        if (entry->d_even)
-            for (i=entry->start_even; i<entry->end_even; i += 0x1000)
+        if (e->d_even)
+            for (i=e->start_even; i<e->end_even; i += 0x1000)
                 tlb->LUT_w[i>>12] = 0;
     }
 
-    if (entry->v_odd)
+    if (e->v_odd)
     {
-        for (i=entry->start_odd; i<entry->end_odd; i += 0x1000)
+        for (i=e->start_odd; i<e->end_odd; i += 0x1000)
             tlb->LUT_r[i>>12] = 0;
-        if (entry->d_odd)
-            for (i=entry->start_odd; i<entry->end_odd; i += 0x1000)
+        if (e->d_odd)
+            for (i=e->start_odd; i<e->end_odd; i += 0x1000)
                 tlb->LUT_w[i>>12] = 0;
     }
 }
 
-void tlb_map(struct tlb_entry* entry)
+void tlb_map(struct tlb* tlb, size_t entry)
 {
     unsigned int i;
+    const struct tlb_entry* e;
 
-    /* FIXME! avoid g_dev usage */
-    struct tlb* tlb = &g_dev.r4300.cp0.tlb;
+    assert(entry < 32);
+    e = &tlb->entries[entry];
 
-    if (entry->v_even)
+    if (e->v_even)
     {
-        if (entry->start_even < entry->end_even &&
-            !(entry->start_even >= 0x80000000 && entry->end_even < 0xC0000000) &&
-            entry->phys_even < 0x20000000)
+        if (e->start_even < e->end_even &&
+            !(e->start_even >= 0x80000000 && e->end_even < 0xC0000000) &&
+            e->phys_even < 0x20000000)
         {
-            for (i=entry->start_even;i<entry->end_even;i+=0x1000)
-                tlb->LUT_r[i>>12] = UINT32_C(0x80000000) | (entry->phys_even + (i - entry->start_even) + 0xFFF);
-            if (entry->d_even)
-                for (i=entry->start_even;i<entry->end_even;i+=0x1000)
-                    tlb->LUT_w[i>>12] = UINT32_C(0x80000000) | (entry->phys_even + (i - entry->start_even) + 0xFFF);
+            for (i=e->start_even;i<e->end_even;i+=0x1000)
+                tlb->LUT_r[i>>12] = UINT32_C(0x80000000) | (e->phys_even + (i - e->start_even) + 0xFFF);
+            if (e->d_even)
+                for (i=e->start_even;i<e->end_even;i+=0x1000)
+                    tlb->LUT_w[i>>12] = UINT32_C(0x80000000) | (e->phys_even + (i - e->start_even) + 0xFFF);
         }
     }
 
-    if (entry->v_odd)
+    if (e->v_odd)
     {
-        if (entry->start_odd < entry->end_odd &&
-            !(entry->start_odd >= 0x80000000 && entry->end_odd < 0xC0000000) &&
-            entry->phys_odd < 0x20000000)
+        if (e->start_odd < e->end_odd &&
+            !(e->start_odd >= 0x80000000 && e->end_odd < 0xC0000000) &&
+            e->phys_odd < 0x20000000)
         {
-            for (i=entry->start_odd;i<entry->end_odd;i+=0x1000)
-                tlb->LUT_r[i>>12] = UINT32_C(0x80000000) | (entry->phys_odd + (i - entry->start_odd) + 0xFFF);
-            if (entry->d_odd)
-                for (i=entry->start_odd;i<entry->end_odd;i+=0x1000)
-                    tlb->LUT_w[i>>12] = UINT32_C(0x80000000) | (entry->phys_odd + (i - entry->start_odd) + 0xFFF);
+            for (i=e->start_odd;i<e->end_odd;i+=0x1000)
+                tlb->LUT_r[i>>12] = UINT32_C(0x80000000) | (e->phys_odd + (i - e->start_odd) + 0xFFF);
+            if (e->d_odd)
+                for (i=e->start_odd;i<e->end_odd;i+=0x1000)
+                    tlb->LUT_w[i>>12] = UINT32_C(0x80000000) | (e->phys_odd + (i - e->start_odd) + 0xFFF);
         }
     }
 }

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -139,7 +139,7 @@ uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address,
         if (r4300->cp0.tlb.LUT_r[address>>12])
             return (r4300->cp0.tlb.LUT_r[address>>12] & UINT32_C(0xFFFFF000)) | (address & UINT32_C(0xFFF));
     }
-    //printf("tlb exception !!! @ %x, %x, add:%x\n", address, w, g_dev.r4300.pc->addr);
+    //printf("tlb exception !!! @ %x, %x, add:%x\n", address, w, r4300->pc->addr);
     //getchar();
     TLB_refill_exception(r4300, address, w);
     //return 0x80000000;

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -23,7 +23,6 @@
 
 #include "api/m64p_types.h"
 #include "exception.h"
-#include "main/main.h"
 #include "main/rom.h"
 
 #include <assert.h>

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -101,11 +101,8 @@ void tlb_map(struct tlb* tlb, size_t entry)
     }
 }
 
-uint32_t virtual_to_physical_address(uint32_t addresse, int w)
+uint32_t virtual_to_physical_address(struct tlb* tlb, uint32_t addresse, int w)
 {
-    /* FIXME! avoid g_dev usage */
-    struct tlb* tlb = &g_dev.r4300.cp0.tlb;
-
     if (addresse >= UINT32_C(0x7f000000) && addresse < UINT32_C(0x80000000) && isGoldeneyeRom)
     {
         /**************************************************

--- a/src/device/r4300/tlb.h
+++ b/src/device/r4300/tlb.h
@@ -62,6 +62,6 @@ void poweron_tlb(struct tlb* tlb);
 void tlb_unmap(struct tlb* tlb, size_t entry);
 void tlb_map(struct tlb* tlb, size_t entry);
 
-uint32_t virtual_to_physical_address(uint32_t addresse, int w);
+uint32_t virtual_to_physical_address(struct tlb* tlb, uint32_t addresse, int w);
 
 #endif /* M64P_DEVICE_R4300_TLB_H */

--- a/src/device/r4300/tlb.h
+++ b/src/device/r4300/tlb.h
@@ -22,6 +22,7 @@
 #ifndef M64P_DEVICE_R4300_TLB_H
 #define M64P_DEVICE_R4300_TLB_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 struct tlb_entry
@@ -58,8 +59,8 @@ struct tlb
 
 void poweron_tlb(struct tlb* tlb);
 
-void tlb_unmap(struct tlb_entry* entry);
-void tlb_map(struct tlb_entry* entry);
+void tlb_unmap(struct tlb* tlb, size_t entry);
+void tlb_map(struct tlb* tlb, size_t entry);
 
 uint32_t virtual_to_physical_address(uint32_t addresse, int w);
 

--- a/src/device/r4300/tlb.h
+++ b/src/device/r4300/tlb.h
@@ -25,6 +25,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct r4300_core;
+
 struct tlb_entry
 {
    short mask;
@@ -62,6 +64,6 @@ void poweron_tlb(struct tlb* tlb);
 void tlb_unmap(struct tlb* tlb, size_t entry);
 void tlb_map(struct tlb* tlb, size_t entry);
 
-uint32_t virtual_to_physical_address(struct tlb* tlb, uint32_t addresse, int w);
+uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address, int w);
 
 #endif /* M64P_DEVICE_R4300_TLB_H */

--- a/src/device/r4300/x86/gr4300.c
+++ b/src/device/r4300/x86/gr4300.c
@@ -1718,7 +1718,7 @@ void gencheck_cop1_unusable(void)
 
    jump_start_rel8();
    
-   gencallinterp((unsigned int)check_cop1_unusable, 0);
+   gencallinterp((unsigned int)dynarec_check_cop1_unusable, 0);
    
    jump_end_rel8();
 }

--- a/src/device/r4300/x86/gr4300.c
+++ b/src/device/r4300/x86/gr4300.c
@@ -441,9 +441,9 @@ void genj_out(void)
    
    mov_m32_imm32(&g_dev.r4300.cp0.last_addr, naddr);
    gencheck_interupt_out(naddr);
-   mov_m32_imm32(&g_dev.r4300.cached_interp.jump_to_address, naddr);
+   mov_m32_imm32(&g_dev.r4300.recomp.jump_to_address, naddr);
    mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct())), (unsigned int)(g_dev.r4300.recomp.dst+1));
-   mov_reg32_imm32(EAX, (unsigned int)jump_to_func);
+   mov_reg32_imm32(EAX, (unsigned int)dynarec_jump_to_address);
    call_reg32(EAX);
 #endif
 }
@@ -528,9 +528,9 @@ void genjal_out(void)
    
    mov_m32_imm32(&g_dev.r4300.cp0.last_addr, naddr);
    gencheck_interupt_out(naddr);
-   mov_m32_imm32(&g_dev.r4300.cached_interp.jump_to_address, naddr);
+   mov_m32_imm32(&g_dev.r4300.recomp.jump_to_address, naddr);
    mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct())), (unsigned int)(g_dev.r4300.recomp.dst+1));
-   mov_reg32_imm32(EAX, (unsigned int)jump_to_func);
+   mov_reg32_imm32(EAX, (unsigned int)dynarec_jump_to_address);
    call_reg32(EAX);
 #endif
 }
@@ -604,9 +604,9 @@ void gentest_out(void)
 
    mov_m32_imm32(&g_dev.r4300.cp0.last_addr, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    gencheck_interupt_out(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
-   mov_m32_imm32(&g_dev.r4300.cached_interp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
+   mov_m32_imm32(&g_dev.r4300.recomp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct())), (unsigned int)(g_dev.r4300.recomp.dst+1));
-   mov_reg32_imm32(EAX, (unsigned int)jump_to_func);
+   mov_reg32_imm32(EAX, (unsigned int)dynarec_jump_to_address);
    call_reg32(EAX);
    
    jump_end_rel32();
@@ -1010,9 +1010,9 @@ void gentestl_out(void)
    gendelayslot();
    mov_m32_imm32(&g_dev.r4300.cp0.last_addr, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    gencheck_interupt_out(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
-   mov_m32_imm32(&g_dev.r4300.cached_interp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
+   mov_m32_imm32(&g_dev.r4300.recomp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct())), (unsigned int)(g_dev.r4300.recomp.dst+1));
-   mov_reg32_imm32(EAX, (unsigned int)jump_to_func);
+   mov_reg32_imm32(EAX, (unsigned int)dynarec_jump_to_address);
    call_reg32(EAX);
    
    jump_end_rel32();

--- a/src/device/r4300/x86/gr4300.c
+++ b/src/device/r4300/x86/gr4300.c
@@ -361,7 +361,7 @@ void gencallinterp(uintptr_t addr, int jump)
 void gendelayslot(void)
 {
    mov_m32_imm32(&g_dev.r4300.delay_slot, 1);
-   recompile_opcode();
+   recompile_opcode(&g_dev.r4300);
    
    free_all_registers();
    gencp0_update_count(g_dev.r4300.recomp.dst->addr+4);

--- a/src/device/r4300/x86/gspecial.c
+++ b/src/device/r4300/x86/gspecial.c
@@ -24,7 +24,6 @@
 #include "assemble.h"
 #include "interpret.h"
 #include "device/r4300/cached_interp.h"
-#include "device/r4300/exception.h"
 #include "device/r4300/ops.h"
 #include "device/r4300/recomp.h"
 #include "device/r4300/recomph.h"
@@ -296,7 +295,7 @@ void gensyscall(void)
    free_all_registers();
    simplify_access();
    mov_m32_imm32(&r4300_cp0_regs()[CP0_CAUSE_REG], 8 << 2);
-   gencallinterp((unsigned int)exception_general, 0);
+   gencallinterp((unsigned int)dynarec_exception_general, 0);
 #endif
 }
 

--- a/src/device/r4300/x86/gspecial.c
+++ b/src/device/r4300/x86/gspecial.c
@@ -191,9 +191,9 @@ void genjr(void)
 
    jump_start_rel32();
    
-   mov_m32_reg32(&g_dev.r4300.cached_interp.jump_to_address, EBX);
+   mov_m32_reg32(&g_dev.r4300.recomp.jump_to_address, EBX);
    mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct())), (unsigned int)(g_dev.r4300.recomp.dst+1));
-   mov_reg32_imm32(EAX, (unsigned int)jump_to_func);
+   mov_reg32_imm32(EAX, (unsigned int)dynarec_jump_to_address);
    call_reg32(EAX);
    
    jump_end_rel32();
@@ -262,9 +262,9 @@ void genjalr(void)
 
    jump_start_rel32();
    
-   mov_m32_reg32(&g_dev.r4300.cached_interp.jump_to_address, EBX);
+   mov_m32_reg32(&g_dev.r4300.recomp.jump_to_address, EBX);
    mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct())), (unsigned int)(g_dev.r4300.recomp.dst+1));
-   mov_reg32_imm32(EAX, (unsigned int)jump_to_func);
+   mov_reg32_imm32(EAX, (unsigned int)dynarec_jump_to_address);
    call_reg32(EAX);
    
    jump_end_rel32();

--- a/src/device/r4300/x86/gspecial.c
+++ b/src/device/r4300/x86/gspecial.c
@@ -181,7 +181,7 @@ void genjr(void)
    mov_eax_memoffs32((unsigned int *)&g_dev.r4300.local_rs);
    mov_memoffs32_eax((unsigned int *)&g_dev.r4300.cp0.last_addr);
    
-   gencheck_interupt_reg();
+   gencheck_interrupt_reg();
    
    mov_eax_memoffs32((unsigned int *)&g_dev.r4300.local_rs);
    mov_reg32_reg32(EBX, EAX);
@@ -252,7 +252,7 @@ void genjalr(void)
    mov_eax_memoffs32((unsigned int *)&g_dev.r4300.local_rs);
    mov_memoffs32_eax((unsigned int *)&g_dev.r4300.cp0.last_addr);
    
-   gencheck_interupt_reg();
+   gencheck_interrupt_reg();
    
    mov_eax_memoffs32((unsigned int *)&g_dev.r4300.local_rs);
    mov_reg32_reg32(EBX, EAX);

--- a/src/device/r4300/x86_64/gr4300.c
+++ b/src/device/r4300/x86_64/gr4300.c
@@ -31,7 +31,7 @@
 #include "device/r4300/cached_interp.h"
 #include "device/r4300/cp1.h"
 #include "device/r4300/exception.h"
-#include "device/r4300/interupt.h"
+#include "device/r4300/interrupt.h"
 #include "device/r4300/ops.h"
 #include "device/r4300/recomp.h"
 #include "device/r4300/recomph.h"
@@ -64,7 +64,7 @@ static void gencp0_update_count(unsigned int addr)
 #endif
 }
 
-static void gencheck_interupt(unsigned long long instr_structure)
+static void gencheck_interrupt(unsigned long long instr_structure)
 {
    mov_xreg32_m32rel(EAX, (void*)(r4300_cp0_next_interrupt()));
    cmp_xreg32_m32rel(EAX, (void*)&r4300_cp0_regs()[CP0_COUNT_REG]);
@@ -73,13 +73,13 @@ static void gencheck_interupt(unsigned long long instr_structure)
 
    mov_reg64_imm64(RAX, (unsigned long long) instr_structure);
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long) gen_interupt);
+   mov_reg64_imm64(RAX, (unsigned long long) gen_interrupt);
    call_reg64(RAX);
 
    jump_end_rel8();
 }
 
-static void gencheck_interupt_out(unsigned int addr)
+static void gencheck_interrupt_out(unsigned int addr)
 {
    mov_xreg32_m32rel(EAX, (void*)(r4300_cp0_next_interrupt()));
    cmp_xreg32_m32rel(EAX, (void*)&r4300_cp0_regs()[CP0_COUNT_REG]);
@@ -89,7 +89,7 @@ static void gencheck_interupt_out(unsigned int addr)
    mov_m32rel_imm32((unsigned int*)(&g_dev.r4300.fake_instr.addr), addr);
    mov_reg64_imm64(RAX, (unsigned long long) (&g_dev.r4300.fake_instr));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long) gen_interupt);
+   mov_reg64_imm64(RAX, (unsigned long long) gen_interrupt);
    call_reg64(RAX);
 
    jump_end_rel8();
@@ -356,7 +356,7 @@ void genfin_block(void)
    gencallinterp((unsigned long long)cached_interpreter_table.FIN_BLOCK, 0);
 }
 
-void gencheck_interupt_reg(void) // addr is in EAX
+void gencheck_interrupt_reg(void) // addr is in EAX
 {
    mov_xreg32_m32rel(EBX, (void*)r4300_cp0_next_interrupt());
    cmp_xreg32_m32rel(EBX, (void*)&r4300_cp0_regs()[CP0_COUNT_REG]);
@@ -366,7 +366,7 @@ void gencheck_interupt_reg(void) // addr is in EAX
    mov_m32rel_xreg32((unsigned int*)(&g_dev.r4300.fake_instr.addr), EAX);
    mov_reg64_imm64(RAX, (unsigned long long) (&g_dev.r4300.fake_instr));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long) gen_interupt);
+   mov_reg64_imm64(RAX, (unsigned long long) gen_interrupt);
    call_reg64(RAX);
 
    jump_end_rel8();
@@ -397,7 +397,7 @@ void genj(void)
    naddr = ((g_dev.r4300.recomp.dst-1)->f.j.inst_index<<2) | (g_dev.r4300.recomp.dst->addr & 0xF0000000);
    
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), naddr);
-   gencheck_interupt((unsigned long long) &g_dev.r4300.cached_interp.actual->block[(naddr-g_dev.r4300.cached_interp.actual->start)/4]);
+   gencheck_interrupt((unsigned long long) &g_dev.r4300.cached_interp.actual->block[(naddr-g_dev.r4300.cached_interp.actual->start)/4]);
    jmp(naddr);
 #endif
 }
@@ -423,7 +423,7 @@ void genj_out(void)
    naddr = ((g_dev.r4300.recomp.dst-1)->f.j.inst_index<<2) | (g_dev.r4300.recomp.dst->addr & 0xF0000000);
    
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), naddr);
-   gencheck_interupt_out(naddr);
+   gencheck_interrupt_out(naddr);
    mov_m32rel_imm32(&g_dev.r4300.recomp.jump_to_address, naddr);
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
@@ -487,7 +487,7 @@ void genjal(void)
    naddr = ((g_dev.r4300.recomp.dst-1)->f.j.inst_index<<2) | (g_dev.r4300.recomp.dst->addr & 0xF0000000);
 
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), naddr);
-   gencheck_interupt((unsigned long long) &g_dev.r4300.cached_interp.actual->block[(naddr-g_dev.r4300.cached_interp.actual->start)/4]);
+   gencheck_interrupt((unsigned long long) &g_dev.r4300.cached_interp.actual->block[(naddr-g_dev.r4300.cached_interp.actual->start)/4]);
    jmp(naddr);
 #endif
 }
@@ -520,7 +520,7 @@ void genjal_out(void)
    naddr = ((g_dev.r4300.recomp.dst-1)->f.j.inst_index<<2) | (g_dev.r4300.recomp.dst->addr & 0xF0000000);
 
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), naddr);
-   gencheck_interupt_out(naddr);
+   gencheck_interrupt_out(naddr);
    mov_m32rel_imm32(&g_dev.r4300.recomp.jump_to_address, naddr);
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
@@ -563,13 +563,13 @@ void gentest(void)
    jump_start_rel32();
 
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
-   gencheck_interupt((unsigned long long) (g_dev.r4300.recomp.dst + (g_dev.r4300.recomp.dst-1)->f.i.immediate));
+   gencheck_interrupt((unsigned long long) (g_dev.r4300.recomp.dst + (g_dev.r4300.recomp.dst-1)->f.i.immediate));
    jmp(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
 
    jump_end_rel32();
 
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + 4);
-   gencheck_interupt((unsigned long long)(g_dev.r4300.recomp.dst + 1));
+   gencheck_interrupt((unsigned long long)(g_dev.r4300.recomp.dst + 1));
    jmp(g_dev.r4300.recomp.dst->addr + 4);
 }
 
@@ -601,7 +601,7 @@ void gentest_out(void)
    jump_start_rel32();
 
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
-   gencheck_interupt_out(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
+   gencheck_interrupt_out(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    mov_m32rel_imm32(&g_dev.r4300.recomp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
@@ -610,7 +610,7 @@ void gentest_out(void)
    jump_end_rel32();
 
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + 4);
-   gencheck_interupt((unsigned long long) (g_dev.r4300.recomp.dst + 1));
+   gencheck_interrupt((unsigned long long) (g_dev.r4300.recomp.dst + 1));
    jmp(g_dev.r4300.recomp.dst->addr + 4);
 }
 
@@ -995,14 +995,14 @@ void gentestl(void)
 
    gendelayslot();
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
-   gencheck_interupt((unsigned long long) (g_dev.r4300.recomp.dst + (g_dev.r4300.recomp.dst-1)->f.i.immediate));
+   gencheck_interrupt((unsigned long long) (g_dev.r4300.recomp.dst + (g_dev.r4300.recomp.dst-1)->f.i.immediate));
    jmp(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    
    jump_end_rel32();
 
    gencp0_update_count(g_dev.r4300.recomp.dst->addr-4);
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + 4);
-   gencheck_interupt((unsigned long long) (g_dev.r4300.recomp.dst + 1));
+   gencheck_interrupt((unsigned long long) (g_dev.r4300.recomp.dst + 1));
    jmp(g_dev.r4300.recomp.dst->addr + 4);
 }
 
@@ -1035,7 +1035,7 @@ void gentestl_out(void)
 
    gendelayslot();
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
-   gencheck_interupt_out(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
+   gencheck_interrupt_out(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    mov_m32rel_imm32(&g_dev.r4300.recomp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
 
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
@@ -1047,7 +1047,7 @@ void gentestl_out(void)
 
    gencp0_update_count(g_dev.r4300.recomp.dst->addr-4);
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + 4);
-   gencheck_interupt((unsigned long long) (g_dev.r4300.recomp.dst + 1));
+   gencheck_interrupt((unsigned long long) (g_dev.r4300.recomp.dst + 1));
    jmp(g_dev.r4300.recomp.dst->addr + 4);
 }
 

--- a/src/device/r4300/x86_64/gr4300.c
+++ b/src/device/r4300/x86_64/gr4300.c
@@ -327,7 +327,7 @@ void gencallinterp(uintptr_t addr, int jump)
 void gendelayslot(void)
 {
    mov_m32rel_imm32((void*)(&g_dev.r4300.delay_slot), 1);
-   recompile_opcode();
+   recompile_opcode(&g_dev.r4300);
    
    free_all_registers();
    gencp0_update_count(g_dev.r4300.recomp.dst->addr+4);

--- a/src/device/r4300/x86_64/gr4300.c
+++ b/src/device/r4300/x86_64/gr4300.c
@@ -424,10 +424,10 @@ void genj_out(void)
    
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), naddr);
    gencheck_interupt_out(naddr);
-   mov_m32rel_imm32(&g_dev.r4300.cached_interp.jump_to_address, naddr);
+   mov_m32rel_imm32(&g_dev.r4300.recomp.jump_to_address, naddr);
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long)jump_to_func);
+   mov_reg64_imm64(RAX, (unsigned long long)dynarec_jump_to_address);
    call_reg64(RAX);
 #endif
 }
@@ -521,10 +521,10 @@ void genjal_out(void)
 
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), naddr);
    gencheck_interupt_out(naddr);
-   mov_m32rel_imm32(&g_dev.r4300.cached_interp.jump_to_address, naddr);
+   mov_m32rel_imm32(&g_dev.r4300.recomp.jump_to_address, naddr);
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long) jump_to_func);
+   mov_reg64_imm64(RAX, (unsigned long long) dynarec_jump_to_address);
    call_reg64(RAX);
 #endif
 }
@@ -602,10 +602,10 @@ void gentest_out(void)
 
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    gencheck_interupt_out(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
-   mov_m32rel_imm32(&g_dev.r4300.cached_interp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
+   mov_m32rel_imm32(&g_dev.r4300.recomp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long) jump_to_func);
+   mov_reg64_imm64(RAX, (unsigned long long) dynarec_jump_to_address);
    call_reg64(RAX);
    jump_end_rel32();
 
@@ -1036,11 +1036,11 @@ void gentestl_out(void)
    gendelayslot();
    mov_m32rel_imm32((void*)(&g_dev.r4300.cp0.last_addr), g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
    gencheck_interupt_out(g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
-   mov_m32rel_imm32(&g_dev.r4300.cached_interp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
+   mov_m32rel_imm32(&g_dev.r4300.recomp.jump_to_address, g_dev.r4300.recomp.dst->addr + (g_dev.r4300.recomp.dst-1)->f.i.immediate*4);
 
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long) jump_to_func);
+   mov_reg64_imm64(RAX, (unsigned long long) dynarec_jump_to_address);
    call_reg64(RAX);
    
    jump_end_rel32();

--- a/src/device/r4300/x86_64/gr4300.c
+++ b/src/device/r4300/x86_64/gr4300.c
@@ -1872,7 +1872,7 @@ void gencheck_cop1_unusable(void)
    jne_rj(0);
    jump_start_rel8();
 
-   gencallinterp((unsigned long long)check_cop1_unusable, 0);
+   gencallinterp((unsigned long long)dynarec_check_cop1_unusable, 0);
 
    jump_end_rel8();
 }

--- a/src/device/r4300/x86_64/gspecial.c
+++ b/src/device/r4300/x86_64/gspecial.c
@@ -220,10 +220,10 @@ void genjr(void)
 
    jump_start_rel32();
    
-   mov_m32rel_xreg32(&g_dev.r4300.cached_interp.jump_to_address, EBX);
+   mov_m32rel_xreg32(&g_dev.r4300.recomp.jump_to_address, EBX);
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long) jump_to_func);
+   mov_reg64_imm64(RAX, (unsigned long long) dynarec_jump_to_address);
    call_reg64(RAX);  /* will never return from call */
 
    jump_end_rel32();
@@ -294,10 +294,10 @@ void genjalr(void)
 
    jump_start_rel32();
    
-   mov_m32rel_xreg32(&g_dev.r4300.cached_interp.jump_to_address, EBX);
+   mov_m32rel_xreg32(&g_dev.r4300.recomp.jump_to_address, EBX);
    mov_reg64_imm64(RAX, (unsigned long long) (g_dev.r4300.recomp.dst+1));
    mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct())), RAX);
-   mov_reg64_imm64(RAX, (unsigned long long) jump_to_func);
+   mov_reg64_imm64(RAX, (unsigned long long) dynarec_jump_to_address);
    call_reg64(RAX);  /* will never return from call */
 
    jump_end_rel32();

--- a/src/device/r4300/x86_64/gspecial.c
+++ b/src/device/r4300/x86_64/gspecial.c
@@ -210,7 +210,7 @@ void genjr(void)
    mov_xreg32_m32rel(EAX, (unsigned int *)&g_dev.r4300.local_rs);
    mov_m32rel_xreg32((unsigned int *)&g_dev.r4300.cp0.last_addr, EAX);
    
-   gencheck_interupt_reg();
+   gencheck_interrupt_reg();
    
    mov_xreg32_m32rel(EAX, (unsigned int *)&g_dev.r4300.local_rs);
    mov_reg32_reg32(EBX, EAX);
@@ -284,7 +284,7 @@ void genjalr(void)
    mov_xreg32_m32rel(EAX, (unsigned int *)&g_dev.r4300.local_rs);
    mov_m32rel_xreg32((unsigned int *)&g_dev.r4300.cp0.last_addr, EAX);
    
-   gencheck_interupt_reg();
+   gencheck_interrupt_reg();
    
    mov_xreg32_m32rel(EAX, (unsigned int *)&g_dev.r4300.local_rs);
    mov_reg32_reg32(EBX, EAX);

--- a/src/device/r4300/x86_64/gspecial.c
+++ b/src/device/r4300/x86_64/gspecial.c
@@ -26,7 +26,6 @@
 #include "assemble.h"
 #include "interpret.h"
 #include "device/r4300/cached_interp.h"
-#include "device/r4300/exception.h"
 #include "device/r4300/ops.h"
 #include "device/r4300/recomp.h"
 #include "device/r4300/recomph.h"
@@ -334,7 +333,7 @@ void gensyscall(void)
    free_registers_move_start();
 
    mov_m32rel_imm32(&r4300_cp0_regs()[CP0_CAUSE_REG], 8 << 2);
-   gencallinterp((unsigned long long)exception_general, 0);
+   gencallinterp((unsigned long long)dynarec_exception_general, 0);
 #endif
 }
 

--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -137,7 +137,7 @@ void protect_framebuffers(struct rdp_core* dp)
                 {
                     fb->once = 0;
                     dp->r4300->recomp.fast_memory = 0;
-                    invalidate_r4300_cached_code(0, 0);
+                    invalidate_r4300_cached_code(dp->r4300, 0, 0);
                 }
             }
         }

--- a/src/device/rsp/rsp_core.c
+++ b/src/device/rsp/rsp_core.c
@@ -285,9 +285,9 @@ void do_SP_Task(struct rsp_core* sp)
 
         cp0_update_count();
         if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP)
-            add_interupt_event(SP_INT, 1000);
+            add_interrupt_event(SP_INT, 1000);
         if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_DP)
-            add_interupt_event(DP_INT, 1000);
+            add_interrupt_event(DP_INT, 1000);
         sp->r4300->mi.regs[MI_INTR_REG] &= ~(MI_INTR_SP | MI_INTR_DP);
         sp->regs[SP_STATUS_REG] &= ~SP_STATUS_TASKDONE;
 
@@ -304,7 +304,7 @@ void do_SP_Task(struct rsp_core* sp)
 
         cp0_update_count();
         if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP)
-            add_interupt_event(SP_INT, 4000/*500*/);
+            add_interrupt_event(SP_INT, 4000/*500*/);
         sp->r4300->mi.regs[MI_INTR_REG] &= ~MI_INTR_SP;
         sp->regs[SP_STATUS_REG] &= ~(SP_STATUS_TASKDONE | SP_STATUS_YIELDED);
     }
@@ -316,7 +316,7 @@ void do_SP_Task(struct rsp_core* sp)
 
         cp0_update_count();
         if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP)
-            add_interupt_event(SP_INT, 0/*100*/);
+            add_interrupt_event(SP_INT, 0/*100*/);
         sp->r4300->mi.regs[MI_INTR_REG] &= ~MI_INTR_SP;
         sp->regs[SP_STATUS_REG] &= ~SP_STATUS_TASKDONE;
     }

--- a/src/device/rsp/rsp_core.c
+++ b/src/device/rsp/rsp_core.c
@@ -284,10 +284,12 @@ void do_SP_Task(struct rsp_core* sp)
         new_frame();
 
         cp0_update_count();
-        if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP)
-            add_interrupt_event(SP_INT, 1000);
-        if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_DP)
-            add_interrupt_event(DP_INT, 1000);
+        if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP) {
+            add_interrupt_event(&sp->r4300->cp0, SP_INT, 1000);
+        }
+        if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_DP) {
+            add_interrupt_event(&sp->r4300->cp0, DP_INT, 1000);
+        }
         sp->r4300->mi.regs[MI_INTR_REG] &= ~(MI_INTR_SP | MI_INTR_DP);
         sp->regs[SP_STATUS_REG] &= ~SP_STATUS_TASKDONE;
 
@@ -303,8 +305,9 @@ void do_SP_Task(struct rsp_core* sp)
         sp->regs2[SP_PC_REG] |= save_pc;
 
         cp0_update_count();
-        if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP)
-            add_interrupt_event(SP_INT, 4000/*500*/);
+        if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP) {
+            add_interrupt_event(&sp->r4300->cp0, SP_INT, 4000/*500*/);
+        }
         sp->r4300->mi.regs[MI_INTR_REG] &= ~MI_INTR_SP;
         sp->regs[SP_STATUS_REG] &= ~(SP_STATUS_TASKDONE | SP_STATUS_YIELDED);
     }
@@ -315,8 +318,9 @@ void do_SP_Task(struct rsp_core* sp)
         sp->regs2[SP_PC_REG] |= save_pc;
 
         cp0_update_count();
-        if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP)
-            add_interrupt_event(SP_INT, 0/*100*/);
+        if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP) {
+            add_interrupt_event(&sp->r4300->cp0, SP_INT, 0/*100*/);
+        }
         sp->r4300->mi.regs[MI_INTR_REG] &= ~MI_INTR_SP;
         sp->regs[SP_STATUS_REG] &= ~SP_STATUS_TASKDONE;
     }

--- a/src/device/rsp/rsp_core.c
+++ b/src/device/rsp/rsp_core.c
@@ -143,7 +143,7 @@ static void update_sp_status(struct rsp_core* sp, uint32_t w)
     if (w & 0x800000) sp->regs[SP_STATUS_REG] &= ~SP_STATUS_SIG7;
     if (w & 0x1000000) sp->regs[SP_STATUS_REG] |= SP_STATUS_SIG7;
 
-    //if (get_event(SP_INT)) return;
+    //if (get_event(&sp->r4300->cp0.q, SP_INT)) return;
     if (!(w & 0x1) && !(w & 0x4))
         return;
 

--- a/src/device/si/pif.c
+++ b/src/device/si/pif.c
@@ -143,7 +143,7 @@ int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
         {
             si->pif.ram[0x3f] = 0;
             cp0_update_count();
-            add_interupt_event(SI_INT, /*0x100*/0x900);
+            add_interrupt_event(SI_INT, /*0x100*/0x900);
         }
         else
         {

--- a/src/device/si/pif.c
+++ b/src/device/si/pif.c
@@ -143,7 +143,7 @@ int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
         {
             si->pif.ram[0x3f] = 0;
             cp0_update_count();
-            add_interrupt_event(SI_INT, /*0x100*/0x900);
+            add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
         }
         else
         {

--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -56,7 +56,7 @@ static void dma_si_write(struct si_controller* si)
     cp0_update_count();
 
     if (g_delay_si) {
-        add_interrupt_event(SI_INT, /*0x100*/0x900);
+        add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
     } else {
         si->regs[SI_STATUS_REG] |= SI_STATUS_INTERRUPT;
         signal_rcp_interrupt(si->r4300, MI_INTR_SI);
@@ -83,7 +83,7 @@ static void dma_si_read(struct si_controller* si)
     cp0_update_count();
 
     if (g_delay_si) {
-        add_interrupt_event(SI_INT, /*0x100*/0x900);
+        add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
     } else {
         si->regs[SI_STATUS_REG] |= SI_STATUS_INTERRUPT;
         signal_rcp_interrupt(si->r4300, MI_INTR_SI);

--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -56,7 +56,7 @@ static void dma_si_write(struct si_controller* si)
     cp0_update_count();
 
     if (g_delay_si) {
-        add_interupt_event(SI_INT, /*0x100*/0x900);
+        add_interrupt_event(SI_INT, /*0x100*/0x900);
     } else {
         si->regs[SI_STATUS_REG] |= SI_STATUS_INTERRUPT;
         signal_rcp_interrupt(si->r4300, MI_INTR_SI);
@@ -83,7 +83,7 @@ static void dma_si_read(struct si_controller* si)
     cp0_update_count();
 
     if (g_delay_si) {
-        add_interupt_event(SI_INT, /*0x100*/0x900);
+        add_interrupt_event(SI_INT, /*0x100*/0x900);
     } else {
         si->regs[SI_STATUS_REG] |= SI_STATUS_INTERRUPT;
         signal_rcp_interrupt(si->r4300, MI_INTR_SI);

--- a/src/device/vi/vi_controller.c
+++ b/src/device/vi/vi_controller.c
@@ -153,7 +153,7 @@ void vi_vertical_interrupt_event(struct vi_controller* vi)
 
     vi->next_vi += vi->delay;
 
-    add_interupt_event_count(VI_INT, vi->next_vi);
+    add_interrupt_event_count(VI_INT, vi->next_vi);
 
     /* trigger interrupt */
     raise_rcp_interrupt(vi->r4300, MI_INTR_VI);

--- a/src/device/vi/vi_controller.c
+++ b/src/device/vi/vi_controller.c
@@ -153,7 +153,7 @@ void vi_vertical_interrupt_event(struct vi_controller* vi)
 
     vi->next_vi += vi->delay;
 
-    add_interrupt_event_count(VI_INT, vi->next_vi);
+    add_interrupt_event_count(&vi->r4300->cp0, VI_INT, vi->next_vi);
 
     /* trigger interrupt */
     raise_rcp_interrupt(vi->r4300, MI_INTR_VI);

--- a/src/main/cheat.c
+++ b/src/main/cheat.c
@@ -86,13 +86,13 @@ static void update_address_16bit(unsigned int address, unsigned short new_value)
 {
     *(unsigned short *)(((unsigned char*)g_dev.ri.rdram.dram + ((address & 0xFFFFFF)^S16))) = new_value;
     address &= 0xfeffffff;  // mask out bit 24 which is used by GS codes to specify 8/16 bits
-    invalidate_r4300_cached_code(address, 2);
+    invalidate_r4300_cached_code(&g_dev.r4300, address, 2);
 }
 
 static void update_address_8bit(unsigned int address, unsigned char new_value)
 {
     *(unsigned char *)(((unsigned char*)g_dev.ri.rdram.dram + ((address & 0xFFFFFF)^S8))) = new_value;
-    invalidate_r4300_cached_code(address, 1);
+    invalidate_r4300_cached_code(&g_dev.r4300, address, 1);
 }
 
 static int address_equal_to_8bit(unsigned int address, unsigned char value)

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -498,7 +498,7 @@ int savestates_load_m64p(char *filepath)
     // assert(savestateData+savestateSize == curr)
 
     to_little_endian_buffer(queue, 4, 256);
-    load_eventqueue_infos(queue);
+    load_eventqueue_infos(&g_dev.r4300.cp0, queue);
 
 #ifdef NEW_DYNAREC
     if (version >= 0x00010100)
@@ -604,7 +604,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     *((unsigned int*)&buffer[12]) = cp0_regs[CP0_COMPARE_REG];
     *((unsigned int*)&buffer[16]) = 0xFFFFFFFF;
 
-    load_eventqueue_infos(buffer);
+    load_eventqueue_infos(&g_dev.r4300.cp0, buffer);
 
     // FPCR
     *r4300_cp1_fcr0() = GETDATA(curr, uint32_t);
@@ -1023,7 +1023,7 @@ int savestates_save_m64p(char *filepath)
     if(autoinc_save_slot)
         savestates_inc_slot();
 
-    save_eventqueue_infos(queue);
+    save_eventqueue_infos(&g_dev.r4300.cp0, queue);
 
     // Allocate memory for the save state data
     save->size = 16788288 + sizeof(queue) + 4;

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -1505,7 +1505,7 @@ int savestates_save(void)
        Otherwise try again in a little while. */
     if ((type == savestates_type_pj64_zip ||
          type == savestates_type_pj64_unc) &&
-        get_next_event_type() > COMPARE_INT)
+        get_next_event_type(&g_dev.r4300.cp0.q) > COMPARE_INT)
         return 0;
 
     if (fname != NULL && type == savestates_type_unknown)

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -489,7 +489,7 @@ int savestates_load_m64p(char *filepath)
         g_dev.r4300.cp0.tlb.entries[i].phys_odd = GETDATA(curr, unsigned int);
     }
 
-    savestates_load_set_pc(GETDATA(curr, uint32_t));
+    savestates_load_set_pc(&g_dev.r4300, GETDATA(curr, uint32_t));
 
     *r4300_cp0_next_interrupt() = GETDATA(curr, unsigned int);
     g_dev.vi.next_vi = GETDATA(curr, unsigned int);
@@ -781,7 +781,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     // No flashram info in pj64 savestate.
     poweron_flashram(&g_dev.pi.flashram);
 
-    savestates_load_set_pc(*r4300_cp0_last_addr());
+    savestates_load_set_pc(&g_dev.r4300, *r4300_cp0_last_addr());
 
     // assert(savestateData+savestateSize == curr)
 

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -1287,7 +1287,7 @@ static int savestates_save_pj64(char *filepath, void *handle,
     PUTARRAY(pj64_magic, curr, unsigned char, 4);
     PUTDATA(curr, unsigned int, SaveRDRAMSize);
     PUTARRAY(g_dev.pi.cart_rom.rom, curr, unsigned int, 0x40/4);
-    PUTDATA(curr, uint32_t, get_event(VI_INT) - cp0_regs[CP0_COUNT_REG]); // vi_timer
+    PUTDATA(curr, uint32_t, get_event(&g_dev.r4300.cp0.q, VI_INT) - cp0_regs[CP0_COUNT_REG]); // vi_timer
     PUTDATA(curr, uint32_t, *r4300_pc());
     PUTARRAY(r4300_regs(), curr, int64_t, 32);
     if ((cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // TODO not sure how pj64 handles this

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -591,7 +591,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     if ((cp0_regs[CP0_STATUS_REG] & UINT32_C(0x04000000)) == 0) // TODO not sure how pj64 handles this
         shuffle_fpr_data(UINT32_C(0x04000000), 0);
 
-    // Initialze the interupts
+    // Initialze the interrupts
     vi_timer += cp0_regs[CP0_COUNT_REG];
     *r4300_cp0_next_interrupt() = (cp0_regs[CP0_COMPARE_REG] < vi_timer)
                   ? cp0_regs[CP0_COMPARE_REG]

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -757,7 +757,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
           (g_dev.r4300.cp0.tlb.entries[i].mask << 12) + 0xFFF;
         g_dev.r4300.cp0.tlb.entries[i].phys_odd = g_dev.r4300.cp0.tlb.entries[i].pfn_odd << 12;
 
-        tlb_map(&g_dev.r4300.cp0.tlb.entries[i]);
+        tlb_map(&g_dev.r4300.cp0.tlb, i);
     }
 
     // pif ram

--- a/tools/savestate_convert.c
+++ b/tools/savestate_convert.c
@@ -84,7 +84,7 @@ char FCR31[4];
 char tlb_e[32][SIZE_TLB_ENTRY];
 char PCaddr[4];
 
-char next_interupt[4];
+char next_interrupt[4];
 char next_vi[4];
 char vi_field[4];
 
@@ -299,7 +299,7 @@ int load_original_mupen64(const char *filename)
     gzread(f, tlb_e[0], 32 * SIZE_TLB_ENTRY);
     gzread(f, PCaddr, 4);
 
-    gzread(f, next_interupt, 4);
+    gzread(f, next_interrupt, 4);
     gzread(f, next_vi, 4);
     gzread(f, vi_field, 4);
 
@@ -384,7 +384,7 @@ int save_newest(const char *filename)
     gzwrite(f, tlb_e[0], 32 * SIZE_TLB_ENTRY);
     gzwrite(f, PCaddr, 4);
 
-    gzwrite(f, next_interupt, 4);
+    gzwrite(f, next_interrupt, 4);
     gzwrite(f, next_vi, 4);
     gzwrite(f, vi_field, 4);
 


### PR DESCRIPTION
Small PR which avoids usage of the g_dev global variable inside TLB code.

This a small step toward a "g_dev free" emulation code. By that, I mean, emulation code (code residing inside the device directory or any of its subdirectory) should hopefully one day not rely directly on the global variable g_dev. But instead access this structure through pointers. At least, that's what I'm trying to do in the long term.