### PR TITLE
Remove byte and hword accessors

### DIFF
--- a/projects/VisualStudio2013/mupen64plus-core.vcxproj
+++ b/projects/VisualStudio2013/mupen64plus-core.vcxproj
@@ -689,7 +689,7 @@
       <ImageHasSafeExceptionHandlers />
     </Link>
     <PreBuildEvent>
-      <Command>cl /c /Fo$(IntDir) /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SYMBOLS $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
+      <Command>cl /c /Fo$(IntDir) /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SUMMARY $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -714,7 +714,7 @@
       </ImageHasSafeExceptionHandlers>
     </Link>
     <PreBuildEvent>
-      <Command>cl /c /Fo$(IntDir) /D "__x86_64__" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SYMBOLS $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
+      <Command>cl /c /Fo$(IntDir) /D "__x86_64__" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SUMMARY $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">
@@ -745,7 +745,7 @@
     <PreBuildEvent>
       <Message>
       </Message>
-      <Command>cl /c /Fo$(IntDir) /D "NEW_DYNAREC=1" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SYMBOLS $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
+      <Command>cl /c /Fo$(IntDir) /D "NEW_DYNAREC=1" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SUMMARY $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|x64'">
@@ -772,7 +772,7 @@
       </ImageHasSafeExceptionHandlers>
     </Link>
     <PreBuildEvent>
-      <Command>cl /c /Fo$(IntDir) /D "__x86_64__" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SYMBOLS $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
+      <Command>cl /c /Fo$(IntDir) /D "__x86_64__" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SUMMARY $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -796,7 +796,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cl /c /Fo$(IntDir) /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SYMBOLS $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
+      <Command>cl /c /Fo$(IntDir) /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SUMMARY $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -819,7 +819,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <PreBuildEvent>
-      <Command>cl /c /Fo$(IntDir) /D "__x86_64__" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SYMBOLS $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
+      <Command>cl /c /Fo$(IntDir) /D "__x86_64__" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SUMMARY $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">
@@ -843,7 +843,7 @@
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cl /c /Fo$(IntDir) /D "NEW_DYNAREC=1" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SYMBOLS $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
+      <Command>cl /c /Fo$(IntDir) /D "NEW_DYNAREC=1" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SUMMARY $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|x64'">
@@ -866,7 +866,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <PreBuildEvent>
-      <Command>cl /c /Fo$(IntDir) /D "__x86_64__" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SYMBOLS $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
+      <Command>cl /c /Fo$(IntDir) /D "__x86_64__" /I ..\..\src ..\..\src\asm_defines\asm_defines.c &amp; dumpbin.exe /SUMMARY $(IntDir)asm_defines.obj | "..\..\..\mupen64plus-win32-deps\gawk-3.1.6-1\bin\gawk.exe" -v dest_dir="../../src/asm_defines" -f ..\..\tools\gen_asm_defines.awk</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/projects/VisualStudio2013/mupen64plus-core.vcxproj.filters
+++ b/projects/VisualStudio2013/mupen64plus-core.vcxproj.filters
@@ -360,6 +360,9 @@
     <ClCompile Include="..\..\src\device\si\transferpak.c">
       <Filter>device\si</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\device\r4300\x86_64\dynarec.c">
+      <Filter>device\r4300\x86_64</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\device\ai\ai_controller.h">

--- a/src/asm_defines/asm_defines.c
+++ b/src/asm_defines/asm_defines.c
@@ -42,7 +42,14 @@
  * The plus one in size is to avoid the creation of zero sized array (which are illegal in C).
  * We need to subtract one in objects symbols sizes to get the correct value.
  */
+
+#ifdef _MSC_VER
+#define _DEFINE(sym, val) \
+    __pragma(const_seg(#sym)) \
+    const char sym[1+val];
+#else
 #define _DEFINE(sym, val) const char sym[1+val];
+#endif
 
 /* Export member m of structure s.
  * Suitable parsing of corresponding object file (objdump/dumpbin/awk)
@@ -101,6 +108,12 @@ DEFINE(tlb, LUT_w);
 
 DEFINE(r4300_core, cached_interp);
 DEFINE(cached_interp, invalid_code);
+
+DEFINE(device, mem);
+DEFINE(memory, readmem);
+DEFINE(memory, readmemd);
+DEFINE(memory, writemem);
+DEFINE(memory, writememd);
 
 #ifdef NEW_DYNAREC
 DEFINE(r4300_core, new_dynarec_hot_state);

--- a/src/asm_defines/asm_defines.c
+++ b/src/asm_defines/asm_defines.c
@@ -79,7 +79,6 @@ DEFINE(r4300_core, return_address);
 
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
 /* ARM dynarec uses a different memory layout */
-DEFINE(r4300_core, whword);
 DEFINE(r4300_core, wword);
 DEFINE(r4300_core, wdword);
 DEFINE(r4300_core, wmask);
@@ -131,7 +130,6 @@ DEFINE(new_dynarec_hot_state, rdword);
 DEFINE(new_dynarec_hot_state, wmask);
 DEFINE(new_dynarec_hot_state, wdword);
 DEFINE(new_dynarec_hot_state, wword);
-DEFINE(new_dynarec_hot_state, whword);
 DEFINE(new_dynarec_hot_state, fcr0);
 DEFINE(new_dynarec_hot_state, fcr31);
 DEFINE(new_dynarec_hot_state, regs);

--- a/src/asm_defines/asm_defines.c
+++ b/src/asm_defines/asm_defines.c
@@ -83,6 +83,7 @@ DEFINE(r4300_core, wbyte);
 DEFINE(r4300_core, whword);
 DEFINE(r4300_core, wword);
 DEFINE(r4300_core, wdword);
+DEFINE(r4300_core, wmask);
 DEFINE(r4300_core, address);
 #endif
 
@@ -128,6 +129,7 @@ DEFINE(new_dynarec_hot_state, stop);
 DEFINE(new_dynarec_hot_state, invc_ptr);
 DEFINE(new_dynarec_hot_state, address);
 DEFINE(new_dynarec_hot_state, rdword);
+DEFINE(new_dynarec_hot_state, wmask);
 DEFINE(new_dynarec_hot_state, wdword);
 DEFINE(new_dynarec_hot_state, wword);
 DEFINE(new_dynarec_hot_state, whword);

--- a/src/asm_defines/asm_defines.c
+++ b/src/asm_defines/asm_defines.c
@@ -79,7 +79,6 @@ DEFINE(r4300_core, return_address);
 
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
 /* ARM dynarec uses a different memory layout */
-DEFINE(r4300_core, wbyte);
 DEFINE(r4300_core, whword);
 DEFINE(r4300_core, wword);
 DEFINE(r4300_core, wdword);
@@ -133,7 +132,6 @@ DEFINE(new_dynarec_hot_state, wmask);
 DEFINE(new_dynarec_hot_state, wdword);
 DEFINE(new_dynarec_hot_state, wword);
 DEFINE(new_dynarec_hot_state, whword);
-DEFINE(new_dynarec_hot_state, wbyte);
 DEFINE(new_dynarec_hot_state, fcr0);
 DEFINE(new_dynarec_hot_state, fcr31);
 DEFINE(new_dynarec_hot_state, regs);

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -99,15 +99,6 @@ static int readd(readfn read_word, void* opaque, uint32_t address, uint64_t* val
     return result;
 }
 
-static int writeb(writefn write_word, void* opaque, uint32_t address, uint8_t value)
-{
-    unsigned int shift = bshift(address);
-    uint32_t w = (uint32_t)value << shift;
-    uint32_t mask = (uint32_t)0xff << shift;
-
-    return write_word(opaque, address, w, mask);
-}
-
 static int writeh(writefn write_word, void* opaque, uint32_t address, uint16_t value)
 {
     unsigned int shift = hshift(address);
@@ -153,10 +144,6 @@ static void read_nothingd(void)
 }
 
 static void write_nothing(void)
-{
-}
-
-static void write_nothingb(void)
 {
 }
 
@@ -214,16 +201,6 @@ static void write_nomem(void)
     write_word_in_memory();
 }
 
-static void write_nomemb(void)
-{
-    struct r4300_core* r4300 = &g_dev.r4300;
-
-    invalidate_r4300_cached_code(r4300, *r4300_address(r4300), 1);
-    *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),1);
-    if (*r4300_address(r4300) == 0x00000000) return;
-    r4300->mem->writememb[*r4300_address(r4300)>>16]();
-}
-
 static void write_nomemh(void)
 {
     struct r4300_core* r4300 = &g_dev.r4300;
@@ -270,11 +247,6 @@ void write_rdram(void)
     writew(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-void write_rdramb(void)
-{
-    writeb(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 void write_rdramh(void)
 {
     writeh(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -309,11 +281,6 @@ void read_rdramFBd(void)
 void write_rdramFB(void)
 {
     writew(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-void write_rdramFBb(void)
-{
-    writeb(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
 }
 
 void write_rdramFBh(void)
@@ -352,11 +319,6 @@ static void write_rdramreg(void)
     writew(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_rdramregb(void)
-{
-    writeb(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 static void write_rdramregh(void)
 {
     writeh(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -391,11 +353,6 @@ static void read_rspmemd(void)
 static void write_rspmem(void)
 {
     writew(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rspmemb(void)
-{
-    writeb(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
 }
 
 static void write_rspmemh(void)
@@ -434,11 +391,6 @@ static void write_rspreg(void)
     writew(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_rspregb(void)
-{
-    writeb(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 static void write_rspregh(void)
 {
     writeh(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -473,11 +425,6 @@ static void read_rspreg2d(void)
 static void write_rspreg2(void)
 {
     writew(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rspreg2b(void)
-{
-    writeb(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
 }
 
 static void write_rspreg2h(void)
@@ -516,11 +463,6 @@ static void write_dp(void)
     writew(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_dpb(void)
-{
-    writeb(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 static void write_dph(void)
 {
     writeh(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -555,11 +497,6 @@ static void read_dpsd(void)
 static void write_dps(void)
 {
     writew(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_dpsb(void)
-{
-    writeb(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
 }
 
 static void write_dpsh(void)
@@ -598,11 +535,6 @@ void write_mi(void)
     writew(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-void write_mib(void)
-{
-    writeb(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 void write_mih(void)
 {
     writeh(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -637,11 +569,6 @@ static void read_vid(void)
 static void write_vi(void)
 {
     writew(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_vib(void)
-{
-    writeb(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
 }
 
 static void write_vih(void)
@@ -680,11 +607,6 @@ static void write_ai(void)
     writew(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_aib(void)
-{
-    writeb(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 static void write_aih(void)
 {
     writeh(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -719,11 +641,6 @@ static void read_pid(void)
 static void write_pi(void)
 {
     writew(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_pib(void)
-{
-    writeb(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
 }
 
 static void write_pih(void)
@@ -762,11 +679,6 @@ static void write_ri(void)
     writew(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_rib(void)
-{
-    writeb(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 static void write_rih(void)
 {
     writeh(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -803,11 +715,6 @@ static void write_si(void)
     writew(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_sib(void)
-{
-    writeb(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 static void write_sih(void)
 {
     writeh(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -841,11 +748,6 @@ static void read_pi_flashram_statusd(void)
 static void write_pi_flashram_command(void)
 {
     writew(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_pi_flashram_commandb(void)
-{
-    writeb(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
 }
 
 static void write_pi_flashram_commandh(void)
@@ -910,11 +812,6 @@ static void write_pif(void)
     writew(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_pifb(void)
-{
-    writeb(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 static void write_pifh(void)
 {
     writeh(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -967,11 +864,6 @@ static void write_dd(void)
     writew(write_dd_regs, NULL, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_ddb(void)
-{
-    writeb(write_dd_regs, NULL, *r4300_address(&g_dev.r4300), *r4300_wbyte(&g_dev.r4300));
-}
-
 static void write_ddh(void)
 {
     writeh(write_dd_regs, NULL, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
@@ -1013,14 +905,6 @@ static void readmemd_with_bp_checks(void)
             M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ);
 
     g_dev.mem.saved_readmemd[*r4300_address(&g_dev.r4300)>>16]();
-}
-
-static void writememb_with_bp_checks(void)
-{
-    check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 1,
-            M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE);
-
-    return g_dev.mem.saved_writememb[*r4300_address(&g_dev.r4300)>>16]();
 }
 
 static void writememh_with_bp_checks(void)
@@ -1087,11 +971,9 @@ void activate_memory_break_write(struct memory* mem, uint32_t address)
 
     if (mem->saved_writemem[region] == NULL)
     {
-        mem->saved_writememb[region] = mem->writememb[region];
         mem->saved_writememh[region] = mem->writememh[region];
         mem->saved_writemem [region] = mem->writemem [region];
         mem->saved_writememd[region] = mem->writememd[region];
-        mem->writememb[region] = writememb_with_bp_checks;
         mem->writememh[region] = writememh_with_bp_checks;
         mem->writemem [region] = writemem_with_bp_checks;
         mem->writememd[region] = writememd_with_bp_checks;
@@ -1104,11 +986,9 @@ void deactivate_memory_break_write(struct memory* mem, uint32_t address)
 
     if (mem->saved_writemem[region] != NULL)
     {
-        mem->writememb[region] = mem->saved_writememb[region];
         mem->writememh[region] = mem->saved_writememh[region];
         mem->writemem [region] = mem->saved_writemem [region];
         mem->writememd[region] = mem->saved_writememd[region];
-        mem->saved_writememb[region] = NULL;
         mem->saved_writememh[region] = NULL;
         mem->saved_writemem [region] = NULL;
         mem->saved_writememd[region] = NULL;
@@ -1122,7 +1002,7 @@ int get_memory_type(struct memory* mem, uint32_t address)
 #endif
 
 #define R(x) read_ ## x ## b, read_ ## x ## h, read_ ## x, read_ ## x ## d
-#define W(x) write_ ## x ## b, write_ ## x ## h, write_ ## x, write_ ## x ## d
+#define W(x) write_ ## x ## h, write_ ## x, write_ ## x ## d
 #define RW(x) R(x), W(x)
 
 void poweron_memory(struct memory* mem)
@@ -1285,7 +1165,7 @@ void poweron_memory(struct memory* mem)
     {
         map_region(mem, 0x9000+i, M64P_MEM_ROM, R(rom), W(nothing));
         map_region(mem, 0xb000+i, M64P_MEM_ROM, R(rom),
-                   write_nothingb, write_nothingh, write_rom, write_nothingd);
+                   write_nothingh, write_rom, write_nothingd);
     }
     for(i = (g_dev.pi.cart_rom.rom_size >> 16); i < 0xfc0; ++i)
     {
@@ -1345,7 +1225,6 @@ static void map_region_r(struct memory* mem,
 
 static void map_region_w(struct memory* mem,
         uint16_t region,
-        void (*write8)(void),
         void (*write16)(void),
         void (*write32)(void),
         void (*write64)(void))
@@ -1354,11 +1233,9 @@ static void map_region_w(struct memory* mem,
     if (lookup_breakpoint(((uint32_t)region << 16), 0x10000,
                           M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) != -1)
     {
-        mem->saved_writememb[region] = write8;
         mem->saved_writememh[region] = write16;
         mem->saved_writemem [region] = write32;
         mem->saved_writememd[region] = write64;
-        mem->writememb[region] = writememb_with_bp_checks;
         mem->writememh[region] = writememh_with_bp_checks;
         mem->writemem [region] = writemem_with_bp_checks;
         mem->writememd[region] = writememd_with_bp_checks;
@@ -1366,7 +1243,6 @@ static void map_region_w(struct memory* mem,
     else
 #endif
     {
-        mem->writememb[region] = write8;
         mem->writememh[region] = write16;
         mem->writemem [region] = write32;
         mem->writememd[region] = write64;
@@ -1380,14 +1256,13 @@ void map_region(struct memory* mem,
                 void (*read16)(void),
                 void (*read32)(void),
                 void (*read64)(void),
-                void (*write8)(void),
                 void (*write16)(void),
                 void (*write32)(void),
                 void (*write64)(void))
 {
     map_region_t(mem, region, type);
     map_region_r(mem, region, read8, read16, read32, read64);
-    map_region_w(mem, region, write8, write16, write32, write64);
+    map_region_w(mem, region, write16, write32, write64);
 }
 
 uint32_t *fast_mem_access(uint32_t address)

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -49,24 +49,9 @@ typedef int (*readfn)(void*,uint32_t,uint32_t*);
 typedef int (*writefn)(void*,uint32_t,uint32_t,uint32_t);
 
 
-static unsigned int bshift(uint32_t address)
-{
-    return ((address & 3) ^ 3) << 3;
-}
-
 static unsigned int hshift(uint32_t address)
 {
     return ((address & 2) ^ 2) << 3;
-}
-
-static int readb(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
-{
-    uint32_t w;
-    unsigned shift = bshift(address);
-    int result = read_word(opaque, address, &w);
-    *value = (w >> shift) & 0xff;
-
-    return result;
 }
 
 static int readh(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
@@ -119,11 +104,6 @@ static void read_nothing(void)
     *g_dev.r4300.rdword = 0;
 }
 
-static void read_nothingb(void)
-{
-    *g_dev.r4300.rdword = 0;
-}
-
 static void read_nothingh(void)
 {
     *g_dev.r4300.rdword = 0;
@@ -149,15 +129,6 @@ static void read_nomem(void)
     *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300), 0);
     if (*r4300_address(r4300) == 0x00000000) return;
     read_word_in_memory();
-}
-
-static void read_nomemb(void)
-{
-    struct r4300_core* r4300 = &g_dev.r4300;
-
-    *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),0);
-    if (*r4300_address(r4300) == 0x00000000) return;
-    read_byte_in_memory();
 }
 
 static void read_nomemh(void)
@@ -204,11 +175,6 @@ void read_rdram(void)
     readw(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-void read_rdramb(void)
-{
-    readb(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 void read_rdramh(void)
 {
     readh(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -233,11 +199,6 @@ void write_rdramd(void)
 void read_rdramFB(void)
 {
     readw(read_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-void read_rdramFBb(void)
-{
-    readb(read_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 void read_rdramFBh(void)
@@ -266,11 +227,6 @@ static void read_rdramreg(void)
     readw(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rdramregb(void)
-{
-    readb(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_rdramregh(void)
 {
     readh(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -295,11 +251,6 @@ static void write_rdramregd(void)
 static void read_rspmem(void)
 {
     readw(read_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_rspmemb(void)
-{
-    readb(read_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_rspmemh(void)
@@ -328,11 +279,6 @@ static void read_rspreg(void)
     readw(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rspregb(void)
-{
-    readb(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_rspregh(void)
 {
     readh(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -357,11 +303,6 @@ static void write_rspregd(void)
 static void read_rspreg2(void)
 {
     readw(read_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_rspreg2b(void)
-{
-    readb(read_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_rspreg2h(void)
@@ -390,11 +331,6 @@ static void read_dp(void)
     readw(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_dpb(void)
-{
-    readb(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_dph(void)
 {
     readh(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -419,11 +355,6 @@ static void write_dpd(void)
 static void read_dps(void)
 {
     readw(read_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_dpsb(void)
-{
-    readb(read_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_dpsh(void)
@@ -452,11 +383,6 @@ static void read_mi(void)
     readw(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_mib(void)
-{
-    readb(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_mih(void)
 {
     readh(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -481,11 +407,6 @@ void write_mid(void)
 static void read_vi(void)
 {
     readw(read_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_vib(void)
-{
-    readb(read_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_vih(void)
@@ -514,11 +435,6 @@ static void read_ai(void)
     readw(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_aib(void)
-{
-    readb(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_aih(void)
 {
     readh(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -543,11 +459,6 @@ static void write_aid(void)
 static void read_pi(void)
 {
     readw(read_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_pib(void)
-{
-    readb(read_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_pih(void)
@@ -576,11 +487,6 @@ static void read_ri(void)
     readw(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rib(void)
-{
-    readb(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_rih(void)
 {
     readh(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -607,11 +513,6 @@ static void read_si(void)
     readw(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_sib(void)
-{
-    readb(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_sih(void)
 {
     readh(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -635,11 +536,6 @@ static void write_sid(void)
 static void read_pi_flashram_status(void)
 {
     readw(read_flashram_status, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_pi_flashram_statusb(void)
-{
-    readb(read_flashram_status, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_pi_flashram_statush(void)
@@ -668,11 +564,6 @@ static void read_rom(void)
     readw(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_romb(void)
-{
-    readb(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_romh(void)
 {
     readh(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -692,11 +583,6 @@ static void write_rom(void)
 static void read_pif(void)
 {
     readw(read_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_pifb(void)
-{
-    readb(read_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_pifh(void)
@@ -741,11 +627,6 @@ static void read_dd(void)
     readw(read_dd_regs, NULL, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_ddb(void)
-{
-    readb(read_dd_regs, NULL, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_ddh(void)
 {
     readh(read_dd_regs, NULL, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -767,14 +648,6 @@ static void write_ddd(void)
 }
 
 #ifdef DBG
-static void readmemb_with_bp_checks(void)
-{
-    check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 1,
-            M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ);
-
-    g_dev.mem.saved_readmemb[*r4300_address(&g_dev.r4300)>>16]();
-}
-
 static void readmemh_with_bp_checks(void)
 {
     check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 2,
@@ -821,11 +694,9 @@ void activate_memory_break_read(struct memory* mem, uint32_t address)
 
     if (mem->saved_readmem[region] == NULL)
     {
-        mem->saved_readmemb[region] = mem->readmemb[region];
         mem->saved_readmemh[region] = mem->readmemh[region];
         mem->saved_readmem [region] = mem->readmem [region];
         mem->saved_readmemd[region] = mem->readmemd[region];
-        mem->readmemb[region] = readmemb_with_bp_checks;
         mem->readmemh[region] = readmemh_with_bp_checks;
         mem->readmem [region] = readmem_with_bp_checks;
         mem->readmemd[region] = readmemd_with_bp_checks;
@@ -838,11 +709,9 @@ void deactivate_memory_break_read(struct memory* mem, uint32_t address)
 
     if (mem->saved_readmem[region] != NULL)
     {
-        mem->readmemb[region] = mem->saved_readmemb[region];
         mem->readmemh[region] = mem->saved_readmemh[region];
         mem->readmem [region] = mem->saved_readmem [region];
         mem->readmemd[region] = mem->saved_readmemd[region];
-        mem->saved_readmemb[region] = NULL;
         mem->saved_readmemh[region] = NULL;
         mem->saved_readmem [region] = NULL;
         mem->saved_readmemd[region] = NULL;
@@ -881,7 +750,7 @@ int get_memory_type(struct memory* mem, uint32_t address)
 }
 #endif
 
-#define R(x) read_ ## x ## b, read_ ## x ## h, read_ ## x, read_ ## x ## d
+#define R(x) read_ ## x ## h, read_ ## x, read_ ## x ## d
 #define W(x) write_ ## x, write_ ## x ## d
 #define RW(x) R(x), W(x)
 
@@ -1075,7 +944,6 @@ static void map_region_t(struct memory* mem, uint16_t region, int type)
 
 static void map_region_r(struct memory* mem,
         uint16_t region,
-        void (*read8)(void),
         void (*read16)(void),
         void (*read32)(void),
         void (*read64)(void))
@@ -1084,11 +952,9 @@ static void map_region_r(struct memory* mem,
     if (lookup_breakpoint(((uint32_t)region << 16), 0x10000,
                           M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) != -1)
     {
-        mem->saved_readmemb[region] = read8;
         mem->saved_readmemh[region] = read16;
         mem->saved_readmem [region] = read32;
         mem->saved_readmemd[region] = read64;
-        mem->readmemb[region] = readmemb_with_bp_checks;
         mem->readmemh[region] = readmemh_with_bp_checks;
         mem->readmem [region] = readmem_with_bp_checks;
         mem->readmemd[region] = readmemd_with_bp_checks;
@@ -1096,7 +962,6 @@ static void map_region_r(struct memory* mem,
     else
 #endif
     {
-        mem->readmemb[region] = read8;
         mem->readmemh[region] = read16;
         mem->readmem [region] = read32;
         mem->readmemd[region] = read64;
@@ -1128,7 +993,6 @@ static void map_region_w(struct memory* mem,
 void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
-                void (*read8)(void),
                 void (*read16)(void),
                 void (*read32)(void),
                 void (*read64)(void),
@@ -1136,7 +1000,7 @@ void map_region(struct memory* mem,
                 void (*write64)(void))
 {
     map_region_t(mem, region, type);
-    map_region_r(mem, region, read8, read16, read32, read64);
+    map_region_r(mem, region, read16, read32, read64);
     map_region_w(mem, region, write32, write64);
 }
 

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -117,9 +117,9 @@ static int writeh(writefn write_word, void* opaque, uint32_t address, uint16_t v
     return write_word(opaque, address, w, mask);
 }
 
-static int writew(writefn write_word, void* opaque, uint32_t address, uint32_t value)
+static int writew(writefn write_word, void* opaque, uint32_t address, uint32_t value, uint32_t wmask)
 {
-    return write_word(opaque, address, value, ~0U);
+    return write_word(opaque, address, value, wmask);
 }
 
 static int writed(writefn write_word, void* opaque, uint32_t address, uint64_t value)
@@ -267,7 +267,7 @@ void read_rdramd(void)
 
 void write_rdram(void)
 {
-    writew(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 void write_rdramb(void)
@@ -308,7 +308,7 @@ void read_rdramFBd(void)
 
 void write_rdramFB(void)
 {
-    writew(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 void write_rdramFBb(void)
@@ -349,7 +349,7 @@ static void read_rdramregd(void)
 
 static void write_rdramreg(void)
 {
-    writew(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_rdramregb(void)
@@ -390,7 +390,7 @@ static void read_rspmemd(void)
 
 static void write_rspmem(void)
 {
-    writew(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_rspmemb(void)
@@ -431,7 +431,7 @@ static void read_rspregd(void)
 
 static void write_rspreg(void)
 {
-    writew(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_rspregb(void)
@@ -472,7 +472,7 @@ static void read_rspreg2d(void)
 
 static void write_rspreg2(void)
 {
-    writew(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_rspreg2b(void)
@@ -513,7 +513,7 @@ static void read_dpd(void)
 
 static void write_dp(void)
 {
-    writew(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_dpb(void)
@@ -554,7 +554,7 @@ static void read_dpsd(void)
 
 static void write_dps(void)
 {
-    writew(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_dpsb(void)
@@ -595,7 +595,7 @@ static void read_mid(void)
 
 void write_mi(void)
 {
-    writew(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 void write_mib(void)
@@ -636,7 +636,7 @@ static void read_vid(void)
 
 static void write_vi(void)
 {
-    writew(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_vib(void)
@@ -677,7 +677,7 @@ static void read_aid(void)
 
 static void write_ai(void)
 {
-    writew(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_aib(void)
@@ -718,7 +718,7 @@ static void read_pid(void)
 
 static void write_pi(void)
 {
-    writew(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_pib(void)
@@ -759,7 +759,7 @@ static void read_rid(void)
 
 static void write_ri(void)
 {
-    writew(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_rib(void)
@@ -800,7 +800,7 @@ static void read_sid(void)
 
 static void write_si(void)
 {
-    writew(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_sib(void)
@@ -840,7 +840,7 @@ static void read_pi_flashram_statusd(void)
 
 static void write_pi_flashram_command(void)
 {
-    writew(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_pi_flashram_commandb(void)
@@ -881,7 +881,7 @@ static void read_romd(void)
 
 static void write_rom(void)
 {
-    writew(write_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
@@ -907,7 +907,7 @@ static void read_pifd(void)
 
 static void write_pif(void)
 {
-    writew(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_pifb(void)
@@ -964,7 +964,7 @@ static void read_ddd(void)
 
 static void write_dd(void)
 {
-    writew(write_dd_regs, NULL, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300));
+    writew(write_dd_regs, NULL, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void write_ddb(void)

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -99,15 +99,6 @@ static int readd(readfn read_word, void* opaque, uint32_t address, uint64_t* val
     return result;
 }
 
-static int writeh(writefn write_word, void* opaque, uint32_t address, uint16_t value)
-{
-    unsigned int shift = hshift(address);
-    uint32_t w = (uint32_t)value << shift;
-    uint32_t mask = (uint32_t)0xffff << shift;
-
-    return write_word(opaque, address, w, mask);
-}
-
 static int writew(writefn write_word, void* opaque, uint32_t address, uint32_t value, uint32_t wmask)
 {
     return write_word(opaque, address, value, wmask);
@@ -144,10 +135,6 @@ static void read_nothingd(void)
 }
 
 static void write_nothing(void)
-{
-}
-
-static void write_nothingh(void)
 {
 }
 
@@ -201,16 +188,6 @@ static void write_nomem(void)
     write_word_in_memory();
 }
 
-static void write_nomemh(void)
-{
-    struct r4300_core* r4300 = &g_dev.r4300;
-
-    invalidate_r4300_cached_code(r4300, *r4300_address(r4300), 2);
-    *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),1);
-    if (*r4300_address(r4300) == 0x00000000) return;
-    write_hword_in_memory();
-}
-
 static void write_nomemd(void)
 {
     struct r4300_core* r4300 = &g_dev.r4300;
@@ -247,11 +224,6 @@ void write_rdram(void)
     writew(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-void write_rdramh(void)
-{
-    writeh(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 void write_rdramd(void)
 {
     writed(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -281,11 +253,6 @@ void read_rdramFBd(void)
 void write_rdramFB(void)
 {
     writew(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-void write_rdramFBh(void)
-{
-    writeh(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
 }
 
 void write_rdramFBd(void)
@@ -319,11 +286,6 @@ static void write_rdramreg(void)
     writew(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_rdramregh(void)
-{
-    writeh(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 static void write_rdramregd(void)
 {
     writed(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -353,11 +315,6 @@ static void read_rspmemd(void)
 static void write_rspmem(void)
 {
     writew(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rspmemh(void)
-{
-    writeh(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
 }
 
 static void write_rspmemd(void)
@@ -391,11 +348,6 @@ static void write_rspreg(void)
     writew(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_rspregh(void)
-{
-    writeh(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 static void write_rspregd(void)
 {
     writed(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -425,11 +377,6 @@ static void read_rspreg2d(void)
 static void write_rspreg2(void)
 {
     writew(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rspreg2h(void)
-{
-    writeh(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
 }
 
 static void write_rspreg2d(void)
@@ -463,11 +410,6 @@ static void write_dp(void)
     writew(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_dph(void)
-{
-    writeh(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 static void write_dpd(void)
 {
     writed(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -497,11 +439,6 @@ static void read_dpsd(void)
 static void write_dps(void)
 {
     writew(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_dpsh(void)
-{
-    writeh(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
 }
 
 static void write_dpsd(void)
@@ -535,11 +472,6 @@ void write_mi(void)
     writew(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-void write_mih(void)
-{
-    writeh(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 void write_mid(void)
 {
     writed(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -569,11 +501,6 @@ static void read_vid(void)
 static void write_vi(void)
 {
     writew(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_vih(void)
-{
-    writeh(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
 }
 
 static void write_vid(void)
@@ -607,11 +534,6 @@ static void write_ai(void)
     writew(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_aih(void)
-{
-    writeh(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 static void write_aid(void)
 {
     writed(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -641,11 +563,6 @@ static void read_pid(void)
 static void write_pi(void)
 {
     writew(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_pih(void)
-{
-    writeh(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
 }
 
 static void write_pid(void)
@@ -679,11 +596,6 @@ static void write_ri(void)
     writew(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_rih(void)
-{
-    writeh(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 static void write_rid(void)
 {
     writed(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -715,11 +627,6 @@ static void write_si(void)
     writew(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_sih(void)
-{
-    writeh(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 static void write_sid(void)
 {
     writed(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -748,11 +655,6 @@ static void read_pi_flashram_statusd(void)
 static void write_pi_flashram_command(void)
 {
     writew(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_pi_flashram_commandh(void)
-{
-    writeh(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
 }
 
 static void write_pi_flashram_commandd(void)
@@ -812,11 +714,6 @@ static void write_pif(void)
     writew(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_pifh(void)
-{
-    writeh(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 static void write_pifd(void)
 {
     writed(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -864,11 +761,6 @@ static void write_dd(void)
     writew(write_dd_regs, NULL, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
-static void write_ddh(void)
-{
-    writeh(write_dd_regs, NULL, *r4300_address(&g_dev.r4300), *r4300_whword(&g_dev.r4300));
-}
-
 static void write_ddd(void)
 {
     writed(write_dd_regs, NULL, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
@@ -905,14 +797,6 @@ static void readmemd_with_bp_checks(void)
             M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ);
 
     g_dev.mem.saved_readmemd[*r4300_address(&g_dev.r4300)>>16]();
-}
-
-static void writememh_with_bp_checks(void)
-{
-    check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 2,
-            M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE);
-
-    return g_dev.mem.saved_writememh[*r4300_address(&g_dev.r4300)>>16]();
 }
 
 static void writemem_with_bp_checks(void)
@@ -971,10 +855,8 @@ void activate_memory_break_write(struct memory* mem, uint32_t address)
 
     if (mem->saved_writemem[region] == NULL)
     {
-        mem->saved_writememh[region] = mem->writememh[region];
         mem->saved_writemem [region] = mem->writemem [region];
         mem->saved_writememd[region] = mem->writememd[region];
-        mem->writememh[region] = writememh_with_bp_checks;
         mem->writemem [region] = writemem_with_bp_checks;
         mem->writememd[region] = writememd_with_bp_checks;
     }
@@ -986,10 +868,8 @@ void deactivate_memory_break_write(struct memory* mem, uint32_t address)
 
     if (mem->saved_writemem[region] != NULL)
     {
-        mem->writememh[region] = mem->saved_writememh[region];
         mem->writemem [region] = mem->saved_writemem [region];
         mem->writememd[region] = mem->saved_writememd[region];
-        mem->saved_writememh[region] = NULL;
         mem->saved_writemem [region] = NULL;
         mem->saved_writememd[region] = NULL;
     }
@@ -1002,7 +882,7 @@ int get_memory_type(struct memory* mem, uint32_t address)
 #endif
 
 #define R(x) read_ ## x ## b, read_ ## x ## h, read_ ## x, read_ ## x ## d
-#define W(x) write_ ## x ## h, write_ ## x, write_ ## x ## d
+#define W(x) write_ ## x, write_ ## x ## d
 #define RW(x) R(x), W(x)
 
 void poweron_memory(struct memory* mem)
@@ -1165,7 +1045,7 @@ void poweron_memory(struct memory* mem)
     {
         map_region(mem, 0x9000+i, M64P_MEM_ROM, R(rom), W(nothing));
         map_region(mem, 0xb000+i, M64P_MEM_ROM, R(rom),
-                   write_nothingh, write_rom, write_nothingd);
+                   write_rom, write_nothingd);
     }
     for(i = (g_dev.pi.cart_rom.rom_size >> 16); i < 0xfc0; ++i)
     {
@@ -1225,7 +1105,6 @@ static void map_region_r(struct memory* mem,
 
 static void map_region_w(struct memory* mem,
         uint16_t region,
-        void (*write16)(void),
         void (*write32)(void),
         void (*write64)(void))
 {
@@ -1233,17 +1112,14 @@ static void map_region_w(struct memory* mem,
     if (lookup_breakpoint(((uint32_t)region << 16), 0x10000,
                           M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) != -1)
     {
-        mem->saved_writememh[region] = write16;
         mem->saved_writemem [region] = write32;
         mem->saved_writememd[region] = write64;
-        mem->writememh[region] = writememh_with_bp_checks;
         mem->writemem [region] = writemem_with_bp_checks;
         mem->writememd[region] = writememd_with_bp_checks;
     }
     else
 #endif
     {
-        mem->writememh[region] = write16;
         mem->writemem [region] = write32;
         mem->writememd[region] = write64;
     }
@@ -1256,13 +1132,12 @@ void map_region(struct memory* mem,
                 void (*read16)(void),
                 void (*read32)(void),
                 void (*read64)(void),
-                void (*write16)(void),
                 void (*write32)(void),
                 void (*write64)(void))
 {
     map_region_t(mem, region, type);
     map_region_r(mem, region, read8, read16, read32, read64);
-    map_region_w(mem, region, write16, write32, write64);
+    map_region_w(mem, region, write32, write64);
 }
 
 uint32_t *fast_mem_access(uint32_t address)

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -49,21 +49,6 @@ typedef int (*readfn)(void*,uint32_t,uint32_t*);
 typedef int (*writefn)(void*,uint32_t,uint32_t,uint32_t);
 
 
-static unsigned int hshift(uint32_t address)
-{
-    return ((address & 2) ^ 2) << 3;
-}
-
-static int readh(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
-{
-    uint32_t w;
-    unsigned shift = hshift(address);
-    int result = read_word(opaque, address, &w);
-    *value = (w >> shift) & 0xffff;
-
-    return result;
-}
-
 static int readw(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
 {
     uint32_t w;
@@ -104,11 +89,6 @@ static void read_nothing(void)
     *g_dev.r4300.rdword = 0;
 }
 
-static void read_nothingh(void)
-{
-    *g_dev.r4300.rdword = 0;
-}
-
 static void read_nothingd(void)
 {
     *g_dev.r4300.rdword = 0;
@@ -129,15 +109,6 @@ static void read_nomem(void)
     *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300), 0);
     if (*r4300_address(r4300) == 0x00000000) return;
     read_word_in_memory();
-}
-
-static void read_nomemh(void)
-{
-    struct r4300_core* r4300 = &g_dev.r4300;
-
-    *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),0);
-    if (*r4300_address(r4300) == 0x00000000) return;
-    read_hword_in_memory();
 }
 
 static void read_nomemd(void)
@@ -175,11 +146,6 @@ void read_rdram(void)
     readw(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-void read_rdramh(void)
-{
-    readh(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 void read_rdramd(void)
 {
     readd(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -199,11 +165,6 @@ void write_rdramd(void)
 void read_rdramFB(void)
 {
     readw(read_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-void read_rdramFBh(void)
-{
-    readh(read_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 void read_rdramFBd(void)
@@ -227,11 +188,6 @@ static void read_rdramreg(void)
     readw(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rdramregh(void)
-{
-    readh(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_rdramregd(void)
 {
     readd(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -251,11 +207,6 @@ static void write_rdramregd(void)
 static void read_rspmem(void)
 {
     readw(read_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_rspmemh(void)
-{
-    readh(read_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_rspmemd(void)
@@ -279,11 +230,6 @@ static void read_rspreg(void)
     readw(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rspregh(void)
-{
-    readh(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_rspregd(void)
 {
     readd(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -303,11 +249,6 @@ static void write_rspregd(void)
 static void read_rspreg2(void)
 {
     readw(read_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_rspreg2h(void)
-{
-    readh(read_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_rspreg2d(void)
@@ -331,11 +272,6 @@ static void read_dp(void)
     readw(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_dph(void)
-{
-    readh(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_dpd(void)
 {
     readd(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -355,11 +291,6 @@ static void write_dpd(void)
 static void read_dps(void)
 {
     readw(read_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_dpsh(void)
-{
-    readh(read_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_dpsd(void)
@@ -383,11 +314,6 @@ static void read_mi(void)
     readw(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_mih(void)
-{
-    readh(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_mid(void)
 {
     readd(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -407,11 +333,6 @@ void write_mid(void)
 static void read_vi(void)
 {
     readw(read_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_vih(void)
-{
-    readh(read_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_vid(void)
@@ -435,11 +356,6 @@ static void read_ai(void)
     readw(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_aih(void)
-{
-    readh(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_aid(void)
 {
     readd(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -459,11 +375,6 @@ static void write_aid(void)
 static void read_pi(void)
 {
     readw(read_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_pih(void)
-{
-    readh(read_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_pid(void)
@@ -487,11 +398,6 @@ static void read_ri(void)
     readw(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rih(void)
-{
-    readh(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_rid(void)
 {
     readd(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -513,11 +419,6 @@ static void read_si(void)
     readw(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_sih(void)
-{
-    readh(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_sid(void)
 {
     readd(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -536,11 +437,6 @@ static void write_sid(void)
 static void read_pi_flashram_status(void)
 {
     readw(read_flashram_status, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_pi_flashram_statush(void)
-{
-    readh(read_flashram_status, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_pi_flashram_statusd(void)
@@ -564,11 +460,6 @@ static void read_rom(void)
     readw(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_romh(void)
-{
-    readh(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_romd(void)
 {
     readd(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -583,11 +474,6 @@ static void write_rom(void)
 static void read_pif(void)
 {
     readw(read_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_pifh(void)
-{
-    readh(read_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void read_pifd(void)
@@ -627,11 +513,6 @@ static void read_dd(void)
     readw(read_dd_regs, NULL, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_ddh(void)
-{
-    readh(read_dd_regs, NULL, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void read_ddd(void)
 {
     readd(read_dd_regs, NULL, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
@@ -648,14 +529,6 @@ static void write_ddd(void)
 }
 
 #ifdef DBG
-static void readmemh_with_bp_checks(void)
-{
-    check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 2,
-            M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ);
-
-    g_dev.mem.saved_readmemh[*r4300_address(&g_dev.r4300)>>16]();
-}
-
 static void readmem_with_bp_checks(void)
 {
     check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 4,
@@ -694,10 +567,8 @@ void activate_memory_break_read(struct memory* mem, uint32_t address)
 
     if (mem->saved_readmem[region] == NULL)
     {
-        mem->saved_readmemh[region] = mem->readmemh[region];
         mem->saved_readmem [region] = mem->readmem [region];
         mem->saved_readmemd[region] = mem->readmemd[region];
-        mem->readmemh[region] = readmemh_with_bp_checks;
         mem->readmem [region] = readmem_with_bp_checks;
         mem->readmemd[region] = readmemd_with_bp_checks;
     }
@@ -709,10 +580,8 @@ void deactivate_memory_break_read(struct memory* mem, uint32_t address)
 
     if (mem->saved_readmem[region] != NULL)
     {
-        mem->readmemh[region] = mem->saved_readmemh[region];
         mem->readmem [region] = mem->saved_readmem [region];
         mem->readmemd[region] = mem->saved_readmemd[region];
-        mem->saved_readmemh[region] = NULL;
         mem->saved_readmem [region] = NULL;
         mem->saved_readmemd[region] = NULL;
     }
@@ -750,7 +619,7 @@ int get_memory_type(struct memory* mem, uint32_t address)
 }
 #endif
 
-#define R(x) read_ ## x ## h, read_ ## x, read_ ## x ## d
+#define R(x) read_ ## x, read_ ## x ## d
 #define W(x) write_ ## x, write_ ## x ## d
 #define RW(x) R(x), W(x)
 
@@ -944,7 +813,6 @@ static void map_region_t(struct memory* mem, uint16_t region, int type)
 
 static void map_region_r(struct memory* mem,
         uint16_t region,
-        void (*read16)(void),
         void (*read32)(void),
         void (*read64)(void))
 {
@@ -952,17 +820,14 @@ static void map_region_r(struct memory* mem,
     if (lookup_breakpoint(((uint32_t)region << 16), 0x10000,
                           M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) != -1)
     {
-        mem->saved_readmemh[region] = read16;
         mem->saved_readmem [region] = read32;
         mem->saved_readmemd[region] = read64;
-        mem->readmemh[region] = readmemh_with_bp_checks;
         mem->readmem [region] = readmem_with_bp_checks;
         mem->readmemd[region] = readmemd_with_bp_checks;
     }
     else
 #endif
     {
-        mem->readmemh[region] = read16;
         mem->readmem [region] = read32;
         mem->readmemd[region] = read64;
     }
@@ -993,14 +858,13 @@ static void map_region_w(struct memory* mem,
 void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
-                void (*read16)(void),
                 void (*read32)(void),
                 void (*read64)(void),
                 void (*write32)(void),
                 void (*write64)(void))
 {
     map_region_t(mem, region, type);
-    map_region_r(mem, region, read16, read32, read64);
+    map_region_r(mem, region, read32, read64);
     map_region_w(mem, region, write32, write64);
 }
 

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -221,7 +221,7 @@ static void write_nomemb(void)
     invalidate_r4300_cached_code(r4300, *r4300_address(r4300), 1);
     *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),1);
     if (*r4300_address(r4300) == 0x00000000) return;
-    write_byte_in_memory();
+    r4300->mem->writememb[*r4300_address(r4300)>>16]();
 }
 
 static void write_nomemh(void)

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -31,7 +31,6 @@ struct memory
     void (*readmemh[0x10000])(void);
     void (*readmemd[0x10000])(void);
     void (*writemem[0x10000])(void);
-    void (*writememb[0x10000])(void);
     void (*writememh[0x10000])(void);
     void (*writememd[0x10000])(void);
 
@@ -41,7 +40,6 @@ struct memory
     void (*saved_readmemh[0x10000])(void);
     void (*saved_readmem [0x10000])(void);
     void (*saved_readmemd[0x10000])(void);
-    void (*saved_writememb[0x10000])(void);
     void (*saved_writememh[0x10000])(void);
     void (*saved_writemem [0x10000])(void);
     void (*saved_writememd[0x10000])(void);
@@ -87,7 +85,6 @@ void map_region(struct memory* mem,
                 void (*read16)(void),
                 void (*read32)(void),
                 void (*read64)(void),
-                void (*write8)(void),
                 void (*write16)(void),
                 void (*write32)(void),
                 void (*write64)(void));
@@ -98,7 +95,6 @@ void read_rdramb(void);
 void read_rdramh(void);
 void read_rdramd(void);
 void write_rdram(void);
-void write_rdramb(void);
 void write_rdramh(void);
 void write_rdramd(void);
 void read_rdramFB(void);
@@ -106,7 +102,6 @@ void read_rdramFBb(void);
 void read_rdramFBh(void);
 void read_rdramFBd(void);
 void write_rdramFB(void);
-void write_rdramFBb(void);
 void write_rdramFBh(void);
 void write_rdramFBd(void);
 

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -27,14 +27,12 @@
 struct memory
 {
     void (*readmem[0x10000])(void);
-    void (*readmemh[0x10000])(void);
     void (*readmemd[0x10000])(void);
     void (*writemem[0x10000])(void);
     void (*writememd[0x10000])(void);
 
 #ifdef DBG
     int memtype[0x10000];
-    void (*saved_readmemh[0x10000])(void);
     void (*saved_readmem [0x10000])(void);
     void (*saved_readmemd[0x10000])(void);
     void (*saved_writemem [0x10000])(void);
@@ -77,7 +75,6 @@ void poweron_memory(struct memory* mem);
 void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
-                void (*read16)(void),
                 void (*read32)(void),
                 void (*read64)(void),
                 void (*write32)(void),
@@ -85,12 +82,10 @@ void map_region(struct memory* mem,
 
 /* XXX: cannot make them static because of dynarec + rdp fb */
 void read_rdram(void);
-void read_rdramh(void);
 void read_rdramd(void);
 void write_rdram(void);
 void write_rdramd(void);
 void read_rdramFB(void);
-void read_rdramFBh(void);
 void read_rdramFBd(void);
 void write_rdramFB(void);
 void write_rdramFBd(void);

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -27,7 +27,6 @@
 struct memory
 {
     void (*readmem[0x10000])(void);
-    void (*readmemb[0x10000])(void);
     void (*readmemh[0x10000])(void);
     void (*readmemd[0x10000])(void);
     void (*writemem[0x10000])(void);
@@ -35,7 +34,6 @@ struct memory
 
 #ifdef DBG
     int memtype[0x10000];
-    void (*saved_readmemb[0x10000])(void);
     void (*saved_readmemh[0x10000])(void);
     void (*saved_readmem [0x10000])(void);
     void (*saved_readmemd[0x10000])(void);
@@ -79,7 +77,6 @@ void poweron_memory(struct memory* mem);
 void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
-                void (*read8)(void),
                 void (*read16)(void),
                 void (*read32)(void),
                 void (*read64)(void),
@@ -88,13 +85,11 @@ void map_region(struct memory* mem,
 
 /* XXX: cannot make them static because of dynarec + rdp fb */
 void read_rdram(void);
-void read_rdramb(void);
 void read_rdramh(void);
 void read_rdramd(void);
 void write_rdram(void);
 void write_rdramd(void);
 void read_rdramFB(void);
-void read_rdramFBb(void);
 void read_rdramFBh(void);
 void read_rdramFBd(void);
 void write_rdramFB(void);

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -31,7 +31,6 @@ struct memory
     void (*readmemh[0x10000])(void);
     void (*readmemd[0x10000])(void);
     void (*writemem[0x10000])(void);
-    void (*writememh[0x10000])(void);
     void (*writememd[0x10000])(void);
 
 #ifdef DBG
@@ -40,7 +39,6 @@ struct memory
     void (*saved_readmemh[0x10000])(void);
     void (*saved_readmem [0x10000])(void);
     void (*saved_readmemd[0x10000])(void);
-    void (*saved_writememh[0x10000])(void);
     void (*saved_writemem [0x10000])(void);
     void (*saved_writememd[0x10000])(void);
 #endif
@@ -85,7 +83,6 @@ void map_region(struct memory* mem,
                 void (*read16)(void),
                 void (*read32)(void),
                 void (*read64)(void),
-                void (*write16)(void),
                 void (*write32)(void),
                 void (*write64)(void));
 
@@ -95,14 +92,12 @@ void read_rdramb(void);
 void read_rdramh(void);
 void read_rdramd(void);
 void write_rdram(void);
-void write_rdramh(void);
 void write_rdramd(void);
 void read_rdramFB(void);
 void read_rdramFBb(void);
 void read_rdramFBh(void);
 void read_rdramFBd(void);
 void write_rdramFB(void);
-void write_rdramFBh(void);
 void write_rdramFBd(void);
 
 /* Returns a pointer to a block of contiguous memory

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -134,9 +134,14 @@ DECLARE_INSTRUCTION(LBU)
     const uint32_t lsaddr = irs32 + iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
+    unsigned int shift = bshift(lsaddr);
+    *r4300_address(r4300) = lsaddr & ~0x3;
     r4300->rdword = (uint64_t*) lsrtp;
-    read_byte_in_memory();
+    read_word_in_memory();
+    if (*r4300_address(r4300)) {
+        *lsrtp >>= shift;
+        *lsrtp &= 0xff;
+    }
 }
 
 DECLARE_INSTRUCTION(LH)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -84,6 +84,11 @@ static unsigned int bshift(uint32_t address)
     return ((address & 3) ^ 3) << 3;
 }
 
+static unsigned int hshift(uint32_t address)
+{
+    return ((address & 2) ^ 2) << 3;
+}
+
 
 /* M64P Pseudo instructions */
 
@@ -348,9 +353,11 @@ DECLARE_INSTRUCTION(SH)
     const uint32_t lsaddr = irs32 + iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
-    *r4300_whword(r4300) = (uint16_t) *lsrtp;
-    write_hword_in_memory();
+    unsigned int shift = hshift(lsaddr);
+    *r4300_address(r4300) = lsaddr & ~0x3;
+    *r4300_wword(r4300) = (uint32_t)*lsrtp << shift;
+    *r4300_wmask(r4300) = UINT32_C(0xffff) << shift;
+    write_word_in_memory();
     CHECK_MEMORY();
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -150,10 +150,13 @@ DECLARE_INSTRUCTION(LH)
     const uint32_t lsaddr = irs32 + iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
+    unsigned int shift = hshift(lsaddr);
+    *r4300_address(r4300) = lsaddr & ~0x3;
     r4300->rdword = (uint64_t*) lsrtp;
-    read_hword_in_memory();
+    read_word_in_memory();
     if (*r4300_address(r4300)) {
+        *lsrtp >>= shift;
+        *lsrtp &= 0xffff;
         *lsrtp = SE16(*lsrtp);
     }
 }

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -78,6 +78,13 @@
 #define BITS_BELOW_MASK64(x) ((UINT64_C(1) << (x)) - 1)
 #define BITS_ABOVE_MASK64(x) (~((UINT64_C(1) << (x)) - 1))
 
+
+static unsigned int bshift(uint32_t address)
+{
+    return ((address & 3) ^ 3) << 3;
+}
+
+
 /* M64P Pseudo instructions */
 
 DECLARE_INSTRUCTION(NI)
@@ -327,9 +334,11 @@ DECLARE_INSTRUCTION(SB)
     const uint32_t lsaddr = irs32 + iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
-    *r4300_wbyte(r4300) = (uint8_t) *lsrtp;
-    write_byte_in_memory();
+    unsigned int shift = bshift(lsaddr);
+    *r4300_address(r4300) = lsaddr & ~0x3;
+    *r4300_wword(r4300) = (uint32_t)*lsrtp << shift;
+    *r4300_wmask(r4300) = UINT32_C(0xff) << shift;
+    write_word_in_memory();
     CHECK_MEMORY();
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -355,6 +355,7 @@ DECLARE_INSTRUCTION(SC)
     {
         *r4300_address(r4300) = lsaddr;
         *r4300_wword(r4300) = (uint32_t) *lsrtp;
+        *r4300_wmask(r4300) = ~UINT32_C(0);
         write_word_in_memory();
         CHECK_MEMORY();
         r4300->llbit = 0;
@@ -374,6 +375,7 @@ DECLARE_INSTRUCTION(SW)
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
     *r4300_wword(r4300) = (uint32_t) *lsrtp;
+    *r4300_wmask(r4300) = ~UINT32_C(0);
     write_word_in_memory();
     CHECK_MEMORY();
 }
@@ -389,6 +391,7 @@ DECLARE_INSTRUCTION(SWL)
     {
         *r4300_address(r4300) = lsaddr;
         *r4300_wword(r4300) = (uint32_t) *lsrtp;
+        *r4300_wmask(r4300) = ~UINT32_C(0);
         write_word_in_memory();
         CHECK_MEMORY();
     }
@@ -406,6 +409,7 @@ DECLARE_INSTRUCTION(SWL)
              * of its high bits into the low bits of the memory word? */
             int new_shift = (lsaddr & 3) * 8;
             *r4300_wword(r4300) = ((uint32_t) old_word & old_mask) | ((uint32_t) *lsrtp >> new_shift);
+            *r4300_wmask(r4300) = ~UINT32_C(0);
             write_word_in_memory();
             CHECK_MEMORY();
         }
@@ -423,6 +427,7 @@ DECLARE_INSTRUCTION(SWR)
     if ((lsaddr & 3) == 3)
     {
         *r4300_wword(r4300) = (uint32_t) *lsrtp;
+        *r4300_wmask(r4300) = ~UINT32_C(0);
         write_word_in_memory();
         CHECK_MEMORY();
     }
@@ -439,6 +444,7 @@ DECLARE_INSTRUCTION(SWR)
              * of its low bits into the high bits of the memory word? */
             int new_shift = (3 - (lsaddr & 3)) * 8;
             *r4300_wword(r4300) = ((uint32_t) old_word & old_mask) | ((uint32_t) *lsrtp << new_shift);
+            *r4300_wmask(r4300) = ~UINT32_C(0);
             write_word_in_memory();
             CHECK_MEMORY();
         }
@@ -1472,6 +1478,7 @@ DECLARE_INSTRUCTION(SWC1)
     ADD_TO_PC(1);
     *r4300_address(r4300) = lslfaddr;
     *r4300_wword(r4300) = *((uint32_t*)(r4300_cp1_regs_simple(&r4300->cp1))[lslfft]);
+    *r4300_wmask(r4300) = ~UINT32_C(0);
     write_word_in_memory();
     CHECK_MEMORY();
 }

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -164,9 +164,14 @@ DECLARE_INSTRUCTION(LHU)
     const uint32_t lsaddr = irs32 + iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
+    unsigned int shift = hshift(lsaddr);
+    *r4300_address(r4300) = lsaddr & ~0x3;
     r4300->rdword = (uint64_t*) lsrtp;
-    read_hword_in_memory();
+    read_word_in_memory();
+    if (*r4300_address(r4300)) {
+        *lsrtp >>= shift;
+        *lsrtp &= 0xffff;
+    }
 }
 
 DECLARE_INSTRUCTION(LL)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -117,10 +117,13 @@ DECLARE_INSTRUCTION(LB)
     const uint32_t lsaddr = irs32 + iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
+    unsigned int shift = bshift(lsaddr);
+    *r4300_address(r4300) = lsaddr & ~0x3;
     r4300->rdword = (uint64_t*) lsrtp;
-    read_byte_in_memory();
+    read_word_in_memory();
     if (*r4300_address(r4300)) {
+        *lsrtp >>= shift;
+        *lsrtp &= 0xff;
         *lsrtp = SE8(*lsrtp);
     }
 }

--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -2905,7 +2905,7 @@ static void do_writestub(int n)
   if(type==STOREB_STUB)
     ftable=(int)g_dev.mem.writemem;
   if(type==STOREH_STUB)
-    ftable=(int)g_dev.mem.writememh;
+    ftable=(int)g_dev.mem.writemem;
   if(type==STOREW_STUB)
     ftable=(int)g_dev.mem.writemem;
   if(type==STORED_STUB)
@@ -2926,8 +2926,17 @@ static void do_writestub(int n)
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
   if(type==STOREH_STUB) {
+    emit_mov(rs, 2);
+    emit_andimm(2, 0x2, 2);
+    emit_xorimm(2, 0x2, 2);
+    emit_shlimm(2, 0x3, 2);
+    emit_shl(rt, 2, rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
+    emit_movimm(0xffff,rt);
+    emit_shl(rt, 2, rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
+    emit_andimm(rs, ~0x3, rs);
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
-    emit_writehword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.whword);
   }
   if(type==STOREW_STUB) {
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
@@ -2989,7 +2998,7 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
   if(type==STOREB_STUB)
     ftable=(int)g_dev.mem.writemem;
   if(type==STOREH_STUB)
-    ftable=(int)g_dev.mem.writememh;
+    ftable=(int)g_dev.mem.writemem;
   if(type==STOREW_STUB)
     ftable=(int)g_dev.mem.writemem;
   if(type==STORED_STUB)
@@ -3010,8 +3019,17 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
   if(type==STOREH_STUB) {
+    emit_mov(rs, 2);
+    emit_andimm(2, 0x2, 2);
+    emit_xorimm(2, 0x2, 2);
+    emit_shlimm(2, 0x3, 2);
+    emit_shl(rt, 2, rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
+    emit_movimm(0xffff,rt);
+    emit_shl(rt, 2, rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
+    emit_andimm(rs, ~0x3, rs);
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
-    emit_writehword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.whword);
   }
   if(type==STOREW_STUB) {
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);

--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -2903,26 +2903,40 @@ static void do_writestub(int n)
   assert(addr>=0);
   int ftable=0;
   if(type==STOREB_STUB)
-    ftable=(int)g_dev.mem.writememb;
+    ftable=(int)g_dev.mem.writemem;
   if(type==STOREH_STUB)
     ftable=(int)g_dev.mem.writememh;
   if(type==STOREW_STUB)
     ftable=(int)g_dev.mem.writemem;
   if(type==STORED_STUB)
     ftable=(int)g_dev.mem.writememd;
-  emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   //emit_shrimm(rs,16,rs);
   //emit_movmem_indexedx4(ftable,rs,rs);
-  if(type==STOREB_STUB)
-    emit_writebyte(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wbyte);
-  if(type==STOREH_STUB)
+  if(type==STOREB_STUB) {
+    emit_mov(rs, 2);
+    emit_andimm(2, 0x3, 2);
+    emit_xorimm(2, 0x3, 2);
+    emit_shlimm(2, 0x3, 2);
+    emit_shl(rt, 2, rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
+    emit_movimm(0xff,rt);
+    emit_shl(rt, 2, rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
+    emit_andimm(rs, ~0x3, rs);
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
+  if(type==STOREH_STUB) {
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
     emit_writehword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.whword);
+  }
   if(type==STOREW_STUB) {
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
     emit_movimm(~UINT32_C(0),HOST_TEMPREG);
     emit_writeword(HOST_TEMPREG,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
   }
   if(type==STORED_STUB) {
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword);
     emit_writeword(r?rth:rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword+4);
   }
@@ -2973,26 +2987,40 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
   assert(rt>=0);
   int ftable=0;
   if(type==STOREB_STUB)
-    ftable=(int)g_dev.mem.writememb;
+    ftable=(int)g_dev.mem.writemem;
   if(type==STOREH_STUB)
     ftable=(int)g_dev.mem.writememh;
   if(type==STOREW_STUB)
     ftable=(int)g_dev.mem.writemem;
   if(type==STORED_STUB)
     ftable=(int)g_dev.mem.writememd;
-  emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   //emit_shrimm(rs,16,rs);
   //emit_movmem_indexedx4(ftable,rs,rs);
-  if(type==STOREB_STUB)
-    emit_writebyte(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wbyte);
-  if(type==STOREH_STUB)
+  if(type==STOREB_STUB) {
+    emit_mov(rs, 2);
+    emit_andimm(2, 0x3, 2);
+    emit_xorimm(2, 0x3, 2);
+    emit_shlimm(2, 0x3, 2);
+    emit_shl(rt, 2, rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
+    emit_movimm(0xff,rt);
+    emit_shl(rt, 2, rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
+    emit_andimm(rs, ~0x3, rs);
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
+  if(type==STOREH_STUB) {
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
     emit_writehword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.whword);
+  }
   if(type==STOREW_STUB) {
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
     emit_movimm(~UINT32_C(0),HOST_TEMPREG);
     emit_writeword(HOST_TEMPREG,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
   }
   if(type==STORED_STUB) {
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword);
     emit_writeword(target?rth:rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword+4);
   }

--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -2733,15 +2733,27 @@ static void do_readstub(int n)
   if(addr<0&&itype[i]!=C1LS&&itype[i]!=LOADLR) addr=get_reg(i_regmap,-1);
   assert(addr>=0);
   int ftable=0;
-  if(type==LOADB_STUB||type==LOADBU_STUB)
-    ftable=(int)g_dev.mem.readmemb;
-  if(type==LOADH_STUB||type==LOADHU_STUB)
-    ftable=(int)g_dev.mem.readmemh;
-  if(type==LOADW_STUB)
+  if(type==LOADB_STUB||type==LOADBU_STUB) {
     ftable=(int)g_dev.mem.readmem;
-  if(type==LOADD_STUB)
+    emit_mov(rs, 2);
+    emit_andimm(2, 0x3, 2);
+    emit_xorimm(2, 0x3, 2);
+    emit_shlimm(2, 0x3, 2);
+    emit_andimm(rs, ~0x3, rs);
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
+  if(type==LOADH_STUB||type==LOADHU_STUB) {
+    ftable=(int)g_dev.mem.readmemh;
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
+  if(type==LOADW_STUB) {
+    ftable=(int)g_dev.mem.readmem;
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
+  if(type==LOADD_STUB) {
     ftable=(int)g_dev.mem.readmemd;
-  emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
   //emit_pusha();
   save_regs(reglist);
   ds=i_regs!=&regs[i];
@@ -2781,16 +2793,25 @@ static void do_readstub(int n)
   //  emit_loadreg(CCREG,cc);
   //}
   if(rt>=0) {
-    if(type==LOADB_STUB)
-      emit_movsbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    if(type==LOADBU_STUB)
-      emit_movzbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    if(type==LOADH_STUB)
-      emit_movswl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    if(type==LOADHU_STUB)
-      emit_movzwl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    if(type==LOADW_STUB)
+    if(type==LOADB_STUB) {
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_shr(rt,2,rt);
+      emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.rdword);
+      emit_movsbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    }
+    if(type==LOADBU_STUB) {
+      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_shr(rt,2,rt);
+    }
+    if(type==LOADH_STUB) {
+      emit_movswl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    }
+    if(type==LOADHU_STUB) {
+      emit_movzwl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    }
+    if(type==LOADW_STUB) {
+      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    }
     if(type==LOADD_STUB) {
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
       if(rth>=0) emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword+4,rth);
@@ -2807,15 +2828,27 @@ static void inline_readstub(int type, int i, u_int addr, signed char regmap[], i
   if(rs<0) rs=get_reg(regmap,-1);
   assert(rs>=0);
   int ftable=0;
-  if(type==LOADB_STUB||type==LOADBU_STUB)
-    ftable=(int)g_dev.mem.readmemb;
-  if(type==LOADH_STUB||type==LOADHU_STUB)
-    ftable=(int)g_dev.mem.readmemh;
-  if(type==LOADW_STUB)
+  if(type==LOADB_STUB||type==LOADBU_STUB) {
     ftable=(int)g_dev.mem.readmem;
-  if(type==LOADD_STUB)
+    emit_mov(rs, 2);
+    emit_andimm(2, 0x3, 2);
+    emit_xorimm(2, 0x3, 2);
+    emit_shlimm(2, 0x3, 2);
+    emit_andimm(rs, ~0x3, rs);
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
+  if(type==LOADH_STUB||type==LOADHU_STUB) {
+    ftable=(int)g_dev.mem.readmemh;
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
+  if(type==LOADW_STUB) {
+    ftable=(int)g_dev.mem.readmem;
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
+  if(type==LOADD_STUB) {
     ftable=(int)g_dev.mem.readmemd;
-  emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  }
   //emit_pusha();
   save_regs(reglist);
   if((signed int)addr>=(signed int)0xC0000000) {
@@ -2859,16 +2892,25 @@ static void inline_readstub(int type, int i, u_int addr, signed char regmap[], i
   //emit_popa();
   restore_regs(reglist);
   if(rt>=0) {
-    if(type==LOADB_STUB)
-      emit_movsbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    if(type==LOADBU_STUB)
-      emit_movzbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    if(type==LOADH_STUB)
-      emit_movswl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    if(type==LOADHU_STUB)
-      emit_movzwl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    if(type==LOADW_STUB)
+    if(type==LOADB_STUB) {
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_shr(rt,2,rt);
+      emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.rdword);
+      emit_movsbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    }
+    if(type==LOADBU_STUB) {
+      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_shr(rt,2,rt);
+    }
+    if(type==LOADH_STUB) {
+      emit_movswl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    }
+    if(type==LOADHU_STUB) {
+      emit_movzwl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    }
+    if(type==LOADW_STUB) {
+      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    }
     if(type==LOADD_STUB) {
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
       if(rth>=0) emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword+4,rth);

--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -2743,7 +2743,12 @@ static void do_readstub(int n)
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
   if(type==LOADH_STUB||type==LOADHU_STUB) {
-    ftable=(int)g_dev.mem.readmemh;
+    ftable=(int)g_dev.mem.readmem;
+    emit_mov(rs, 2);
+    emit_andimm(2, 0x2, 2);
+    emit_xorimm(2, 0x2, 2);
+    emit_shlimm(2, 0x3, 2);
+    emit_andimm(rs, ~0x3, rs);
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
   if(type==LOADW_STUB) {
@@ -2804,10 +2809,14 @@ static void do_readstub(int n)
       emit_shr(rt,2,rt);
     }
     if(type==LOADH_STUB) {
+      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_shr(rt,2,rt);
+      emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.rdword);
       emit_movswl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
     }
     if(type==LOADHU_STUB) {
-      emit_movzwl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_shr(rt,2,rt);
     }
     if(type==LOADW_STUB) {
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
@@ -2838,7 +2847,12 @@ static void inline_readstub(int type, int i, u_int addr, signed char regmap[], i
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
   if(type==LOADH_STUB||type==LOADHU_STUB) {
-    ftable=(int)g_dev.mem.readmemh;
+    ftable=(int)g_dev.mem.readmem;
+    emit_mov(rs, 2);
+    emit_andimm(2, 0x2, 2);
+    emit_xorimm(2, 0x2, 2);
+    emit_shlimm(2, 0x3, 2);
+    emit_andimm(rs, ~0x3, rs);
     emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
   if(type==LOADW_STUB) {
@@ -2903,10 +2917,14 @@ static void inline_readstub(int type, int i, u_int addr, signed char regmap[], i
       emit_shr(rt,2,rt);
     }
     if(type==LOADH_STUB) {
+      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_shr(rt,2,rt);
+      emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.rdword);
       emit_movswl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
     }
     if(type==LOADHU_STUB) {
-      emit_movzwl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+      emit_shr(rt,2,rt);
     }
     if(type==LOADW_STUB) {
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);

--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -2919,8 +2919,8 @@ static void do_writestub(int n)
     emit_writehword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.whword);
   if(type==STOREW_STUB) {
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
-    emit_movimm(~UINT32_C(0),rt);
-    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
+    emit_movimm(~UINT32_C(0),HOST_TEMPREG);
+    emit_writeword(HOST_TEMPREG,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
   }
   if(type==STORED_STUB) {
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword);
@@ -2989,8 +2989,8 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
     emit_writehword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.whword);
   if(type==STOREW_STUB) {
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
-    emit_movimm(~UINT32_C(0),rt);
-    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
+    emit_movimm(~UINT32_C(0),HOST_TEMPREG);
+    emit_writeword(HOST_TEMPREG,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
   }
   if(type==STORED_STUB) {
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword);

--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -2917,8 +2917,11 @@ static void do_writestub(int n)
     emit_writebyte(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wbyte);
   if(type==STOREH_STUB)
     emit_writehword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.whword);
-  if(type==STOREW_STUB)
+  if(type==STOREW_STUB) {
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
+    emit_movimm(~UINT32_C(0),rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
+  }
   if(type==STORED_STUB) {
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword);
     emit_writeword(r?rth:rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword+4);
@@ -2984,8 +2987,11 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
     emit_writebyte(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wbyte);
   if(type==STOREH_STUB)
     emit_writehword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.whword);
-  if(type==STOREW_STUB)
+  if(type==STOREW_STUB) {
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
+    emit_movimm(~UINT32_C(0),rt);
+    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
+  }
   if(type==STORED_STUB) {
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword);
     emit_writeword(target?rth:rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword+4);

--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -56,8 +56,14 @@ void invalidate_addr_r8(void);
 void invalidate_addr_r9(void);
 void invalidate_addr_r10(void);
 void invalidate_addr_r12(void);
-void indirect_jump_indexed(void);
-void indirect_jump(void);
+void read_byte_new(void);
+void read_hword_new(void);
+void read_word_new(void);
+void read_dword_new(void);
+void write_byte_new(void);
+void write_hword_new(void);
+void write_word_new(void);
+void write_dword_new(void);
 
 static void *dyna_linker(void * src, u_int vaddr);
 static void *dyna_linker_ds(void * src, u_int vaddr);
@@ -103,6 +109,10 @@ static const u_int invalidate_addr_reg[16] = {
   0};
 
 static u_int jump_table_symbols[] = {
+  (int)NULL /*MFC0*/,
+  (int)NULL /*MTC0*/,
+  (int)NULL /*TLBR*/,
+  (int)NULL /*TLBP*/,
   (int)invalidate_addr,
   (int)dyna_linker,
   (int)dyna_linker_ds,
@@ -114,13 +124,7 @@ static u_int jump_table_symbols[] = {
   (int)fp_exception_ds,
   (int)jump_syscall,
   (int)jump_eret,
-  (int)indirect_jump_indexed,
-  (int)indirect_jump,
   (int)do_interrupt,
-  (int)NULL /*MFC0*/,
-  (int)NULL /*MTC0*/,
-  (int)NULL /*TLBR*/,
-  (int)NULL /*TLBP*/,
   (int)TLBWI_new,
   (int)TLBWR_new,
   (int)jump_vaddr_r0,
@@ -222,7 +226,15 @@ static u_int jump_table_symbols[] = {
   (int)sqrt_d,
   (int)abs_d,
   (int)mov_d,
-  (int)neg_d
+  (int)neg_d,
+  (int)read_byte_new,
+  (int)read_hword_new,
+  (int)read_word_new,
+  (int)read_dword_new,
+  (int)write_byte_new,
+  (int)write_hword_new,
+  (int)write_word_new,
+  (int)write_dword_new
 };
 
 /* Linker */
@@ -2718,9 +2730,8 @@ static void do_readstub(int n)
   struct regstat *i_regs=(struct regstat *)stubs[n][5];
   u_int reglist=stubs[n][7];
   signed char *i_regmap=i_regs->regmap;
-  int addr=get_reg(i_regmap,AGEN1+(i&1));
   int rth,rt;
-  int ds;
+
   if(itype[i]==C1LS||itype[i]==LOADLR) {
     rth=get_reg(i_regmap,FTEMP|64);
     rt=get_reg(i_regmap,FTEMP);
@@ -2729,98 +2740,56 @@ static void do_readstub(int n)
     rt=get_reg(i_regmap,rt1[i]);
   }
   assert(rs>=0);
-  if(addr<0) addr=rt;
-  if(addr<0&&itype[i]!=C1LS&&itype[i]!=LOADLR) addr=get_reg(i_regmap,-1);
-  assert(addr>=0);
   int ftable=0;
-  if(type==LOADB_STUB||type==LOADBU_STUB) {
-    ftable=(int)g_dev.mem.readmem;
-    emit_mov(rs, 2);
-    emit_andimm(2, 0x3, 2);
-    emit_xorimm(2, 0x3, 2);
-    emit_shlimm(2, 0x3, 2);
-    emit_andimm(rs, ~0x3, rs);
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  int mem=0;
+  if(type==LOADB_STUB||type==LOADBU_STUB){
+    ftable=(int)read_byte_new;
+    mem=(int)g_dev.mem.readmem;
   }
-  if(type==LOADH_STUB||type==LOADHU_STUB) {
-    ftable=(int)g_dev.mem.readmem;
-    emit_mov(rs, 2);
-    emit_andimm(2, 0x2, 2);
-    emit_xorimm(2, 0x2, 2);
-    emit_shlimm(2, 0x3, 2);
-    emit_andimm(rs, ~0x3, rs);
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==LOADH_STUB||type==LOADHU_STUB){
+    ftable=(int)read_hword_new;
+    mem=(int)g_dev.mem.readmem;
   }
-  if(type==LOADW_STUB) {
-    ftable=(int)g_dev.mem.readmem;
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==LOADW_STUB){
+    ftable=(int)read_word_new;
+    mem=(int)g_dev.mem.readmem;
   }
-  if(type==LOADD_STUB) {
-    ftable=(int)g_dev.mem.readmemd;
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==LOADD_STUB){
+    ftable=(int)read_dword_new;
+    mem=(int)g_dev.mem.readmemd;
   }
-  //emit_pusha();
+  emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+
   save_regs(reglist);
-  ds=i_regs!=&regs[i];
+  int ds=i_regs!=&regs[i];
   int real_rs=(itype[i]==LOADLR)?-1:get_reg(i_regmap,rs1[i]);
   u_int cmask=ds?-1:(0x100f|~i_regs->wasconst);
-  if(!ds) load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty&~(1<<addr)&(real_rs<0?-1:~(1<<real_rs))&0x100f,i);
-  wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty&cmask&~(1<<addr)&(real_rs<0?-1:~(1<<real_rs)));
-  if(!ds) wb_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty&~(1<<addr)&(real_rs<0?-1:~(1<<real_rs))&~0x100f,i);
-  emit_shrimm(rs,16,1);
+  if(!ds) load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty&(real_rs<0?-1:~(1<<real_rs))&0x100f,i);
+  wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty&cmask&(real_rs<0?-1:~(1<<real_rs)));
+  if(!ds) wb_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty&(real_rs<0?-1:~(1<<real_rs))&~0x100f,i);
+
   int cc=get_reg(i_regmap,CCREG);
   if(cc<0) {
     emit_loadreg(CCREG,2);
   }
-  emit_movimm(ftable,0);
+
+  emit_movimm(mem,0);
   emit_addimm(cc<0?2:cc,2*stubs[n][6]+2,2);
   emit_movimm(start+stubs[n][3]*4+(((regs[i].was32>>rs1[i])&1)<<1)+ds,3);
-  //emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.last_count,temp);
-  //emit_add(cc,temp,cc);
-  //emit_writeword(cc,(u_int)&g_dev.r4300.new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG]);
-  //emit_mov(15,14);
-  emit_call((int)&indirect_jump_indexed);
-  //emit_callreg(rs);
-  //emit_readword_dualindexedx4(rs,HOST_TEMPREG,15);
-  // We really shouldn't need to update the count here,
-  // but not doing so causes random crashes...
-  emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG],HOST_TEMPREG);
-  emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.next_interrupt,2);
-  emit_addimm(HOST_TEMPREG,-2*stubs[n][6]-2,HOST_TEMPREG);
-  emit_writeword(2,(u_int)&g_dev.r4300.new_dynarec_hot_state.last_count);
-  emit_sub(HOST_TEMPREG,2,cc<0?HOST_TEMPREG:cc);
-  if(cc<0) {
-    emit_storereg(CCREG,HOST_TEMPREG);
-  }
-  //emit_popa();
+  emit_call((int)ftable);
   restore_regs(reglist);
-  //if((cc=get_reg(regmap,CCREG))>=0) {
-  //  emit_loadreg(CCREG,cc);
-  //}
+
   if(rt>=0) {
-    if(type==LOADB_STUB) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-      emit_shr(rt,2,rt);
-      emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.rdword);
+    if(type==LOADB_STUB)
       emit_movsbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    }
-    if(type==LOADBU_STUB) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-      emit_shr(rt,2,rt);
-    }
-    if(type==LOADH_STUB) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-      emit_shr(rt,2,rt);
-      emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.rdword);
+    if(type==LOADBU_STUB)
+      emit_movzbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    if(type==LOADH_STUB)
       emit_movswl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    }
-    if(type==LOADHU_STUB) {
+    if(type==LOADHU_STUB)
+      emit_movzwl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    if(type==LOADW_STUB)
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-      emit_shr(rt,2,rt);
-    }
-    if(type==LOADW_STUB) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    }
     if(type==LOADD_STUB) {
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
       if(rth>=0) emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword+4,rth);
@@ -2836,34 +2805,27 @@ static void inline_readstub(int type, int i, u_int addr, signed char regmap[], i
   int rt=get_reg(regmap,target);
   if(rs<0) rs=get_reg(regmap,-1);
   assert(rs>=0);
+
   int ftable=0;
-  if(type==LOADB_STUB||type==LOADBU_STUB) {
-    ftable=(int)g_dev.mem.readmem;
-    emit_mov(rs, 2);
-    emit_andimm(2, 0x3, 2);
-    emit_xorimm(2, 0x3, 2);
-    emit_shlimm(2, 0x3, 2);
-    emit_andimm(rs, ~0x3, rs);
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  int mem=0;
+  if(type==LOADB_STUB||type==LOADBU_STUB){
+    ftable=(int)read_byte_new;
+    mem=(int)g_dev.mem.readmem;
   }
-  if(type==LOADH_STUB||type==LOADHU_STUB) {
-    ftable=(int)g_dev.mem.readmem;
-    emit_mov(rs, 2);
-    emit_andimm(2, 0x2, 2);
-    emit_xorimm(2, 0x2, 2);
-    emit_shlimm(2, 0x3, 2);
-    emit_andimm(rs, ~0x3, rs);
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==LOADH_STUB||type==LOADHU_STUB){
+    ftable=(int)read_hword_new;
+    mem=(int)g_dev.mem.readmem;
   }
-  if(type==LOADW_STUB) {
-    ftable=(int)g_dev.mem.readmem;
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==LOADW_STUB){
+    ftable=(int)read_word_new;
+    mem=(int)g_dev.mem.readmem;
   }
-  if(type==LOADD_STUB) {
-    ftable=(int)g_dev.mem.readmemd;
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==LOADD_STUB){
+    ftable=(int)read_dword_new;
+    mem=(int)g_dev.mem.readmemd;
   }
-  //emit_pusha();
+  emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+
   save_regs(reglist);
   if((signed int)addr>=(signed int)0xC0000000) {
     // Theoretically we can have a pagefault here, if the TLB has never
@@ -2875,60 +2837,33 @@ static void inline_readstub(int type, int i, u_int addr, signed char regmap[], i
     if(!ds) wb_dirtys(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty);
     else wb_dirtys(branch_regs[i-1].regmap_entry,branch_regs[i-1].was32,branch_regs[i-1].wasdirty);
   }
-  //emit_shrimm(rs,16,1);
+
   int cc=get_reg(regmap,CCREG);
   if(cc<0) {
     emit_loadreg(CCREG,2);
   }
-  //emit_movimm(ftable,0);
-  emit_movimm(((u_int *)ftable)[addr>>16],0);
-  //emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.last_count,12);
+
+  emit_movimm(mem,0);
   emit_addimm(cc<0?2:cc,CLOCK_DIVIDER*(adj+1),2);
   if((signed int)addr>=(signed int)0xC0000000) {
     // Pagefault address
     int ds=regmap!=regs[i].regmap;
     emit_movimm(start+i*4+(((regs[i].was32>>rs1[i])&1)<<1)+ds,3);
   }
-  //emit_add(12,2,2);
-  //emit_writeword(2,(u_int)&g_dev.r4300.new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG]);
-  //emit_call(((u_int *)ftable)[addr>>16]);
-  emit_call((int)&indirect_jump);
-  // We really shouldn't need to update the count here,
-  // but not doing so causes random crashes...
-  emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG],HOST_TEMPREG);
-  emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.next_interrupt,2);
-  emit_addimm(HOST_TEMPREG,-CLOCK_DIVIDER*(adj+1),HOST_TEMPREG);
-  emit_writeword(2,(u_int)&g_dev.r4300.new_dynarec_hot_state.last_count);
-  emit_sub(HOST_TEMPREG,2,cc<0?HOST_TEMPREG:cc);
-  if(cc<0) {
-    emit_storereg(CCREG,HOST_TEMPREG);
-  }
-  //emit_popa();
+  emit_call((int)ftable);
   restore_regs(reglist);
+
   if(rt>=0) {
-    if(type==LOADB_STUB) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-      emit_shr(rt,2,rt);
-      emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.rdword);
+    if(type==LOADB_STUB)
       emit_movsbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    }
-    if(type==LOADBU_STUB) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-      emit_shr(rt,2,rt);
-    }
-    if(type==LOADH_STUB) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-      emit_shr(rt,2,rt);
-      emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.rdword);
+    if(type==LOADBU_STUB)
+      emit_movzbl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    if(type==LOADH_STUB)
       emit_movswl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    }
-    if(type==LOADHU_STUB) {
+    if(type==LOADHU_STUB)
+      emit_movzwl((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
+    if(type==LOADW_STUB)
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-      emit_shr(rt,2,rt);
-    }
-    if(type==LOADW_STUB) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
-    }
     if(type==LOADD_STUB) {
       emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword,rt);
       if(rth>=0) emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.rdword+4,rth);
@@ -2947,9 +2882,8 @@ static void do_writestub(int n)
   struct regstat *i_regs=(struct regstat *)stubs[n][5];
   u_int reglist=stubs[n][7];
   signed char *i_regmap=i_regs->regmap;
-  int addr=get_reg(i_regmap,AGEN1+(i&1));
   int rth,rt,r;
-  int ds;
+
   if(itype[i]==C1LS) {
     rth=get_reg(i_regmap,FTEMP|64);
     rt=get_reg(i_regmap,r=FTEMP);
@@ -2959,91 +2893,54 @@ static void do_writestub(int n)
   }
   assert(rs>=0);
   assert(rt>=0);
-  if(addr<0) addr=get_reg(i_regmap,-1);
-  assert(addr>=0);
   int ftable=0;
-  if(type==STOREB_STUB)
-    ftable=(int)g_dev.mem.writemem;
-  if(type==STOREH_STUB)
-    ftable=(int)g_dev.mem.writemem;
-  if(type==STOREW_STUB)
-    ftable=(int)g_dev.mem.writemem;
-  if(type==STORED_STUB)
-    ftable=(int)g_dev.mem.writememd;
-  //emit_shrimm(rs,16,rs);
-  //emit_movmem_indexedx4(ftable,rs,rs);
-  if(type==STOREB_STUB) {
-    emit_mov(rs, 2);
-    emit_andimm(2, 0x3, 2);
-    emit_xorimm(2, 0x3, 2);
-    emit_shlimm(2, 0x3, 2);
-    emit_shl(rt, 2, rt);
+  int mem=0;
+  emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==STOREB_STUB){
+    ftable=(int)write_byte_new;
+    mem=(int)g_dev.mem.writemem;
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
-    emit_movimm(0xff,rt);
-    emit_shl(rt, 2, rt);
-    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
-    emit_andimm(rs, ~0x3, rs);
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
-  if(type==STOREH_STUB) {
-    emit_mov(rs, 2);
-    emit_andimm(2, 0x2, 2);
-    emit_xorimm(2, 0x2, 2);
-    emit_shlimm(2, 0x3, 2);
-    emit_shl(rt, 2, rt);
+  if(type==STOREH_STUB){
+    ftable=(int)write_hword_new;
+    mem=(int)g_dev.mem.writemem;
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
-    emit_movimm(0xffff,rt);
-    emit_shl(rt, 2, rt);
-    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
-    emit_andimm(rs, ~0x3, rs);
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
-  if(type==STOREW_STUB) {
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==STOREW_STUB){
+    ftable=(int)write_word_new;
+    mem=(int)g_dev.mem.writemem;
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
-    emit_movimm(~UINT32_C(0),HOST_TEMPREG);
-    emit_writeword(HOST_TEMPREG,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
   }
-  if(type==STORED_STUB) {
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==STORED_STUB){
+    ftable=(int)write_dword_new;
+    mem=(int)g_dev.mem.writememd;
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword);
     emit_writeword(r?rth:rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword+4);
   }
-  //emit_pusha();
+
   save_regs(reglist);
-  ds=i_regs!=&regs[i];
+  int ds=i_regs!=&regs[i];
   int real_rs=get_reg(i_regmap,rs1[i]);
   u_int cmask=ds?-1:(0x100f|~i_regs->wasconst);
-  if(!ds) load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty&~(1<<addr)&(real_rs<0?-1:~(1<<real_rs))&0x100f,i);
-  wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty&cmask&~(1<<addr)&(real_rs<0?-1:~(1<<real_rs)));
-  if(!ds) wb_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty&~(1<<addr)&(real_rs<0?-1:~(1<<real_rs))&~0x100f,i);
-  emit_shrimm(rs,16,1);
+  if(!ds) load_all_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty&(real_rs<0?-1:~(1<<real_rs))&0x100f,i);
+  wb_dirtys(i_regs->regmap_entry,i_regs->was32,i_regs->wasdirty&cmask&(real_rs<0?-1:~(1<<real_rs)));
+  if(!ds) wb_consts(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty&(real_rs<0?-1:~(1<<real_rs))&~0x100f,i);
+
   int cc=get_reg(i_regmap,CCREG);
   if(cc<0) {
     emit_loadreg(CCREG,2);
   }
-  emit_movimm(ftable,0);
+
+  emit_movimm(mem,0);
   emit_addimm(cc<0?2:cc,2*stubs[n][6]+2,2);
   emit_movimm(start+stubs[n][3]*4+(((regs[i].was32>>rs1[i])&1)<<1)+ds,3);
-  //emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.last_count,temp);
-  //emit_addimm(cc,2*stubs[n][5]+2,cc);
-  //emit_add(cc,temp,cc);
-  //emit_writeword(cc,(u_int)&g_dev.r4300.new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG]);
-  emit_call((int)&indirect_jump_indexed);
-  //emit_callreg(rs);
-  emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG],HOST_TEMPREG);
-  emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.next_interrupt,2);
-  emit_addimm(HOST_TEMPREG,-2*stubs[n][6]-2,HOST_TEMPREG);
-  emit_writeword(2,(u_int)&g_dev.r4300.new_dynarec_hot_state.last_count);
-  emit_sub(HOST_TEMPREG,2,cc<0?HOST_TEMPREG:cc);
+  emit_call((int)ftable);
+  emit_addimm(2,-2*stubs[n][6]-2,cc<0?HOST_TEMPREG:cc);
   if(cc<0) {
     emit_storereg(CCREG,HOST_TEMPREG);
   }
-  //emit_popa();
+
   restore_regs(reglist);
-  //if((cc=get_reg(regmap,CCREG))>=0) {
-  //  emit_loadreg(CCREG,cc);
-  //}
   emit_jmp(stubs[n][2]); // return address
 }
 
@@ -3054,55 +2951,32 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
   int rt=get_reg(regmap,target);
   assert(rs>=0);
   assert(rt>=0);
+
   int ftable=0;
-  if(type==STOREB_STUB)
-    ftable=(int)g_dev.mem.writemem;
-  if(type==STOREH_STUB)
-    ftable=(int)g_dev.mem.writemem;
-  if(type==STOREW_STUB)
-    ftable=(int)g_dev.mem.writemem;
-  if(type==STORED_STUB)
-    ftable=(int)g_dev.mem.writememd;
-  //emit_shrimm(rs,16,rs);
-  //emit_movmem_indexedx4(ftable,rs,rs);
-  if(type==STOREB_STUB) {
-    emit_mov(rs, 2);
-    emit_andimm(2, 0x3, 2);
-    emit_xorimm(2, 0x3, 2);
-    emit_shlimm(2, 0x3, 2);
-    emit_shl(rt, 2, rt);
+  int mem=0;
+  emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==STOREB_STUB){
+    ftable=(int)write_byte_new;
+    mem=(int)g_dev.mem.writemem;
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
-    emit_movimm(0xff,rt);
-    emit_shl(rt, 2, rt);
-    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
-    emit_andimm(rs, ~0x3, rs);
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
-  if(type==STOREH_STUB) {
-    emit_mov(rs, 2);
-    emit_andimm(2, 0x2, 2);
-    emit_xorimm(2, 0x2, 2);
-    emit_shlimm(2, 0x3, 2);
-    emit_shl(rt, 2, rt);
+  if(type==STOREH_STUB){
+    ftable=(int)write_hword_new;
+    mem=(int)g_dev.mem.writemem;
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
-    emit_movimm(0xffff,rt);
-    emit_shl(rt, 2, rt);
-    emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
-    emit_andimm(rs, ~0x3, rs);
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
   }
-  if(type==STOREW_STUB) {
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==STOREW_STUB){
+    ftable=(int)write_word_new;
+    mem=(int)g_dev.mem.writemem;
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wword);
-    emit_movimm(~UINT32_C(0),HOST_TEMPREG);
-    emit_writeword(HOST_TEMPREG,(u_int)&g_dev.r4300.new_dynarec_hot_state.wmask);
   }
-  if(type==STORED_STUB) {
-    emit_writeword(rs,(u_int)&g_dev.r4300.new_dynarec_hot_state.address);
+  if(type==STORED_STUB){
+    ftable=(int)write_dword_new;
+    mem=(int)g_dev.mem.writememd;
     emit_writeword(rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword);
     emit_writeword(target?rth:rt,(u_int)&g_dev.r4300.new_dynarec_hot_state.wdword+4);
   }
-  //emit_pusha();
+
   save_regs(reglist);
   if(((signed int)addr>=(signed int)0xC0000000)||((addr>>16)==0xa430)||((addr>>16)==0x8430)) {
     // Theoretically we can have a pagefault here, if the TLB has never
@@ -3114,33 +2988,25 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
     if(!ds) wb_dirtys(regs[i].regmap_entry,regs[i].was32,regs[i].wasdirty);
     else wb_dirtys(branch_regs[i-1].regmap_entry,branch_regs[i-1].was32,branch_regs[i-1].wasdirty);
   }
-  //emit_shrimm(rs,16,1);
+
   int cc=get_reg(regmap,CCREG);
   if(cc<0) {
     emit_loadreg(CCREG,2);
   }
-  //emit_movimm(ftable,0);
-  emit_movimm(((u_int *)ftable)[addr>>16],0);
-  //emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.last_count,12);
+  
+  emit_movimm(mem,0);
   emit_addimm(cc<0?2:cc,CLOCK_DIVIDER*(adj+1),2);
   if(((signed int)addr>=(signed int)0xC0000000)||((addr>>16)==0xa430)||((addr>>16)==0x8430)) {
     // Pagefault address
     int ds=regmap!=regs[i].regmap;
     emit_movimm(start+i*4+(((regs[i].was32>>rs1[i])&1)<<1)+ds,3);
   }
-  //emit_add(12,2,2);
-  //emit_writeword(2,(u_int)&g_dev.r4300.new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG]);
-  //emit_call(((u_int *)ftable)[addr>>16]);
-  emit_call((int)&indirect_jump);
-  emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp0_regs[CP0_COUNT_REG],HOST_TEMPREG);
-  emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.next_interrupt,2);
-  emit_addimm(HOST_TEMPREG,-CLOCK_DIVIDER*(adj+1),HOST_TEMPREG);
-  emit_writeword(2,(u_int)&g_dev.r4300.new_dynarec_hot_state.last_count);
-  emit_sub(HOST_TEMPREG,2,cc<0?HOST_TEMPREG:cc);
+
+  emit_call((int)ftable);
+  emit_addimm(2,-CLOCK_DIVIDER*(adj+1),cc<0?HOST_TEMPREG:cc);
   if(cc<0) {
     emit_storereg(CCREG,HOST_TEMPREG);
   }
-  //emit_popa();
   restore_regs(reglist);
 }
 
@@ -4753,10 +4619,10 @@ static void arch_init(void) {
   g_dev.r4300.new_dynarec_hot_state.rounding_modes[2]=0x1<<22; // ceil
   g_dev.r4300.new_dynarec_hot_state.rounding_modes[3]=0x2<<22; // floor
 
-  jump_table_symbols[15] = (int) cached_interpreter_table.MFC0;
-  jump_table_symbols[16] = (int) cached_interpreter_table.MTC0;
-  jump_table_symbols[17] = (int) cached_interpreter_table.TLBR;
-  jump_table_symbols[18] = (int) cached_interpreter_table.TLBP;
+  jump_table_symbols[0] = (int) cached_interpreter_table.MFC0;
+  jump_table_symbols[1] = (int) cached_interpreter_table.MTC0;
+  jump_table_symbols[2] = (int) cached_interpreter_table.TLBR;
+  jump_table_symbols[3] = (int) cached_interpreter_table.TLBP;
 
   #ifdef RAM_OFFSET
   g_dev.r4300.new_dynarec_hot_state.ram_offset=((int)g_dev.ri.rdram.dram-(int)0x80000000)>>2;

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -86,7 +86,6 @@ fp_wmask               = offsetof_struct_new_dynarec_hot_state_wmask
 fp_wdword              = offsetof_struct_new_dynarec_hot_state_wdword
 fp_wword               = offsetof_struct_new_dynarec_hot_state_wword
 fp_whword              = offsetof_struct_new_dynarec_hot_state_whword
-fp_wbyte               = offsetof_struct_new_dynarec_hot_state_wbyte
 fp_fcr0                = offsetof_struct_new_dynarec_hot_state_fcr0
 fp_fcr31               = offsetof_struct_new_dynarec_hot_state_fcr31
 fp_regs                = offsetof_struct_new_dynarec_hot_state_regs
@@ -484,14 +483,6 @@ GLOBAL_FUNCTION(write_rdram_new):
     str    r0, [r2, r3, lsl #2]
     b      .E12
 
-GLOBAL_FUNCTION(write_rdramb_new):
-    ldr    r3, [fp, #fp_ram_offset]
-    ldr    r2, [fp, #fp_address]
-    ldrb   r0, [fp, #fp_wbyte]
-    eor    r2, r2, #3
-    strb   r0, [r2, r3, lsl #2]
-    b      .E12
-
 GLOBAL_FUNCTION(write_rdramh_new):
     ldr    r3, [fp, #fp_ram_offset]
     ldr    r2, [fp, #fp_address]
@@ -631,30 +622,6 @@ GLOBAL_FUNCTION(write_nomem_new):
     str    r0, [r1, r12, lsl #2]
     mov    pc, lr
 
-GLOBAL_FUNCTION(write_nomemb_new):
-    str    r3, [fp, #fp_free_space]
-    str    lr, [fp, #fp_free_space+4]
-    bl     do_invalidate
-    ldr    r1, [fp, #fp_address]
-#ifdef ARMv5_ONLY
-    ldr    r12, =fp_memory_map
-#else
-    movw   r12, #:lower16:fp_memory_map
-    movt   r12, #:upper16:fp_memory_map
-#endif
-    add    r12, fp, r12
-    ldr    lr, [fp, #fp_free_space+4]
-    lsr    r0, r1, #12
-    ldr    r3, [fp, #fp_free_space]
-    ldr    r12, [r12, r0, lsl #2]
-    mov    r2, #1
-    tst    r12, #0x40000000
-    bne    tlb_exception
-    eor    r1, r1, #3
-    ldrb   r0, [fp, #fp_wbyte]
-    strb   r0, [r1, r12, lsl #2]
-    mov    pc, lr
-
 GLOBAL_FUNCTION(write_nomemh_new):
     str    r3, [fp, #fp_free_space]
     str    lr, [fp, #fp_free_space+4]
@@ -714,21 +681,6 @@ GLOBAL_FUNCTION(write_mi_new):
     mov    r1, #0
     str    r1, [fp, #fp_pending_exception]
     bl     write_mi
-    ldr    lr, [fp, #fp_free_space+4]
-    ldr    r3, [fp, #fp_free_space]
-    ldr    r1, [fp, #fp_pending_exception]
-    tst    r1, r1
-    bne    mi_exception
-    mov    pc, lr
-    
-GLOBAL_FUNCTION(write_mib_new):
-    str    r3, [fp, #fp_free_space]
-    str    lr, [fp, #fp_free_space+4]
-    add    r3, #4
-    str    r3, [fp, #fp_pcaddr]
-    mov    r1, #0
-    str    r1, [fp, #fp_pending_exception]
-    bl     write_mib
     ldr    lr, [fp, #fp_free_space+4]
     ldr    r3, [fp, #fp_free_space]
     ldr    r1, [fp, #fp_pending_exception]

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -82,6 +82,7 @@ fp_stop                = offsetof_struct_new_dynarec_hot_state_stop
 fp_invc_ptr            = offsetof_struct_new_dynarec_hot_state_invc_ptr
 fp_address             = offsetof_struct_new_dynarec_hot_state_address
 fp_rdword              = offsetof_struct_new_dynarec_hot_state_rdword
+fp_wmask               = offsetof_struct_new_dynarec_hot_state_wmask
 fp_wdword              = offsetof_struct_new_dynarec_hot_state_wdword
 fp_wword               = offsetof_struct_new_dynarec_hot_state_wword
 fp_whword              = offsetof_struct_new_dynarec_hot_state_whword
@@ -474,6 +475,12 @@ GLOBAL_FUNCTION(write_rdram_new):
     ldr    r3, [fp, #fp_ram_offset]
     ldr    r2, [fp, #fp_address]
     ldr    r0, [fp, #fp_wword]
+    ldr    r12, [fp, #fp_wmask]
+    and    r0, r0, r12
+    mvn    r12, r12
+    ldr    r1, [r2, r3, lsl #2]
+    and    r12, r1, r12
+    orr    r0, r0, r12
     str    r0, [r2, r3, lsl #2]
     b      .E12
 
@@ -615,6 +622,12 @@ GLOBAL_FUNCTION(write_nomem_new):
     tst    r12, #0x40000000
     bne    tlb_exception
     ldr    r0, [fp, #fp_wword]
+    ldr    r2, [fp, #fp_wmask]
+    and    r0, r0, r2
+    mvn    r2, r2
+    ldr    r3, [r1, r12, lsl #2]
+    and    r2, r3, r2
+    orr    r0, r0, r2
     str    r0, [r1, r12, lsl #2]
     mov    pc, lr
 

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -71,8 +71,9 @@
 device_r4300_new_dynarec_hot_state_dynarec_local = (offsetof_struct_device_r4300 + offsetof_struct_r4300_core_new_dynarec_hot_state + offsetof_struct_new_dynarec_hot_state_dynarec_local)
 
 /* Defines offsets for fp addressed variables */
-fp_free_space          = offsetof_struct_new_dynarec_hot_state_dynarec_local + 20
 fp_saved_context       = offsetof_struct_new_dynarec_hot_state_dynarec_local + 28
+fp_stack_level_1       = offsetof_struct_new_dynarec_hot_state_dynarec_local + 64
+fp_stack_level_2       = offsetof_struct_new_dynarec_hot_state_dynarec_local + 96
 fp_next_interrupt      = offsetof_struct_new_dynarec_hot_state_next_interrupt
 fp_cycle_count         = offsetof_struct_new_dynarec_hot_state_cycle_count
 fp_last_count          = offsetof_struct_new_dynarec_hot_state_last_count
@@ -337,15 +338,6 @@ GLOBAL_FUNCTION(jump_syscall):
     bl     get_addr_ht
     mov    pc, r0
 
-GLOBAL_FUNCTION(indirect_jump_indexed):
-    ldr    r0, [r0, r1, lsl #2]
-
-GLOBAL_FUNCTION(indirect_jump):
-    ldr    r12, [fp, #fp_last_count]
-    add    r2, r2, r12 
-    str    r2, [fp, #fp_cp0_regs+36] /* Count */
-    mov    pc, r0
-
 GLOBAL_FUNCTION(jump_eret):
     ldr    r1, [fp, #fp_cp0_regs+48] /* Status */
     ldr    r0, [fp, #fp_last_count]
@@ -469,6 +461,154 @@ LOCAL_FUNCTION(invalidate_addr_call):
     bl     invalidate_block
     ldmia  fp, {r0, r1, r2, r3, r12, pc}
 
+GLOBAL_FUNCTION(read_byte_new):
+    ldr    r12, [fp, #fp_last_count]
+    add    r2, r2, r12
+    str    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r1, [fp, #fp_address]
+    and    r12, r1, #3
+    eor    r12, r12, #3
+    lsl    r12, r12, #3
+    str    r12, [fp, #fp_stack_level_1]
+    bic    r1, r1, #3
+    str    r1, [fp, #fp_address]
+    lsr    r1, r1, #16
+    ldr    r0, [r0, r1, lsl #2]
+    str    lr, [fp, #fp_stack_level_1+4]
+    mov    lr, pc
+    mov    pc, r0
+    ldr    lr, [fp, #fp_stack_level_1+4]
+    ldr    r12, [fp, #fp_stack_level_1]
+    ldr    r1, [fp, #fp_rdword]
+    lsr    r1, r1, r12
+    and    r1, r1, #0xff
+    str    r1, [fp, #fp_rdword]
+    mov    pc, lr
+
+GLOBAL_FUNCTION(read_hword_new):
+    ldr    r12, [fp, #fp_last_count]
+    add    r2, r2, r12
+    str    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r1, [fp, #fp_address]
+    and    r12, r1, #2
+    eor    r12, r12, #2
+    lsl    r12, r12, #3
+    str    r12, [fp, #fp_stack_level_1]
+    bic    r1, r1, #3
+    str    r1, [fp, #fp_address]
+    lsr    r1, r1, #16
+    ldr    r0, [r0, r1, lsl #2]
+    str    lr, [fp, #fp_stack_level_1+4]
+    mov    lr, pc
+    mov    pc, r0
+    ldr    lr, [fp, #fp_stack_level_1+4]
+    ldr    r12, [fp, #fp_stack_level_1]
+    ldr    r1, [fp, #fp_rdword]
+    lsr    r1, r1, r12
+#ifdef ARMv5_ONLY
+    ldr    r12, =0xffff
+#else
+    movw   r12, #0xffff
+#endif
+    and    r1, r1, r12
+    str    r1, [fp, #fp_rdword]
+    mov    pc, lr
+
+GLOBAL_FUNCTION(read_word_new):
+GLOBAL_FUNCTION(read_dword_new):
+    ldr    r12, [fp, #fp_last_count]
+    add    r2, r2, r12
+    str    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r1, [fp, #fp_address]
+    lsr    r1, r1, #16
+    ldr    r0, [r0, r1, lsl #2]
+    str    lr, [fp, #fp_stack_level_1]
+    mov    lr, pc
+    mov    pc, r0
+    ldr    lr, [fp, #fp_stack_level_1]
+    mov    pc, lr
+
+GLOBAL_FUNCTION(write_byte_new):
+    ldr    r12, [fp, #fp_last_count]
+    add    r2, r2, r12
+    str    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r1, [fp, #fp_address]
+    and    r12, r1, #3
+    eor    r12, r12, #3
+    lsl    r12, r12, #3
+    ldr    r2, [fp, #fp_wword]
+    lsl    r2, r2, r12
+    str    r2, [fp, #fp_wword]
+    mov    r2, #0xff
+    lsl    r2, r2, r12
+    str    r2, [fp, #fp_wmask]
+    bic    r1, r1, #3
+    str    r1, [fp, #fp_address]
+    lsr    r1, r1, #16
+    ldr    r0, [r0, r1, lsl #2]
+    str    lr, [fp, #fp_stack_level_1]
+    mov    lr, pc
+    mov    pc, r0
+    ldr    lr, [fp, #fp_stack_level_1]
+    ldr    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r12, [fp, #fp_next_interrupt]
+    sub    r2, r2, r12
+    str    r12, [fp, #fp_last_count]
+    mov    pc, lr
+
+GLOBAL_FUNCTION(write_hword_new):
+    ldr    r12, [fp, #fp_last_count]
+    add    r2, r2, r12
+    str    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r1, [fp, #fp_address]
+    and    r12, r1, #2
+    eor    r12, r12, #2
+    lsl    r12, r12, #3
+    ldr    r2, [fp, #fp_wword]
+    lsl    r2, r2, r12
+    str    r2, [fp, #fp_wword]
+#ifdef ARMv5_ONLY
+    ldr    r2, =0xffff
+#else
+    movw   r2, #0xffff
+#endif
+    lsl    r2, r2, r12
+    str    r2, [fp, #fp_wmask]
+    bic    r1, r1, #3
+    str    r1, [fp, #fp_address]
+    lsr    r1, r1, #16
+    ldr    r0, [r0, r1, lsl #2]
+    str    lr, [fp, #fp_stack_level_1]
+    mov    lr, pc
+    mov    pc, r0
+    ldr    lr, [fp, #fp_stack_level_1]
+    ldr    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r12, [fp, #fp_next_interrupt]
+    sub    r2, r2, r12
+    str    r12, [fp, #fp_last_count]
+    mov    pc, lr
+
+GLOBAL_FUNCTION(write_word_new):
+    mvn    r12, #0
+    str    r12, [fp, #fp_wmask]
+    
+GLOBAL_FUNCTION(write_dword_new):
+    ldr    r12, [fp, #fp_last_count]
+    add    r2, r2, r12
+    str    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r1, [fp, #fp_address]
+    lsr    r1, r1, #16
+    ldr    r0, [r0, r1, lsl #2]
+    str    lr, [fp, #fp_stack_level_1]
+    mov    lr, pc
+    mov    pc, r0
+    ldr    lr, [fp, #fp_stack_level_1]
+    ldr    r2, [fp, #fp_cp0_regs+36] /* Count */
+    ldr    r12, [fp, #fp_next_interrupt]
+    sub    r2, r2, r12
+    str    r12, [fp, #fp_last_count]
+    mov    pc, lr
+
 GLOBAL_FUNCTION(write_rdram_new):
     ldr    r3, [fp, #fp_ram_offset]
     ldr    r2, [fp, #fp_address]
@@ -545,8 +685,8 @@ GLOBAL_FUNCTION(read_nomemd_new):
     mov    pc, lr
 
 GLOBAL_FUNCTION(write_nomem_new):
-    str    r3, [fp, #fp_free_space]
-    str    lr, [fp, #fp_free_space+4]
+    str    r3, [fp, #fp_stack_level_2]
+    str    lr, [fp, #fp_stack_level_2+4]
     bl     do_invalidate
     ldr    r1, [fp, #fp_address]
 #ifdef ARMv5_ONLY
@@ -556,9 +696,9 @@ GLOBAL_FUNCTION(write_nomem_new):
     movt   r12, #:upper16:fp_memory_map
 #endif
     add    r12, fp, r12
-    ldr    lr, [fp, #fp_free_space+4]
+    ldr    lr, [fp, #fp_stack_level_2+4]
     lsr    r0, r1, #12
-    ldr    r3, [fp, #fp_free_space]
+    ldr    r3, [fp, #fp_stack_level_2]
     ldr    r12, [r12, r0, lsl #2]
     mov    r2, #1
     tst    r12, #0x40000000
@@ -574,8 +714,8 @@ GLOBAL_FUNCTION(write_nomem_new):
     mov    pc, lr
 
 GLOBAL_FUNCTION(write_nomemd_new):
-    str    r3, [fp, #fp_free_space]
-    str    lr, [fp, #fp_free_space+4]
+    str    r3, [fp, #fp_stack_level_2]
+    str    lr, [fp, #fp_stack_level_2+4]
     bl     do_invalidate
     ldr    r1, [fp, #fp_address]
 #ifdef ARMv5_ONLY
@@ -585,9 +725,9 @@ GLOBAL_FUNCTION(write_nomemd_new):
     movt   r12, #:upper16:fp_memory_map
 #endif
     add    r12, fp, r12
-    ldr    lr, [fp, #fp_free_space+4]
+    ldr    lr, [fp, #fp_stack_level_2+4]
     lsr    r0, r1, #12
-    ldr    r3, [fp, #fp_free_space]
+    ldr    r3, [fp, #fp_stack_level_2]
     ldr    r12, [r12, r0, lsl #2]
     mov    r2, #1
     lsls   r12, #2
@@ -601,30 +741,30 @@ GLOBAL_FUNCTION(write_nomemd_new):
     mov    pc, lr
     
 GLOBAL_FUNCTION(write_mi_new):
-    str    r3, [fp, #fp_free_space]
-    str    lr, [fp, #fp_free_space+4]
+    str    r3, [fp, #fp_stack_level_2]
+    str    lr, [fp, #fp_stack_level_2+4]
     add    r3, #4
     str    r3, [fp, #fp_pcaddr]
     mov    r1, #0
     str    r1, [fp, #fp_pending_exception]
     bl     write_mi
-    ldr    lr, [fp, #fp_free_space+4]
-    ldr    r3, [fp, #fp_free_space]
+    ldr    lr, [fp, #fp_stack_level_2+4]
+    ldr    r3, [fp, #fp_stack_level_2]
     ldr    r1, [fp, #fp_pending_exception]
     tst    r1, r1
     bne    mi_exception
     mov    pc, lr
     
 GLOBAL_FUNCTION(write_mid_new):
-    str    r3, [fp, #fp_free_space]
-    str    lr, [fp, #fp_free_space+4]
+    str    r3, [fp, #fp_stack_level_2]
+    str    lr, [fp, #fp_stack_level_2+4]
     add    r3, #4
     str    r3, [fp, #fp_pcaddr]
     mov    r1, #0
     str    r1, [fp, #fp_pending_exception]
     bl     write_mid
-    ldr    lr, [fp, #fp_free_space+4]
-    ldr    r3, [fp, #fp_free_space]
+    ldr    lr, [fp, #fp_stack_level_2+4]
+    ldr    r3, [fp, #fp_stack_level_2]
     ldr    r1, [fp, #fp_pending_exception]
     tst    r1, r1
     bne    mi_exception

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -521,26 +521,6 @@ GLOBAL_FUNCTION(read_nomem_new):
     str    r0, [fp, #fp_rdword]
     mov    pc, lr
 
-GLOBAL_FUNCTION(read_nomemh_new):
-    ldr    r1, [fp, #fp_address]
-#ifdef ARMv5_ONLY
-    ldr    r12, =fp_memory_map
-#else
-    movw   r12, #:lower16:fp_memory_map
-    movt   r12, #:upper16:fp_memory_map
-#endif
-    add    r12, fp, r12
-    lsr    r0, r1, #12
-    ldr    r12, [r12, r0, lsl #2]
-    mov    r2, #0
-    tst    r12, r12
-    bmi    tlb_exception
-    lsl    r12, r12, #2
-    eor    r1, r1, #2
-    ldrh   r0, [r1, r12]
-    str    r0, [fp, #fp_rdword]
-    mov    pc, lr
-
 GLOBAL_FUNCTION(read_nomemd_new):
     ldr    r1, [fp, #fp_address]
 #ifdef ARMv5_ONLY

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -85,7 +85,6 @@ fp_rdword              = offsetof_struct_new_dynarec_hot_state_rdword
 fp_wmask               = offsetof_struct_new_dynarec_hot_state_wmask
 fp_wdword              = offsetof_struct_new_dynarec_hot_state_wdword
 fp_wword               = offsetof_struct_new_dynarec_hot_state_wword
-fp_whword              = offsetof_struct_new_dynarec_hot_state_whword
 fp_fcr0                = offsetof_struct_new_dynarec_hot_state_fcr0
 fp_fcr31               = offsetof_struct_new_dynarec_hot_state_fcr31
 fp_regs                = offsetof_struct_new_dynarec_hot_state_regs
@@ -483,15 +482,6 @@ GLOBAL_FUNCTION(write_rdram_new):
     str    r0, [r2, r3, lsl #2]
     b      .E12
 
-GLOBAL_FUNCTION(write_rdramh_new):
-    ldr    r3, [fp, #fp_ram_offset]
-    ldr    r2, [fp, #fp_address]
-    ldrh   r0, [fp, #fp_whword]
-    eor    r2, r2, #2
-    lsl    r3, r3, #2
-    strh   r0, [r2, r3]
-    b      .E12
-
 GLOBAL_FUNCTION(write_rdramd_new):
     ldr    r3, [fp, #fp_ram_offset]
     ldr    r2, [fp, #fp_address]
@@ -622,30 +612,6 @@ GLOBAL_FUNCTION(write_nomem_new):
     str    r0, [r1, r12, lsl #2]
     mov    pc, lr
 
-GLOBAL_FUNCTION(write_nomemh_new):
-    str    r3, [fp, #fp_free_space]
-    str    lr, [fp, #fp_free_space+4]
-    bl     do_invalidate
-    ldr    r1, [fp, #fp_address]
-#ifdef ARMv5_ONLY
-    ldr    r12, =fp_memory_map
-#else
-    movw   r12, #:lower16:fp_memory_map
-    movt   r12, #:upper16:fp_memory_map
-#endif
-    add    r12, fp, r12
-    ldr    lr, [fp, #fp_free_space+4]
-    lsr    r0, r1, #12
-    ldr    r3, [fp, #fp_free_space]
-    ldr    r12, [r12, r0, lsl #2]
-    mov    r2, #1
-    lsls   r12, #2
-    bcs    tlb_exception
-    eor    r1, r1, #2
-    ldrh   r0, [fp, #fp_whword]
-    strh   r0, [r1, r12]
-    mov    pc, lr
-
 GLOBAL_FUNCTION(write_nomemd_new):
     str    r3, [fp, #fp_free_space]
     str    lr, [fp, #fp_free_space+4]
@@ -681,21 +647,6 @@ GLOBAL_FUNCTION(write_mi_new):
     mov    r1, #0
     str    r1, [fp, #fp_pending_exception]
     bl     write_mi
-    ldr    lr, [fp, #fp_free_space+4]
-    ldr    r3, [fp, #fp_free_space]
-    ldr    r1, [fp, #fp_pending_exception]
-    tst    r1, r1
-    bne    mi_exception
-    mov    pc, lr
-    
-GLOBAL_FUNCTION(write_mih_new):
-    str    r3, [fp, #fp_free_space]
-    str    lr, [fp, #fp_free_space+4]
-    add    r3, #4
-    str    r3, [fp, #fp_pcaddr]
-    mov    r1, #0
-    str    r1, [fp, #fp_pending_exception]
-    bl     write_mih
     ldr    lr, [fp, #fp_free_space+4]
     ldr    r3, [fp, #fp_free_space]
     ldr    r1, [fp, #fp_pending_exception]

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -521,25 +521,6 @@ GLOBAL_FUNCTION(read_nomem_new):
     str    r0, [fp, #fp_rdword]
     mov    pc, lr
 
-GLOBAL_FUNCTION(read_nomemb_new):
-    ldr    r1, [fp, #fp_address]
-#ifdef ARMv5_ONLY
-    ldr    r12, =fp_memory_map
-#else
-    movw   r12, #:lower16:fp_memory_map
-    movt   r12, #:upper16:fp_memory_map
-#endif
-    add    r12, fp, r12
-    lsr    r0, r1, #12
-    ldr    r12, [r12, r0, lsl #2]
-    mov    r2, #0
-    tst    r12, r12
-    bmi    tlb_exception
-    eor    r1, r1, #3
-    ldrb   r0, [r1, r12, lsl #2]
-    str    r0, [fp, #fp_rdword]
-    mov    pc, lr
-
 GLOBAL_FUNCTION(read_nomemh_new):
     ldr    r1, [fp, #fp_address]
 #ifdef ARMv5_ONLY

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -183,7 +183,6 @@ void fp_exception_ds(void);
 void jump_syscall(void);
 void jump_eret(void);
 void read_nomem_new(void);
-void read_nomemh_new(void);
 void read_nomemd_new(void);
 void write_nomem_new(void);
 void write_nomemd_new(void);
@@ -7632,7 +7631,6 @@ void new_dynarec_init(void)
     g_dev.mem.writemem[n] = write_nomem_new;
     g_dev.mem.writememd[n] = write_nomemd_new;
     g_dev.mem.readmem[n] = read_nomem_new;
-    g_dev.mem.readmemh[n] = read_nomemh_new;
     g_dev.mem.readmemd[n] = read_nomemd_new;
   }
   for(n=0x8000;n<0x8080;n++) { // 0x80000000 .. 0x807FFFFF
@@ -7643,7 +7641,6 @@ void new_dynarec_init(void)
     g_dev.mem.writemem[n] = write_nomem_new;
     g_dev.mem.writememd[n] = write_nomemd_new;
     g_dev.mem.readmem[n] = read_nomem_new;
-    g_dev.mem.readmemh[n] = read_nomemh_new;
     g_dev.mem.readmemd[n] = read_nomemd_new;
   }
 

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -187,13 +187,10 @@ void read_nomemb_new(void);
 void read_nomemh_new(void);
 void read_nomemd_new(void);
 void write_nomem_new(void);
-void write_nomemh_new(void);
 void write_nomemd_new(void);
 void write_rdram_new(void);
-void write_rdramh_new(void);
 void write_rdramd_new(void);
 void write_mi_new(void);
-void write_mih_new(void);
 void write_mid_new(void);
 
 /* interpreted opcode */
@@ -7634,7 +7631,6 @@ void new_dynarec_init(void)
     g_dev.r4300.new_dynarec_hot_state.memory_map[n]=-1;
   for(n=0;n<0x8000;n++) { // 0 .. 0x7FFFFFFF
     g_dev.mem.writemem[n] = write_nomem_new;
-    g_dev.mem.writememh[n] = write_nomemh_new;
     g_dev.mem.writememd[n] = write_nomemd_new;
     g_dev.mem.readmem[n] = read_nomem_new;
     g_dev.mem.readmemb[n] = read_nomemb_new;
@@ -7643,12 +7639,10 @@ void new_dynarec_init(void)
   }
   for(n=0x8000;n<0x8080;n++) { // 0x80000000 .. 0x807FFFFF
     g_dev.mem.writemem[n] = write_rdram_new;
-    g_dev.mem.writememh[n] = write_rdramh_new;
     g_dev.mem.writememd[n] = write_rdramd_new;
   }
   for(n=0xC000;n<0x10000;n++) { // 0xC0000000 .. 0xFFFFFFFF
     g_dev.mem.writemem[n] = write_nomem_new;
-    g_dev.mem.writememh[n] = write_nomemh_new;
     g_dev.mem.writememd[n] = write_nomemd_new;
     g_dev.mem.readmem[n] = read_nomem_new;
     g_dev.mem.readmemb[n] = read_nomemb_new;
@@ -7657,11 +7651,9 @@ void new_dynarec_init(void)
   }
 
   g_dev.mem.writemem[0x8430] = write_mi_new;
-  g_dev.mem.writememh[0x8430] = write_mih_new;
   g_dev.mem.writememd[0x8430] = write_mid_new;
 
   g_dev.mem.writemem[0xa430] = write_mi_new;
-  g_dev.mem.writememh[0xa430] = write_mih_new;
   g_dev.mem.writememd[0xa430] = write_mid_new;
 
   tlb_hacks();

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -187,15 +187,12 @@ void read_nomemb_new(void);
 void read_nomemh_new(void);
 void read_nomemd_new(void);
 void write_nomem_new(void);
-void write_nomemb_new(void);
 void write_nomemh_new(void);
 void write_nomemd_new(void);
 void write_rdram_new(void);
-void write_rdramb_new(void);
 void write_rdramh_new(void);
 void write_rdramd_new(void);
 void write_mi_new(void);
-void write_mib_new(void);
 void write_mih_new(void);
 void write_mid_new(void);
 
@@ -7637,7 +7634,6 @@ void new_dynarec_init(void)
     g_dev.r4300.new_dynarec_hot_state.memory_map[n]=-1;
   for(n=0;n<0x8000;n++) { // 0 .. 0x7FFFFFFF
     g_dev.mem.writemem[n] = write_nomem_new;
-    g_dev.mem.writememb[n] = write_nomemb_new;
     g_dev.mem.writememh[n] = write_nomemh_new;
     g_dev.mem.writememd[n] = write_nomemd_new;
     g_dev.mem.readmem[n] = read_nomem_new;
@@ -7647,13 +7643,11 @@ void new_dynarec_init(void)
   }
   for(n=0x8000;n<0x8080;n++) { // 0x80000000 .. 0x807FFFFF
     g_dev.mem.writemem[n] = write_rdram_new;
-    g_dev.mem.writememb[n] = write_rdramb_new;
     g_dev.mem.writememh[n] = write_rdramh_new;
     g_dev.mem.writememd[n] = write_rdramd_new;
   }
   for(n=0xC000;n<0x10000;n++) { // 0xC0000000 .. 0xFFFFFFFF
     g_dev.mem.writemem[n] = write_nomem_new;
-    g_dev.mem.writememb[n] = write_nomemb_new;
     g_dev.mem.writememh[n] = write_nomemh_new;
     g_dev.mem.writememd[n] = write_nomemd_new;
     g_dev.mem.readmem[n] = read_nomem_new;
@@ -7663,12 +7657,10 @@ void new_dynarec_init(void)
   }
 
   g_dev.mem.writemem[0x8430] = write_mi_new;
-  g_dev.mem.writememb[0x8430] = write_mib_new;
   g_dev.mem.writememh[0x8430] = write_mih_new;
   g_dev.mem.writememd[0x8430] = write_mid_new;
 
   g_dev.mem.writemem[0xa430] = write_mi_new;
-  g_dev.mem.writememb[0xa430] = write_mib_new;
   g_dev.mem.writememh[0xa430] = write_mih_new;
   g_dev.mem.writememd[0xa430] = write_mid_new;
 

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -183,7 +183,6 @@ void fp_exception_ds(void);
 void jump_syscall(void);
 void jump_eret(void);
 void read_nomem_new(void);
-void read_nomemb_new(void);
 void read_nomemh_new(void);
 void read_nomemd_new(void);
 void write_nomem_new(void);
@@ -7633,7 +7632,6 @@ void new_dynarec_init(void)
     g_dev.mem.writemem[n] = write_nomem_new;
     g_dev.mem.writememd[n] = write_nomemd_new;
     g_dev.mem.readmem[n] = read_nomem_new;
-    g_dev.mem.readmemb[n] = read_nomemb_new;
     g_dev.mem.readmemh[n] = read_nomemh_new;
     g_dev.mem.readmemd[n] = read_nomemd_new;
   }
@@ -7645,7 +7643,6 @@ void new_dynarec_init(void)
     g_dev.mem.writemem[n] = write_nomem_new;
     g_dev.mem.writememd[n] = write_nomemd_new;
     g_dev.mem.readmem[n] = read_nomem_new;
-    g_dev.mem.readmemb[n] = read_nomemb_new;
     g_dev.mem.readmemh[n] = read_nomemh_new;
     g_dev.mem.readmemd[n] = read_nomemd_new;
   }

--- a/src/device/r4300/new_dynarec/new_dynarec.h
+++ b/src/device/r4300/new_dynarec/new_dynarec.h
@@ -69,7 +69,6 @@ struct new_dynarec_hot_state
     uint32_t wmask;
     uint64_t wdword;
     uint32_t wword;
-    uint16_t whword;
     uint32_t fcr0;
     uint32_t fcr31;
     int64_t  regs[32];

--- a/src/device/r4300/new_dynarec/new_dynarec.h
+++ b/src/device/r4300/new_dynarec/new_dynarec.h
@@ -70,7 +70,6 @@ struct new_dynarec_hot_state
     uint64_t wdword;
     uint32_t wword;
     uint16_t whword;
-    uint8_t  wbyte;
     uint32_t fcr0;
     uint32_t fcr31;
     int64_t  regs[32];

--- a/src/device/r4300/new_dynarec/new_dynarec.h
+++ b/src/device/r4300/new_dynarec/new_dynarec.h
@@ -53,10 +53,11 @@ struct new_dynarec_hot_state
     unsigned char restore_candidate[512];
     unsigned int memory_map[1048576];
 #elif NEW_DYNAREC == NEW_DYNAREC_ARM
-    /* 0-4: Stack space used by dynarec to push/pop caller-saved register (r0-r3, r12)
-       5-6: free_space,
-       6-15: saved_context */
-    uint32_t dynarec_local[16];
+    /* 0-6:   used by dynarec to push/pop caller-saved register (r0-r3, r12) and possibly lr (see invalidate_addr)
+       7-15:  saved_context,
+       16-23: stack_level_1
+       24-31: stack_level_2 */
+    uint32_t dynarec_local[32];
     unsigned int next_interrupt;
     int cycle_count;
     int last_count;

--- a/src/device/r4300/new_dynarec/new_dynarec.h
+++ b/src/device/r4300/new_dynarec/new_dynarec.h
@@ -66,6 +66,7 @@ struct new_dynarec_hot_state
     char* invc_ptr;
     uint32_t address;
     uint64_t rdword;
+    uint32_t wmask;
     uint64_t wdword;
     uint32_t wword;
     uint16_t whword;

--- a/src/device/r4300/new_dynarec/x86/assem_x86.c
+++ b/src/device/r4300/new_dynarec/x86/assem_x86.c
@@ -2859,8 +2859,10 @@ static void do_writestub(int n)
     emit_writebyte(rt,(int)r4300_wbyte(&g_dev.r4300));
   if(type==STOREH_STUB)
     emit_writehword(rt,(int)r4300_whword(&g_dev.r4300));
-  if(type==STOREW_STUB)
+  if(type==STOREW_STUB) {
     emit_writeword(rt,(int)r4300_wword(&g_dev.r4300));
+    emit_writeword_imm(~UINT32_C(0),(int)r4300_wmask(&g_dev.r4300));
+  }
   if(type==STORED_STUB) {
     emit_writeword(rt,(int)r4300_wdword(&g_dev.r4300));
     emit_writeword(r?rth:rt,(int)r4300_wdword(&g_dev.r4300)+4);
@@ -2933,8 +2935,10 @@ static void inline_writestub(int type, int i, u_int addr, signed char regmap[], 
     emit_writebyte(rt,(int)r4300_wbyte(&g_dev.r4300));
   if(type==STOREH_STUB)
     emit_writehword(rt,(int)r4300_whword(&g_dev.r4300));
-  if(type==STOREW_STUB)
+  if(type==STOREW_STUB) {
     emit_writeword(rt,(int)r4300_wword(&g_dev.r4300));
+    emit_writeword_imm(~UINT32_C(0),(int)r4300_wmask(&g_dev.r4300));
+  }
   if(type==STORED_STUB) {
     emit_writeword(rt,(int)r4300_wdword(&g_dev.r4300));
     emit_writeword(target?rth:rt,(int)r4300_wdword(&g_dev.r4300)+4);

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -102,7 +102,6 @@ cglobal invalidate_block_edi
 cglobal write_rdram_new
 cglobal write_rdramd_new
 cglobal read_nomem_new
-cglobal read_nomemh_new
 cglobal read_nomemd_new
 cglobal write_nomem_new
 cglobal write_nomemd_new
@@ -515,20 +514,6 @@ read_nomem_new:
     test    edx,    edx
     js      tlb_exception
     mov     ecx,    [edi+edx*4]
-    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)],    ecx
-    ret
-
-read_nomemh_new:
-    get_got_address
-    mov     edx,    [find_local_data(g_dev_r4300_address)]
-    mov     edi,    edx
-    shr     edx,    12
-    mov     edx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_memory_map+edx*4)]
-    mov     eax,    00h
-    test    edx,    edx
-    js      tlb_exception
-    xor     edi,    2
-    movzx   ecx,    WORD [edi+edx*4]
     mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)],    ecx
     ret
 

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -75,6 +75,10 @@
 %define g_dev_r4300_new_dynarec_hot_state_branch_target     (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_new_dynarec_hot_state + offsetof_struct_new_dynarec_hot_state_branch_target)
 %define g_dev_r4300_new_dynarec_hot_state_restore_candidate (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_new_dynarec_hot_state + offsetof_struct_new_dynarec_hot_state_restore_candidate)
 %define g_dev_r4300_new_dynarec_hot_state_memory_map        (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_new_dynarec_hot_state + offsetof_struct_new_dynarec_hot_state_memory_map)
+%define g_dev_mem_readmem                                   (g_dev + offsetof_struct_device_mem + offsetof_struct_memory_readmem)
+%define g_dev_mem_readmemd                                  (g_dev + offsetof_struct_device_mem + offsetof_struct_memory_readmemd)
+%define g_dev_mem_writemem                                  (g_dev + offsetof_struct_device_mem + offsetof_struct_memory_writemem)
+%define g_dev_mem_writememd                                 (g_dev + offsetof_struct_device_mem + offsetof_struct_memory_writememd)
 
 cglobal jump_vaddr_eax
 cglobal jump_vaddr_ecx
@@ -99,6 +103,14 @@ cglobal invalidate_block_ebx
 cglobal invalidate_block_ebp
 cglobal invalidate_block_esi
 cglobal invalidate_block_edi
+cglobal read_byte_new
+cglobal read_hword_new
+cglobal read_word_new
+cglobal read_dword_new
+cglobal write_byte_new
+cglobal write_hword_new
+cglobal write_word_new
+cglobal write_dword_new
 cglobal write_rdram_new
 cglobal write_rdramd_new
 cglobal read_nomem_new
@@ -119,8 +131,6 @@ cextern invalidate_block
 cextern new_dynarec_check_interrupt
 cextern get_addr_32
 cextern write_mi
-cextern write_mib
-cextern write_mih
 cextern write_mid
 cextern TLB_refill_exception_new
 cextern g_dev
@@ -467,6 +477,151 @@ invalidate_block_call:
     pop     eax
     ret
 
+read_byte_new:
+    get_got_address
+    add     esi,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)]
+    mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi
+    mov     eax,    [find_local_data(g_dev_r4300_address)]
+    mov     ecx,    eax
+    and     ecx,    3
+    xor     ecx,    3
+    shl     ecx,    3
+    mov     [find_local_data(g_dev_r4300_wmask)], ecx
+    and     eax,    0xFFFFFFFC
+    mov     [find_local_data(g_dev_r4300_address)], eax
+    shr     eax,    16
+    mov     eax,    [eax*4 + find_local_data(g_dev_mem_readmem)]
+    call    eax
+    mov     ecx,    [find_local_data(g_dev_r4300_wmask)]
+    mov     eax,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)]
+    shr     eax,    cl
+    and     eax,    0xFF
+    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)], eax
+    ret
+
+read_hword_new:
+    get_got_address
+    add     esi,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)]
+    mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi
+    mov     eax,    [find_local_data(g_dev_r4300_address)]
+    mov     ecx,    eax
+    and     ecx,    2
+    xor     ecx,    2
+    shl     ecx,    3
+    mov     [find_local_data(g_dev_r4300_wmask)], ecx
+    and     eax,    0xFFFFFFFC
+    mov     [find_local_data(g_dev_r4300_address)], eax
+    shr     eax,    16
+    mov     eax,    [eax*4 + find_local_data(g_dev_mem_readmem)]
+    call    eax
+    mov     ecx,    [find_local_data(g_dev_r4300_wmask)]
+    mov     eax,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)]
+    shr     eax,    cl
+    and     eax,    0xFFFF
+    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)], eax
+    ret
+
+read_word_new:
+    get_got_address
+    add     esi,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)]
+    mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi
+    mov     eax,    [find_local_data(g_dev_r4300_address)]
+    shr     eax,    16
+    mov     eax,    [eax*4 + find_local_data(g_dev_mem_readmem)]
+    call    eax
+    ret
+
+read_dword_new:
+    get_got_address
+    add     esi,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)]
+    mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi
+    mov     eax,    [find_local_data(g_dev_r4300_address)]
+    shr     eax,    16
+    mov     eax,    [eax*4 + find_local_data(g_dev_mem_readmemd)]
+    call    eax
+    ret
+
+write_byte_new:
+    get_got_address
+    add     esi,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)]
+    mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi
+    mov     eax,    [find_local_data(g_dev_r4300_address)]
+    mov     ecx,    eax
+    and     ecx,    3
+    xor     ecx,    3
+    shl     ecx,    3
+    mov     edx,    [find_local_data(g_dev_r4300_wword)]
+    shl     edx,    cl
+    mov     [find_local_data(g_dev_r4300_wword)], edx
+    mov     edx,    0xFF
+    shl     edx,    cl
+    mov     [find_local_data(g_dev_r4300_wmask)], edx
+    and     eax,    0xFFFFFFFC
+    mov     [find_local_data(g_dev_r4300_address)], eax
+    shr     eax,    16
+    mov     eax,    [eax*4 + find_local_data(g_dev_mem_writemem)]
+    call    eax
+    mov     eax,    [find_local_data(g_dev_r4300_cp0_next_interrupt)]
+    mov     esi,    [find_local_data(g_dev_r4300_cp0_regs+36)]
+    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)],    eax
+    sub     esi,    eax
+    ret
+
+write_hword_new:
+    get_got_address
+    add     esi,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)]
+    mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi
+    mov     eax,    [find_local_data(g_dev_r4300_address)]
+    mov     ecx,    eax
+    and     ecx,    2
+    xor     ecx,    2
+    shl     ecx,    3
+    mov     edx,    [find_local_data(g_dev_r4300_wword)]
+    shl     edx,    cl
+    mov     [find_local_data(g_dev_r4300_wword)], edx
+    mov     edx,    0xFFFF
+    shl     edx,    cl
+    mov     [find_local_data(g_dev_r4300_wmask)], edx
+    and     eax,    0xFFFFFFFC
+    mov     [find_local_data(g_dev_r4300_address)], eax
+    shr     eax,    16
+    mov     eax,    [eax*4 + find_local_data(g_dev_mem_writemem)]
+    call    eax
+    mov     eax,    [find_local_data(g_dev_r4300_cp0_next_interrupt)]
+    mov     esi,    [find_local_data(g_dev_r4300_cp0_regs+36)]
+    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)],    eax
+    sub     esi,    eax
+    ret
+
+write_word_new:
+    get_got_address
+    add     esi,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)]
+    mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi
+    mov     eax,    [find_local_data(g_dev_r4300_address)]
+    shr     eax,    16
+    mov     eax,    [eax*4 + find_local_data(g_dev_mem_writemem)]
+    mov     DWORD [find_local_data(g_dev_r4300_wmask)], 0xFFFFFFFF
+    call    eax
+    mov     eax,    [find_local_data(g_dev_r4300_cp0_next_interrupt)]
+    mov     esi,    [find_local_data(g_dev_r4300_cp0_regs+36)]
+    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)],    eax
+    sub     esi,    eax
+    ret
+
+write_dword_new:
+    get_got_address
+    add     esi,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)]
+    mov     [find_local_data(g_dev_r4300_cp0_regs+36)],    esi
+    mov     eax,    [find_local_data(g_dev_r4300_address)]
+    shr     eax,    16
+    mov     eax,    [eax*4 + find_local_data(g_dev_mem_writememd)]
+    call    eax
+    mov     eax,    [find_local_data(g_dev_r4300_cp0_next_interrupt)]
+    mov     esi,    [find_local_data(g_dev_r4300_cp0_regs+36)]
+    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_last_count)],    eax
+    sub     esi,    eax
+    ret
+
 write_rdram_new:
     get_got_address
     mov     edx,    [find_local_data(g_dev_r4300_address)]
@@ -589,7 +744,7 @@ mi_exception:
 ;Output:
     ;None
     mov     edi,    [find_local_data(g_dev_r4300_address)]
-    add     esp,    024h
+    add     esp,    028h
     call    wb_base_reg
     jmp     do_interrupt
 
@@ -600,7 +755,7 @@ tlb_exception:
     ;esp+0x24 = instr addr + flags
 ;Output:
     ;None
-    add     esp,    024h
+    add     esp,    028h
     call    wb_base_reg
     add     esp,    -4
     push    eax

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -102,7 +102,6 @@ cglobal invalidate_block_edi
 cglobal write_rdram_new
 cglobal write_rdramd_new
 cglobal read_nomem_new
-cglobal read_nomemb_new
 cglobal read_nomemh_new
 cglobal read_nomemd_new
 cglobal write_nomem_new
@@ -516,20 +515,6 @@ read_nomem_new:
     test    edx,    edx
     js      tlb_exception
     mov     ecx,    [edi+edx*4]
-    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)],    ecx
-    ret
-
-read_nomemb_new:
-    get_got_address
-    mov     edx,    [find_local_data(g_dev_r4300_address)]
-    mov     edi,    edx
-    shr     edx,    12
-    mov     edx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_memory_map+edx*4)]
-    mov     eax,    00h
-    test    edx,    edx
-    js      tlb_exception
-    xor     edi,    3
-    movzx   ecx,    BYTE [edi+edx*4]
     mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)],    ecx
     ret
 

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -57,6 +57,7 @@
 
 %define g_dev_ri_rdram_dram                                 (g_dev + offsetof_struct_device_ri + offsetof_struct_ri_controller_rdram + offsetof_struct_rdram_dram)
 %define g_dev_r4300_address                                 (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_address)
+%define g_dev_r4300_wmask                                   (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wmask)
 %define g_dev_r4300_wword                                   (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wword)
 %define g_dev_r4300_wbyte                                   (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wbyte)
 %define g_dev_r4300_whword                                  (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_whword)
@@ -481,6 +482,11 @@ write_rdram_new:
     mov     edx,    [find_local_data(g_dev_r4300_address)]
     add     edx,    [find_local_data(g_dev_ri_rdram_dram)]
     mov     ecx,    [find_local_data(g_dev_r4300_wword)]
+    mov     eax,    [find_local_data(g_dev_r4300_wmask)]
+    and     ecx,    eax
+    not     eax
+    and     eax,    [edx - 0x80000000]
+    or      ecx,    eax
     mov     [edx - 0x80000000],    ecx
     jmp     _E12
 
@@ -589,6 +595,11 @@ write_nomem_new:
     shl     edx,    2
     jc      tlb_exception
     mov     ecx,    [find_local_data(g_dev_r4300_wword)]
+    mov     eax,    [find_local_data(g_dev_r4300_wmask)]
+    and     ecx,    eax
+    not     eax
+    and     eax,    [edi+edx]
+    or      ecx,    eax
     mov     [edi+edx],    ecx
     ret
 

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -59,7 +59,6 @@
 %define g_dev_r4300_address                                 (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_address)
 %define g_dev_r4300_wmask                                   (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wmask)
 %define g_dev_r4300_wword                                   (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wword)
-%define g_dev_r4300_whword                                  (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_whword)
 %define g_dev_r4300_wdword                                  (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wdword)
 %define g_dev_r4300_stop                                    (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_stop)
 %define g_dev_r4300_regs                                    (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_regs)
@@ -101,17 +100,14 @@ cglobal invalidate_block_ebp
 cglobal invalidate_block_esi
 cglobal invalidate_block_edi
 cglobal write_rdram_new
-cglobal write_rdramh_new
 cglobal write_rdramd_new
 cglobal read_nomem_new
 cglobal read_nomemb_new
 cglobal read_nomemh_new
 cglobal read_nomemd_new
 cglobal write_nomem_new
-cglobal write_nomemh_new
 cglobal write_nomemd_new
 cglobal write_mi_new
-cglobal write_mih_new
 cglobal write_mid_new
 cglobal breakpoint
 
@@ -486,15 +482,6 @@ write_rdram_new:
     mov     [edx - 0x80000000],    ecx
     jmp     _E12
 
-write_rdramh_new:
-    get_got_address
-    mov     edx,    [find_local_data(g_dev_r4300_address)]
-    xor     edx,    2
-    add     edx,    [find_local_data(g_dev_ri_rdram_dram)]
-    mov     cx,     WORD [find_local_data(g_dev_r4300_whword)]
-    mov     WORD [edx - 0x80000000],    cx
-    jmp     _E12
-
 write_rdramd_new:
     get_got_address
     mov     edx,    [find_local_data(g_dev_r4300_address)]
@@ -590,17 +577,6 @@ write_nomem_new:
     mov     [edi+edx],    ecx
     ret
 
-write_nomemh_new:
-    call    do_invalidate
-    mov     edx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_memory_map+edx*4)]
-    mov     eax,    01h
-    shl     edx,    2
-    jc      tlb_exception
-    xor     edi,    2
-    mov     cx,     WORD [find_local_data(g_dev_r4300_whword)]
-    mov     WORD [edi+edx],    cx
-    ret
-
 write_nomemd_new:
     call    do_invalidate
     mov     edx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_memory_map+edx*4)]
@@ -620,18 +596,6 @@ write_mi_new:
     mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_pcaddr)],    ecx
     mov     DWORD [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)],    0
     call    write_mi
-    mov     ecx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)]
-    test    ecx,    ecx
-    jne     mi_exception
-    ret
-
-write_mih_new:
-    get_got_address
-    mov     ecx,    [024h+esp]
-    add     ecx,    4
-    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_pcaddr)],    ecx
-    mov     DWORD [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)],    0
-    call    write_mih
     mov     ecx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)]
     test    ecx,    ecx
     jne     mi_exception

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -59,7 +59,6 @@
 %define g_dev_r4300_address                                 (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_address)
 %define g_dev_r4300_wmask                                   (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wmask)
 %define g_dev_r4300_wword                                   (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wword)
-%define g_dev_r4300_wbyte                                   (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wbyte)
 %define g_dev_r4300_whword                                  (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_whword)
 %define g_dev_r4300_wdword                                  (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_wdword)
 %define g_dev_r4300_stop                                    (g_dev + offsetof_struct_device_r4300 + offsetof_struct_r4300_core_stop)
@@ -102,7 +101,6 @@ cglobal invalidate_block_ebp
 cglobal invalidate_block_esi
 cglobal invalidate_block_edi
 cglobal write_rdram_new
-cglobal write_rdramb_new
 cglobal write_rdramh_new
 cglobal write_rdramd_new
 cglobal read_nomem_new
@@ -110,11 +108,9 @@ cglobal read_nomemb_new
 cglobal read_nomemh_new
 cglobal read_nomemd_new
 cglobal write_nomem_new
-cglobal write_nomemb_new
 cglobal write_nomemh_new
 cglobal write_nomemd_new
 cglobal write_mi_new
-cglobal write_mib_new
 cglobal write_mih_new
 cglobal write_mid_new
 cglobal breakpoint
@@ -490,15 +486,6 @@ write_rdram_new:
     mov     [edx - 0x80000000],    ecx
     jmp     _E12
 
-write_rdramb_new:
-    get_got_address
-    mov     edx,    [find_local_data(g_dev_r4300_address)]
-    xor     edx,    3
-    add     edx,    [find_local_data(g_dev_ri_rdram_dram)]
-    mov     cl,     BYTE [find_local_data(g_dev_r4300_wbyte)]
-    mov     BYTE [edx - 0x80000000],    cl
-    jmp     _E12
-
 write_rdramh_new:
     get_got_address
     mov     edx,    [find_local_data(g_dev_r4300_address)]
@@ -603,17 +590,6 @@ write_nomem_new:
     mov     [edi+edx],    ecx
     ret
 
-write_nomemb_new:
-    call    do_invalidate
-    mov     edx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_memory_map+edx*4)]
-    mov     eax,    01h
-    shl     edx,    2
-    jc      tlb_exception
-    xor     edi,    3
-    mov     cl,     BYTE [find_local_data(g_dev_r4300_wbyte)]
-    mov     BYTE [edi+edx],    cl
-    ret
-
 write_nomemh_new:
     call    do_invalidate
     mov     edx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_memory_map+edx*4)]
@@ -644,18 +620,6 @@ write_mi_new:
     mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_pcaddr)],    ecx
     mov     DWORD [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)],    0
     call    write_mi
-    mov     ecx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)]
-    test    ecx,    ecx
-    jne     mi_exception
-    ret
-
-write_mib_new:
-    get_got_address
-    mov     ecx,    [024h+esp]
-    add     ecx,    4
-    mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_pcaddr)],    ecx
-    mov     DWORD [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)],    0
-    call    write_mib
     mov     ecx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)]
     test    ecx,    ecx
     jne     mi_exception

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -296,16 +296,6 @@ uint32_t* r4300_wmask(struct r4300_core* r4300)
 #endif
 }
 
-uint8_t*  r4300_wbyte(struct r4300_core* r4300)
-{
-#if NEW_DYNAREC != NEW_DYNAREC_ARM
-/* ARM dynarec uses a different memory layout */
-    return &r4300->wbyte;
-#else
-    return &r4300->new_dynarec_hot_state.wbyte;
-#endif
-}
-
 uint16_t* r4300_whword(struct r4300_core* r4300)
 {
 #if NEW_DYNAREC != NEW_DYNAREC_ARM

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -286,6 +286,16 @@ uint32_t* r4300_address(struct r4300_core* r4300)
 #endif
 }
 
+uint32_t* r4300_wmask(struct r4300_core* r4300)
+{
+#if NEW_DYNAREC != NEW_DYNAREC_ARM
+/* ARM dynarec uses a different memory layout */
+    return &r4300->wmask;
+#else
+    return &r4300->new_dynarec_hot_state.wmask;
+#endif
+}
+
 uint8_t*  r4300_wbyte(struct r4300_core* r4300)
 {
 #if NEW_DYNAREC != NEW_DYNAREC_ARM

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -296,16 +296,6 @@ uint32_t* r4300_wmask(struct r4300_core* r4300)
 #endif
 }
 
-uint16_t* r4300_whword(struct r4300_core* r4300)
-{
-#if NEW_DYNAREC != NEW_DYNAREC_ARM
-/* ARM dynarec uses a different memory layout */
-    return &r4300->whword;
-#else
-    return &r4300->new_dynarec_hot_state.whword;
-#endif
-}
-
 uint32_t* r4300_wword(struct r4300_core* r4300)
 {
 #if NEW_DYNAREC != NEW_DYNAREC_ARM

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -227,7 +227,6 @@ uint64_t* r4300_wdword(struct r4300_core* r4300);
 #define read_hword_in_memory()  r4300->mem->readmemh [*r4300_address(r4300)>>16]()
 #define read_dword_in_memory()  r4300->mem->readmemd [*r4300_address(r4300)>>16]()
 #define write_word_in_memory()  r4300->mem->writemem [*r4300_address(r4300)>>16]()
-#define write_byte_in_memory()  r4300->mem->writememb[*r4300_address(r4300)>>16]()
 #define write_hword_in_memory() r4300->mem->writememh[*r4300_address(r4300)>>16]()
 #define write_dword_in_memory() r4300->mem->writememd[*r4300_address(r4300)>>16]()
 

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -225,7 +225,6 @@ uint32_t* r4300_wword(struct r4300_core* r4300);
 uint64_t* r4300_wdword(struct r4300_core* r4300);
 
 #define read_word_in_memory()   r4300->mem->readmem  [*r4300_address(r4300)>>16]()
-#define read_byte_in_memory()   r4300->mem->readmemb [*r4300_address(r4300)>>16]()
 #define read_hword_in_memory()  r4300->mem->readmemh [*r4300_address(r4300)>>16]()
 #define read_dword_in_memory()  r4300->mem->readmemd [*r4300_address(r4300)>>16]()
 #define write_word_in_memory()  r4300->mem->writemem [*r4300_address(r4300)>>16]()

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -171,7 +171,6 @@ struct r4300_core
     uint32_t wmask;
 
     union {
-        uint8_t  wbyte;
         uint16_t whword;
         uint32_t wword;
         uint64_t wdword;
@@ -217,7 +216,6 @@ unsigned int get_r4300_emumode(struct r4300_core* r4300);
 
 uint32_t* r4300_address(struct r4300_core* r4300);
 uint32_t* r4300_wmask(struct r4300_core* r4300);
-uint8_t*  r4300_wbyte(struct r4300_core* r4300);
 uint16_t* r4300_whword(struct r4300_core* r4300);
 uint32_t* r4300_wword(struct r4300_core* r4300);
 uint64_t* r4300_wdword(struct r4300_core* r4300);

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -147,6 +147,12 @@ struct r4300_core
 
         uint32_t jump_to_address;
 
+#if defined(__x86_64__)
+        unsigned long long shift;
+#else
+        unsigned int shift;
+#endif
+
 #if defined(PROFILE_R4300)
         FILE* pfProfile;
 #endif

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -225,7 +225,6 @@ uint32_t* r4300_wword(struct r4300_core* r4300);
 uint64_t* r4300_wdword(struct r4300_core* r4300);
 
 #define read_word_in_memory()   r4300->mem->readmem  [*r4300_address(r4300)>>16]()
-#define read_hword_in_memory()  r4300->mem->readmemh [*r4300_address(r4300)>>16]()
 #define read_dword_in_memory()  r4300->mem->readmemd [*r4300_address(r4300)>>16]()
 #define write_word_in_memory()  r4300->mem->writemem [*r4300_address(r4300)>>16]()
 #define write_dword_in_memory() r4300->mem->writememd[*r4300_address(r4300)>>16]()

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -171,7 +171,6 @@ struct r4300_core
     uint32_t wmask;
 
     union {
-        uint16_t whword;
         uint32_t wword;
         uint64_t wdword;
     };
@@ -216,7 +215,6 @@ unsigned int get_r4300_emumode(struct r4300_core* r4300);
 
 uint32_t* r4300_address(struct r4300_core* r4300);
 uint32_t* r4300_wmask(struct r4300_core* r4300);
-uint16_t* r4300_whword(struct r4300_core* r4300);
 uint32_t* r4300_wword(struct r4300_core* r4300);
 uint64_t* r4300_wdword(struct r4300_core* r4300);
 
@@ -225,7 +223,6 @@ uint64_t* r4300_wdword(struct r4300_core* r4300);
 #define read_hword_in_memory()  r4300->mem->readmemh [*r4300_address(r4300)>>16]()
 #define read_dword_in_memory()  r4300->mem->readmemd [*r4300_address(r4300)>>16]()
 #define write_word_in_memory()  r4300->mem->writemem [*r4300_address(r4300)>>16]()
-#define write_hword_in_memory() r4300->mem->writememh[*r4300_address(r4300)>>16]()
 #define write_dword_in_memory() r4300->mem->writememd[*r4300_address(r4300)>>16]()
 
 /* Allow cached/dynarec r4300 implementations to invalidate

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -168,6 +168,8 @@ struct r4300_core
 
 #if NEW_DYNAREC != NEW_DYNAREC_ARM
 /* ARM dynarec uses a different memory layout */
+    uint32_t wmask;
+
     union {
         uint8_t  wbyte;
         uint16_t whword;
@@ -214,6 +216,7 @@ int* r4300_stop(struct r4300_core* r4300);
 unsigned int get_r4300_emumode(struct r4300_core* r4300);
 
 uint32_t* r4300_address(struct r4300_core* r4300);
+uint32_t* r4300_wmask(struct r4300_core* r4300);
 uint8_t*  r4300_wbyte(struct r4300_core* r4300);
 uint16_t* r4300_whword(struct r4300_core* r4300);
 uint32_t* r4300_wword(struct r4300_core* r4300);

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -386,20 +386,39 @@ void genlh(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
-        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmemh);
-        cmp_reg32_imm32(EAX, (unsigned int)read_rdramh);
+        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
+        cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(47);
+    je_rj(112);
 
     mov_m32_imm32((unsigned int *)&(*r4300_pc_struct(r4300)), (unsigned int)(r4300->recomp.dst+1)); // 10
+    /* if non RDRAM read,
+     * compute shift (ECX) and address (EBX) to perform a regular read
+     * Save ECX content to memory as ECX can be overwritten when calling readmem function */
+    mov_reg32_reg32(ECX, EBX); // 2
+    and_reg32_imm32(ECX, 2); // 6
+    xor_reg32_imm32(ECX, 2); // 6
+    shl_reg32_imm8(ECX, 3); // 3
+    mov_m32_reg32((unsigned int *)&r4300->recomp.shift, ECX); // 6
+    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
     shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmemh); // 7
+    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
     call_reg32(EBX); // 2
+    mov_reg32_m32(EBX, (unsigned int *)(r4300_address(r4300))); // 6
+    and_reg32_reg32(EBX, EBX); // 2
+    je_rj(51); // 2
+
+    mov_reg32_m32(EAX, (unsigned int *)r4300->recomp.dst->f.i.rt); // 6
+    mov_reg32_m32(ECX, (unsigned int *)&r4300->recomp.shift); // 6
+    shr_reg32_cl(EAX); // 2
+    and_reg32_imm32(EAX, 0xffff); // 6
+    mov_m32_reg32((unsigned int*)r4300->recomp.dst->f.i.rt, EAX); // 6
     movsx_reg32_m16(EAX, (unsigned short *)r4300->recomp.dst->f.i.rt); // 7
     jmp_imm_short(16); // 2
 
+    /* else (RDRAM read), read hword */
     and_reg32_imm32(EBX, 0x7FFFFF); // 6
     xor_reg8_imm8(BL, 2); // 3
     movsx_reg32_16preg32pimm32(EAX, EBX, (unsigned int)r4300->ri->rdram.dram); // 7

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -703,11 +703,12 @@ void gensw(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(41);
+    je_rj(51);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_reg32((unsigned int *)(r4300_wword(r4300)), ECX); // 6
+    mov_m32_imm32((unsigned int *)(r4300_wmask(r4300)), ~UINT32_C(0)); // 10
     shr_reg32_imm8(EBX, 16); // 3
     mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writemem); // 7
     call_reg32(EBX); // 2
@@ -4076,11 +4077,12 @@ void genswc1(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(41);
+    je_rj(51);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_reg32((unsigned int *)(r4300_wword(r4300)), ECX); // 6
+    mov_m32_imm32((unsigned int *)(r4300_wmask(r4300)), ~UINT32_C(0)); // 10
     shr_reg32_imm8(EBX, 16); // 3
     mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writemem); // 7
     call_reg32(EBX); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -415,6 +415,7 @@ void genlhu(struct r4300_core* r4300)
 #else
     free_all_registers();
     simplify_access();
+    /* get address in both EAX and EBX */
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
@@ -426,20 +427,36 @@ void genlhu(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
-        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmemh);
-        cmp_reg32_imm32(EAX, (unsigned int)read_rdramh);
+        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
+        cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(46);
+    je_rj(93);
 
     mov_m32_imm32((unsigned int *)&(*r4300_pc_struct(r4300)), (unsigned int)(r4300->recomp.dst+1)); // 10
+    /* if non RDRAM read,
+     * compute shift (ECX) and address (EBX) to perform a regular read
+     * Save ECX content to memory as ECX can be overwritten when calling readmem function */
+    mov_reg32_reg32(ECX, EBX); // 2
+    and_reg32_imm32(ECX, 2); // 6
+    xor_reg32_imm32(ECX, 2); // 6
+    shl_reg32_imm8(ECX, 3); // 3
+    mov_m32_reg32((unsigned int *)&r4300->recomp.shift, ECX); // 6
+    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
     shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmemh); // 7
+    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
     call_reg32(EBX); // 2
+    mov_reg32_m32(EBX, (unsigned int *)(r4300_address(r4300))); // 6
+    and_reg32_reg32(EBX, EBX); // 2
+    je_rj(31); // 2
+
     mov_reg32_m32(EAX, (unsigned int *)r4300->recomp.dst->f.i.rt); // 6
+    mov_reg32_m32(ECX, (unsigned int *)&r4300->recomp.shift); // 6
+    shr_reg32_cl(EAX); // 2
     jmp_imm_short(15); // 2
 
+    /* else (RDRAM read), read hword */
     and_reg32_imm32(EBX, 0x7FFFFF); // 6
     xor_reg8_imm8(BL, 2); // 3
     mov_reg32_preg32pimm32(EAX, EBX, (unsigned int)r4300->ri->rdram.dram); // 6

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -643,7 +643,11 @@ void gensh(struct r4300_core* r4300)
 #else
     free_all_registers();
     simplify_access();
-    mov_reg16_m16(CX, (unsigned short *)r4300->recomp.dst->f.i.rt);
+
+    /* get value in EDX */
+    xor_reg32_reg32(EDX, EDX);
+    mov_reg16_m16(DX, (unsigned short *)r4300->recomp.dst->f.i.rt);
+    /* get address in both EAX and EBX */
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
@@ -655,24 +659,36 @@ void gensh(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
-        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writememh);
-        cmp_reg32_imm32(EAX, (unsigned int)write_rdramh);
+        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
+        cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(42);
+    je_rj(79);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
+    /* if non RDRAM write,
+     * compute shift (ECX), word (EDX), wmask (EDX) and address (EBX) to perform a regular write */
+    mov_reg32_reg32(ECX, EBX); // 2
+    and_reg32_imm32(ECX, 2); // 6
+    xor_reg32_imm32(ECX, 2); // 6
+    shl_reg32_imm8(ECX, 3); // 3
+    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
-    mov_m16_reg16((unsigned short *)(r4300_whword(r4300)), CX); // 7
+    shl_reg32_cl(EDX); // 2
+    mov_m32_reg32((unsigned int *)(r4300_wword(r4300)), EDX); // 6
+    mov_reg32_imm32(EDX, 0xffff); // 5
+    shl_reg32_cl(EDX); // 2
+    mov_m32_reg32((unsigned int *)(r4300_wmask(r4300)), EDX); // 6
     shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writememh); // 7
+    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writemem); // 7
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300_address(r4300))); // 5
     jmp_imm_short(18); // 2
 
+    /* else (RDRAM write), write hword */
     mov_reg32_reg32(EAX, EBX); // 2
     and_reg32_imm32(EBX, 0x7FFFFF); // 6
     xor_reg8_imm8(BL, 2); // 3
-    mov_preg32pimm32_reg16(EBX, (unsigned int)r4300->ri->rdram.dram, CX); // 7
+    mov_preg32pimm32_reg16(EBX, (unsigned int)r4300->ri->rdram.dram, DX); // 7
 
     mov_reg32_reg32(EBX, EAX);
     shr_reg32_imm8(EBX, 12);

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -268,20 +268,39 @@ void genlb(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
-        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmemb);
-        cmp_reg32_imm32(EAX, (unsigned int)read_rdramb);
+        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
+        cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(47);
+    je_rj(112);
 
     mov_m32_imm32((unsigned int *)&(*r4300_pc_struct(r4300)), (unsigned int)(r4300->recomp.dst+1)); // 10
+    /* if non RDRAM read,
+     * compute shift (ECX) and address (EBX) to perform a regular read
+     * Save ECX content to memory as ECX can be overwritten when calling readmem function */
+    mov_reg32_reg32(ECX, EBX); // 2
+    and_reg32_imm32(ECX, 3); // 6
+    xor_reg32_imm32(ECX, 3); // 6
+    shl_reg32_imm8(ECX, 3); // 3
+    mov_m32_reg32((unsigned int *)&r4300->recomp.shift, ECX); // 6
+    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
     shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmemb); // 7
+    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
     call_reg32(EBX); // 2
+    mov_reg32_m32(EBX, (unsigned int *)(r4300_address(r4300))); // 6
+    and_reg32_reg32(EBX, EBX); // 2
+    je_rj(51); // 2
+
+    mov_reg32_m32(EAX, (unsigned int *)r4300->recomp.dst->f.i.rt); // 6
+    mov_reg32_m32(ECX, (unsigned int *)&r4300->recomp.shift); // 6
+    shr_reg32_cl(EAX); // 2
+    and_reg32_imm32(EAX, 0xff); // 6
+    mov_m32_reg32((unsigned int*)r4300->recomp.dst->f.i.rt, EAX); // 6
     movsx_reg32_m8(EAX, (unsigned char *)r4300->recomp.dst->f.i.rt); // 7
     jmp_imm_short(16); // 2
 
+    /* else (RDRAM read), read byte */
     and_reg32_imm32(EBX, 0x7FFFFF); // 6
     xor_reg8_imm8(BL, 3); // 3
     movsx_reg32_8preg32pimm32(EAX, EBX, (unsigned int)r4300->ri->rdram.dram); // 7

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -813,11 +813,14 @@ void gensh(struct r4300_core* r4300)
 #else
     free_registers_move_start();
 
-    mov_xreg16_m16rel(CX, (unsigned short *)r4300->recomp.dst->f.i.rt);
+    /* get value in EDX */
+    xor_reg64_reg64(RDX, RDX);
+    mov_xreg16_m16rel(DX, (unsigned short *)r4300->recomp.dst->f.i.rt);
+    /* get address in both EAX and EBX */
     mov_xreg32_m32rel(EAX, (unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->writememh);
+    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->writemem);
     if (r4300->recomp.fast_memory)
     {
         and_eax_imm32(0xDF800000);
@@ -825,28 +828,40 @@ void gensh(struct r4300_core* r4300)
     }
     else
     {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdramh);
+        mov_reg64_imm64(RDI, (unsigned long long) write_rdram);
         shr_reg32_imm8(EAX, 16);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(50);
+    je_rj(91);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
+    /* if non RDRAM write,
+     * compute shift (ECX), word (EDX), wmask (EDX) and address (EBX) to perform a regular write */
+    mov_reg32_reg32(ECX, EBX); // 2
+    and_reg32_imm32(ECX, 2); // 6
+    xor_reg8_imm8(CL, 2); // 4
+    shl_reg32_imm8(ECX, 3); // 3
+    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
-    mov_m16rel_xreg16((unsigned short *)(r4300_whword(r4300)), CX); // 8
+    shl_reg32_cl(EDX); // 2
+    mov_m32rel_xreg32((unsigned int *)(r4300_wword(r4300)), EDX); // 7
+    mov_reg64_imm64(RDX, 0xffff); // 10
+    shl_reg32_cl(EDX); // 2
+    mov_m32rel_xreg32((unsigned int *)(r4300_wmask(r4300)), EDX); // 7
     shr_reg32_imm8(EBX, 16); // 3
     mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
     call_reg64(RBX); // 2
     mov_xreg32_m32rel(EAX, (unsigned int *)(r4300_address(r4300))); // 7
     jmp_imm_short(26); // 2
 
+    /* else (RDRAM write), write hword */
     mov_reg64_imm64(RSI, (unsigned long long) r4300->ri->rdram.dram); // 10
     mov_reg32_reg32(EAX, EBX); // 2
     and_reg32_imm32(EBX, 0x7FFFFF); // 6
     xor_reg8_imm8(BL, 2); // 4
-    mov_preg64preg64_reg16(RBX, RSI, CX); // 4
+    mov_preg64preg64_reg16(RBX, RSI, DX); // 4
 
     mov_reg64_imm64(RSI, (unsigned long long) r4300->cached_interp.invalid_code);
     mov_reg32_reg32(EBX, EAX);

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -511,7 +511,7 @@ void genlbu(struct r4300_core* r4300)
 
 void genlh(struct r4300_core* r4300)
 {
-    int gpr1, gpr2, base1, base2 = 0;
+    int gpr1, gpr2, base1, base2;
 #if defined(COUNT_INSTR)
     inc_m32rel(&instr_count[25]);
 #endif
@@ -520,9 +520,9 @@ void genlh(struct r4300_core* r4300)
 #else
     free_registers_move_start();
 
-    ld_register_alloc(r4300, &gpr1, &gpr2, &base1, &base2);
+    ld_register_alloc2(r4300, &gpr1, &gpr2, &base1, &base2);
 
-    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->readmemh);
+    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->readmem);
     if (r4300->recomp.fast_memory)
     {
         and_reg32_imm32(gpr1, 0xDF800000);
@@ -530,7 +530,7 @@ void genlh(struct r4300_core* r4300)
     }
     else
     {
-        mov_reg64_imm64(base2, (unsigned long long) read_rdramh);
+        mov_reg64_imm64(base2, (unsigned long long) read_rdram);
         shr_reg32_imm8(gpr1, 16);
         mov_reg64_preg64x8preg64(gpr1, gpr1, base1);
         cmp_reg64_reg64(gpr1, base2);
@@ -540,14 +540,31 @@ void genlh(struct r4300_core* r4300)
 
     mov_reg64_imm64(gpr1, (unsigned long long) (r4300->recomp.dst+1));
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), gpr1);
+    /* if non RDRAM read,
+     * compute shift (base2) and address (gpr2) to perform a regular read.
+     * Save base2 content to memory as RCX can be overwritten when calling readmem function */
+    mov_reg64_reg64(base2, gpr2);
+    and_reg64_imm8(base2, 2);
+    xor_reg8_imm8(base2, 2);
+    shl_reg64_imm8(base2, 3);
+    mov_m64rel_xreg64(&r4300->recomp.shift, base2);
+    and_reg64_imm32(gpr2, ~UINT32_C(3));
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), gpr2);
     mov_reg64_imm64(gpr1, (unsigned long long) r4300->recomp.dst->f.i.rt);
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), gpr1);
     shr_reg32_imm8(gpr2, 16);
     mov_reg64_preg64x8preg64(gpr2, gpr2, base1);
     call_reg64(gpr2);
-    movsx_xreg32_m16rel(gpr1, (unsigned short *)r4300->recomp.dst->f.i.rt);
-    jmp_imm_short(24);
+    mov_xreg32_m32rel(gpr2, (unsigned int *)(r4300_address(r4300)));
+    and_reg64_reg64(gpr2, gpr2);
+    je_rj(58);
+
+    mov_xreg64_m64rel(gpr1, (unsigned long long*)r4300->recomp.dst->f.i.rt); // 7
+    mov_xreg64_m64rel(RCX, &r4300->recomp.shift); // 7
+    shr_reg64_cl(gpr1); // 3
+    mov_m64rel_xreg64((unsigned long long*)r4300->recomp.dst->f.i.rt, gpr1); // 7
+    movsx_xreg32_m16rel(gpr1, (unsigned short *)r4300->recomp.dst->f.i.rt); // 8
+    jmp_imm_short(24); // 2
 
     jump_end_rel8();
     mov_reg64_imm64(base1, (unsigned long long) r4300->ri->rdram.dram); // 10

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -890,12 +890,13 @@ void gensw(struct r4300_core* r4300)
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(49);
+    je_rj(60);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_wword(r4300)), ECX); // 7
+    mov_m32rel_imm32((unsigned int *)(r4300_wmask(r4300)), ~UINT32_C(0)); // 11
     shr_reg32_imm8(EBX, 16); // 3
     mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
     call_reg64(RBX); // 2
@@ -4251,12 +4252,13 @@ void genswc1(struct r4300_core* r4300)
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(49);
+    je_rj(60);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_wword(r4300)), ECX); // 7
+    mov_m32rel_imm32((unsigned int *)(r4300_wmask(r4300)), ~UINT32_C(0)); // 11
     shr_reg32_imm8(EBX, 16); // 3
     mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
     call_reg64(RBX); // 2

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -561,7 +561,7 @@ void genlh(struct r4300_core* r4300)
 
 void genlhu(struct r4300_core* r4300)
 {
-    int gpr1, gpr2, base1, base2 = 0;
+    int gpr1, gpr2, base1, base2;
 #if defined(COUNT_INSTR)
     inc_m32rel(&instr_count[29]);
 #endif
@@ -570,9 +570,9 @@ void genlhu(struct r4300_core* r4300)
 #else
     free_registers_move_start();
 
-    ld_register_alloc(r4300, &gpr1, &gpr2, &base1, &base2);
+    ld_register_alloc2(r4300, &gpr1, &gpr2, &base1, &base2);
 
-    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->readmemh);
+    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->readmem);
     if (r4300->recomp.fast_memory)
     {
         and_reg32_imm32(gpr1, 0xDF800000);
@@ -580,7 +580,7 @@ void genlhu(struct r4300_core* r4300)
     }
     else
     {
-        mov_reg64_imm64(base2, (unsigned long long) read_rdramh);
+        mov_reg64_imm64(base2, (unsigned long long) read_rdram);
         shr_reg32_imm8(gpr1, 16);
         mov_reg64_preg64x8preg64(gpr1, gpr1, base1);
         cmp_reg64_reg64(gpr1, base2);
@@ -590,14 +590,29 @@ void genlhu(struct r4300_core* r4300)
 
     mov_reg64_imm64(gpr1, (unsigned long long) (r4300->recomp.dst+1));
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), gpr1);
+    /* if non RDRAM read,
+     * compute shift (base2) and address (gpr2) to perform a regular read.
+     * Save base2 content to memory as RCX can be overwritten when calling readmem function */
+    mov_reg64_reg64(base2, gpr2);
+    and_reg64_imm8(base2, 2);
+    xor_reg8_imm8(base2, 2);
+    shl_reg64_imm8(base2, 3);
+    mov_m64rel_xreg64(&r4300->recomp.shift, base2);
+    and_reg64_imm32(gpr2, ~UINT32_C(3));
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), gpr2);
     mov_reg64_imm64(gpr1, (unsigned long long) r4300->recomp.dst->f.i.rt);
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), gpr1);
     shr_reg32_imm8(gpr2, 16);
     mov_reg64_preg64x8preg64(gpr2, gpr2, base1);
     call_reg64(gpr2);
-    mov_xreg32_m32rel(gpr1, (unsigned int *)r4300->recomp.dst->f.i.rt);
-    jmp_imm_short(23);
+    mov_xreg32_m32rel(gpr2, (unsigned int *)(r4300_address(r4300)));
+    and_reg64_reg64(gpr2, gpr2);
+    je_rj(48);
+
+    mov_xreg32_m32rel(gpr1, (unsigned int *)r4300->recomp.dst->f.i.rt); // 7
+    mov_xreg64_m64rel(RCX, &r4300->recomp.shift); // 7
+    shr_reg64_cl(gpr1); // 3
+    jmp_imm_short(23); // 2
 
     jump_end_rel8();
     mov_reg64_imm64(base1, (unsigned long long) r4300->ri->rdram.dram); // 10
@@ -605,7 +620,8 @@ void genlhu(struct r4300_core* r4300)
     xor_reg8_imm8(gpr2, 2); // 4
     mov_reg32_preg64preg64(gpr1, gpr2, base1); // 3
 
-    and_reg32_imm32(gpr1, 0xFFFF);
+    and_reg32_imm32(gpr1, 0xFFFF); // 6
+
     set_register_state(gpr1, (unsigned int*)r4300->recomp.dst->f.i.rt, 1, 0);
 #endif
 }

--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -93,7 +93,7 @@ int write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 
 
 #define R(x) read_ ## x ## b, read_ ## x ## h, read_ ## x, read_ ## x ## d
-#define W(x) write_ ## x ## b, write_ ## x ## h, write_ ## x, write_ ## x ## d
+#define W(x) write_ ## x ## h, write_ ## x, write_ ## x ## d
 #define RW(x) R(x), W(x)
 
 void protect_framebuffers(struct rdp_core* dp)

--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -92,7 +92,7 @@ int write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 }
 
 
-#define R(x) read_ ## x ## b, read_ ## x ## h, read_ ## x, read_ ## x ## d
+#define R(x) read_ ## x ## h, read_ ## x, read_ ## x ## d
 #define W(x) write_ ## x, write_ ## x ## d
 #define RW(x) R(x), W(x)
 

--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -92,7 +92,7 @@ int write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 }
 
 
-#define R(x) read_ ## x ## h, read_ ## x, read_ ## x ## d
+#define R(x) read_ ## x, read_ ## x ## d
 #define W(x) write_ ## x, write_ ## x ## d
 #define RW(x) R(x), W(x)
 

--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -93,7 +93,7 @@ int write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 
 
 #define R(x) read_ ## x ## b, read_ ## x ## h, read_ ## x, read_ ## x ## d
-#define W(x) write_ ## x ## h, write_ ## x, write_ ## x ## d
+#define W(x) write_ ## x, write_ ## x ## d
 #define RW(x) R(x), W(x)
 
 void protect_framebuffers(struct rdp_core* dp)

--- a/tools/gen_asm_defines.awk
+++ b/tools/gen_asm_defines.awk
@@ -3,10 +3,6 @@ BEGIN {
   gas_file =  dest_dir"/asm_defines_gas.h";
 }
 
-NR==1 {
-  msvc = match($0, /Microsoft/);
-}
-
 {
   where = match($0, /offsetof_struct/);
   
@@ -17,10 +13,7 @@ NR==1 {
     sub(/\r/, "", offset_name);
     sub(/\n/, "", offset_name);
     
-    if(msvc != 0)
-      offset_value = $2;
-    else
-      offset_value = $1;
+    offset_value = $1;
         
     sub(/0x/, "", offset_value);
     


### PR DESCRIPTION
With this PR I'm trying to remove byte and hword memory accessors as it adds lots of duplication and bloat. I already tried and failed in a previous attempt (PR47). This time, I went much more gradually (each commit is buildable and should be easily inspectable in case of any regression). I left the dword accessors for a later PR as it require some more work, and I'd like this PR to get some testing early. I'm looking especially for testing on the dynarecs (both Hacktarux and new_dynarec).

I'm really looking forward to get this tested and merged ! This is something I've been hoping for some years now :)