### PR TITLE
Get World Driver Championship booting

### DIFF
--- a/src/device/rsp/rsp_core.c
+++ b/src/device/rsp/rsp_core.c
@@ -40,7 +40,7 @@ static void dma_sp_write(struct rsp_core* sp)
     unsigned int length = ((l & 0xfff) | 7) + 1;
     unsigned int count = ((l >> 12) & 0xff) + 1;
     unsigned int skip = ((l >> 20) & 0xfff);
- 
+
     unsigned int memaddr = sp->regs[SP_MEM_ADDR_REG] & 0xfff;
     unsigned int dramaddr = sp->regs[SP_DRAM_ADDR_REG] & 0xffffff;
 
@@ -143,8 +143,8 @@ static void update_sp_status(struct rsp_core* sp, uint32_t w)
     if (w & 0x800000) sp->regs[SP_STATUS_REG] &= ~SP_STATUS_SIG7;
     if (w & 0x1000000) sp->regs[SP_STATUS_REG] |= SP_STATUS_SIG7;
 
-    //if (get_event(&sp->r4300->cp0.q, SP_INT)) return;
-    if (!(w & 0x1) && !(w & 0x4))
+    if (sp->rsp_task_locked && (get_event(&sp->r4300->cp0.q, SP_INT))) return;
+    if (!(w & 0x1) && !(w & 0x4) && !sp->rsp_task_locked)
         return;
 
     if (!(sp->regs[SP_STATUS_REG] & (SP_STATUS_HALT | SP_STATUS_BROKE)))
@@ -167,6 +167,7 @@ void poweron_rsp(struct rsp_core* sp)
     memset(sp->regs, 0, SP_REGS_COUNT*sizeof(uint32_t));
     memset(sp->regs2, 0, SP_REGS2_COUNT*sizeof(uint32_t));
 
+    sp->rsp_task_locked = 0;
     sp->regs[SP_STATUS_REG] = 1;
 }
 
@@ -284,6 +285,12 @@ void do_SP_Task(struct rsp_core* sp)
         new_frame();
 
         cp0_update_count();
+        sp->rsp_task_locked = 0;
+        if ((sp->regs[SP_STATUS_REG] & (SP_STATUS_HALT | SP_STATUS_BROKE)) == 0)
+        {
+            sp->rsp_task_locked = 1;
+            sp->r4300->mi.regs[MI_INTR_REG] |= MI_INTR_SP;
+        }
         if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP) {
             add_interrupt_event(&sp->r4300->cp0, SP_INT, 1000);
         }
@@ -305,6 +312,12 @@ void do_SP_Task(struct rsp_core* sp)
         sp->regs2[SP_PC_REG] |= save_pc;
 
         cp0_update_count();
+        sp->rsp_task_locked = 0;
+        if ((sp->regs[SP_STATUS_REG] & (SP_STATUS_HALT | SP_STATUS_BROKE)) == 0)
+        {
+            sp->rsp_task_locked = 1;
+            sp->r4300->mi.regs[MI_INTR_REG] |= MI_INTR_SP;
+        }
         if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP) {
             add_interrupt_event(&sp->r4300->cp0, SP_INT, 4000/*500*/);
         }
@@ -318,6 +331,12 @@ void do_SP_Task(struct rsp_core* sp)
         sp->regs2[SP_PC_REG] |= save_pc;
 
         cp0_update_count();
+        sp->rsp_task_locked = 0;
+        if ((sp->regs[SP_STATUS_REG] & (SP_STATUS_HALT | SP_STATUS_BROKE)) == 0)
+        {
+            sp->rsp_task_locked = 1;
+            sp->r4300->mi.regs[MI_INTR_REG] |= MI_INTR_SP;
+        }
         if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_SP) {
             add_interrupt_event(&sp->r4300->cp0, SP_INT, 0/*100*/);
         }
@@ -328,9 +347,12 @@ void do_SP_Task(struct rsp_core* sp)
 
 void rsp_interrupt_event(struct rsp_core* sp)
 {
-    /* XXX: assume task has fully completed */
-    sp->regs[SP_STATUS_REG] |=
-        SP_STATUS_TASKDONE | SP_STATUS_BROKE | SP_STATUS_HALT;
+    if(!sp->rsp_task_locked)
+    {
+        /* XXX: assume task has fully completed */
+        sp->regs[SP_STATUS_REG] |=
+            SP_STATUS_TASKDONE | SP_STATUS_BROKE | SP_STATUS_HALT;
+    }
 
     if ((sp->regs[SP_STATUS_REG] & SP_STATUS_INTR_BREAK) != 0)
     {

--- a/src/device/rsp/rsp_core.h
+++ b/src/device/rsp/rsp_core.h
@@ -79,6 +79,7 @@ struct rsp_core
     uint32_t mem[SP_MEM_SIZE/4];
     uint32_t regs[SP_REGS_COUNT];
     uint32_t regs2[SP_REGS2_COUNT];
+    uint32_t rsp_task_locked;
 
     struct r4300_core* r4300;
     struct rdp_core* dp;


### PR DESCRIPTION
This is not something that should be merged, but I figured since there was code involved a PR would be an easier place to look at it than an Issue. Plus it's awesome.

To boot WDC, you need to use rsp-cxd4 and enable "SupportCPUSemaphoreLock". That, plus this change, should allow WDC to boot. I assume it will also fix Stunt Racer 64 and similar games.

The graphics are messed up (polygons everywhere). I know nothing about how the N64 works or interrupts or anything. This is just the result of me messing around for the last 4-5 days based on things I had read from HatCat/cxd4, angrylion, etc..

I am hoping that this will be a good hint for people much smarter than me @richard42 @bsmiles32 @Gillou68310 @fzurita @cxd4 and that someone will be able to take it from here and get these games working properly.