### PR TITLE
Restore old behavior when allocating memory for RDRAM

### DIFF
--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -97,7 +97,7 @@ EXPORT m64p_error CALL CoreStartup(int APIVersion, const char *ConfigPath, const
     /* allocate memory for rdram */
     disable_extra_mem = ConfigGetParamInt(g_CoreConfig, "DisableExtraMem");
     g_rdram_size = (disable_extra_mem == 0) ? 0x800000 : 0x400000;
-    g_rdram = malloc(g_rdram_size);
+    g_rdram = malloc(RDRAM_MAX_SIZE);
     if (g_rdram == NULL) {
         g_rdram_size = 0;
         return M64ERR_NO_MEMORY;


### PR DESCRIPTION
As seen in https://github.com/mupen64plus/mupen64plus-core/blob/b67105b031d51607305376175281078a45bff0c2/src/main/main.h#L48

Correct me if I'm wrong, but it seems like we always used to allocated the full RDRAM size even though the expansion pak was disabled. After the refactor we are allocating just enough.

This is causing a crash when loading and saving save states because we try to copy the full expansion pak size to and from the save state. This pull request fixes the crash.

This is the commit that broke it:
https://github.com/mupen64plus/mupen64plus-core/commit/99d489dbcc4396ff29a1461aff7a01db1ee2940a
