### PR TITLE
CountPerOp=3 for CBFD

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -2864,14 +2864,14 @@ GoodName=Conker's Bad Fur Day (E) [!]
 CRC=373F5889 9A6CA80A
 SaveType=Eeprom 16KB
 Players=4
-CountPerScanline=2200
+CountPerOp=3
 
 [00E2920665F2329B95797A7EAABC2390]
 GoodName=Conker's Bad Fur Day (U) [!]
 CRC=30C7AC50 7704072D
 SaveType=Eeprom 16KB
 Players=4
-CountPerScanline=2200
+CountPerOp=3
 
 [DB7A03B77D44DB81B8A3FCDFC4B72D8C]
 GoodName=Cruis'n Exotica (U) [!]


### PR DESCRIPTION
CountPerScanline=2200 was taken from looking at the Project64 RDB file. After a bit of testing it seems that CountPerOp=3 gives the best performance without any timing issues.