### PR TITLE
Allow user-requested window position

### DIFF
--- a/src/api/vidext_sdl2_compat.h
+++ b/src/api/vidext_sdl2_compat.h
@@ -21,7 +21,7 @@
 
 #include <SDL_config.h>
 #include <SDL_surface.h>
-
+#include "main/main.h"
 #ifndef USE_GLES
 
 #ifndef SDL_VIDEO_OPENGL
@@ -375,8 +375,13 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags)
 {
     SDL_DisplayMode desktop_mode;
     int display = GetVideoDisplay();
-    int window_x = SDL_WINDOWPOS_UNDEFINED_DISPLAY(display);
-    int window_y = SDL_WINDOWPOS_UNDEFINED_DISPLAY(display);
+    int window_x = ConfigGetParamInt(g_CoreConfig, "ScreenPosX");
+    int window_y = ConfigGetParamInt(g_CoreConfig, "ScreenPosY");
+    if (window_x == -1 || window_y == -1)
+    {
+        window_x = SDL_WINDOWPOS_UNDEFINED_DISPLAY(display);
+        window_y = SDL_WINDOWPOS_UNDEFINED_DISPLAY(display);
+    }
     Uint32 window_flags;
     Uint32 surface_flags;
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -280,6 +280,9 @@ int main_set_core_defaults(void)
     ConfigSetDefaultInt(g_CoreConfig, "CountPerScanline", -1, "Modify the default count per scanline(-1 or 0=Game default)");
     ConfigSetDefaultBool(g_CoreConfig, "DisableSpecRecomp", 1, "Disable speculative precompilation in new dynarec");
 
+    ConfigSetDefaultInt(g_CoreConfig, "ScreenPosX", -1, "X position of window");
+    ConfigSetDefaultInt(g_CoreConfig, "ScreenPosY", -1, "Y position of window");
+
     /* handle upgrades */
     if (bUpgrade)
     {


### PR DESCRIPTION
Reads the two g_CoreConfig options ScreenPosX and ScreenPosY
Sets the final window to this position, or returns to the old behaviour if unset (checks for default values -1,-1)

I feel these changes are much less clean than the changes I made to ui-console to allow storing the options.
I also have no idea whether screen coordinates work the same way on all platforms, or whether there are other cases where these changes might lead to issues.

Finally they might fill a pretty niche need. For me it was spawning multiple instances at once and having them tiled out rather than all on top of each other.
My attempts to use external applications to move the windows when they were created were not as successful as this change was.

Remade request #259 as I had some issue with another pull request being mixed into it that I was not good enough at git to solve