### PR TITLE
Fix excessive warnings when compiling using clang.

### DIFF
--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -64,12 +64,20 @@ static void nullf() {}
 #if ASSEM_DEBUG
     #define assem_debug(...) DebugMessage(M64MSG_VERBOSE, __VA_ARGS__)
 #else
+#ifdef __clang__
+    #define assem_debug(...)
+#else
     #define assem_debug nullf
+#endif
 #endif
 #if INV_DEBUG
     #define inv_debug(...) DebugMessage(M64MSG_VERBOSE, __VA_ARGS__)
 #else
+#ifdef __clang__
+    #define inv_debug(...)
+#else
     #define inv_debug nullf
+#endif
 #endif
 
 /* registers that may be allocated */


### PR DESCRIPTION
Just a couple of warning fixes. This generates a lot of output when building due to the amount those macros are used.