### PR TITLE
Remove custom CountPerScanline values

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -792,7 +792,6 @@ RefMD5=90448C4175EE9D0247674474DCABDFED
 GoodName=All-Star Baseball 2001 (U) [!]
 CRC=5446C6EF E18E47BB
 RefMD5=90448C4175EE9D0247674474DCABDFED
-CountPerScanline=1400
 
 [CD04ABC5979F22EF5D6FDC4DCFAA4D50]
 GoodName=All-Star Baseball 2001 (U) [f1] (PAL)
@@ -1398,7 +1397,6 @@ CRC=A1B64A61 D014940B
 Players=4
 SaveType=Controller Pack
 CountPerOp=3
-CountPerScanline=1450
 
 [9D5A1B779F8B43E63E8CE8427675A7EF]
 GoodName=Beetle Adventure Racing! (E) (M3) [h1C]
@@ -1416,7 +1414,6 @@ CRC=9C7318D2 24AE0DC1
 Players=4
 SaveType=Controller Pack
 CountPerOp=3
-CountPerScanline=1400
 
 [E126B84FA242916289D04D68C0E20BFE]
 GoodName=Beetle Adventure Racing! (J) [b1]
@@ -1429,7 +1426,6 @@ CRC=EDF419A8 BF1904CC
 SaveType=Controller Pack
 Players=4
 CountPerOp=3
-CountPerScanline=1400
 
 [D11BC38F26EA2835FBF017FE9BD404FE]
 GoodName=Beetle Adventure Racing! (U) (M3) [b1]
@@ -1941,7 +1937,6 @@ CRC=8F12C096 45DC17E1
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-CountPerScanline=2200
 
 [5BF0F2351AEE577A8345D6E13D197E06]
 GoodName=Bug's Life, A (E) [f1] (NTSC)
@@ -1954,7 +1949,6 @@ CRC=2B38AEC0 6350B810
 SaveType=Controller Pack
 Players=1
 CountPerOp=1
-CountPerScanline=2200
 
 [504C92A5978B7EAE7A3FD30645E06D39]
 GoodName=Bug's Life, A (F) [f1] (NTSC)
@@ -1967,7 +1961,6 @@ CRC=DFF227D9 0D4D8169
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-CountPerScanline=2200
 
 [919E5D60A7F9A79D89AC179123D47EEE]
 GoodName=Bug's Life, A (G) [f1] (NTSC)
@@ -1980,7 +1973,6 @@ CRC=F63B89CE 4582D57D
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-CountPerScanline=2200
 
 [7FD6BFFB80F920E01EF869829D485EA3]
 GoodName=Bug's Life, A (U) [!]
@@ -1988,7 +1980,6 @@ CRC=82DC04FD CF2D82F4
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-CountPerScanline=2200
 
 [14ACC20454B0C2789C9F7EF7A556231A]
 GoodName=Bug's Life, A (U) [b1]
@@ -1996,7 +1987,6 @@ CRC=82DC04FD CF2D82F4
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-CountPerScanline=2200
 
 [6472BD444D2025B1D883FFAE35D94FD4]
 GoodName=Bug's Life, A (U) [b1][f1] (PAL)
@@ -4644,7 +4634,6 @@ GoodName=FIFA Soccer 64 (E) (M3) [!]
 CRC=C3F19159 65D2BC5A
 Players=4
 SaveType=Controller Pack
-CountPerScanline=2504
 
 [1D71761771E3BFFC091E38B9E8B5E590]
 GoodName=FIFA Soccer 64 (E) (M3) [b1]
@@ -4676,7 +4665,6 @@ GoodName=FIFA Soccer 64 (U) (M3) [!]
 CRC=C3F19159 65D2BC5A
 Players=4
 SaveType=Controller Pack
-CountPerScanline=2504
 
 [CA56F2DE80839EC88750C15A21AA7C53]
 GoodName=FIFA Soccer 64 (U) (M3) [b1]
@@ -5416,7 +5404,6 @@ CRC=BD1263E5 388C9BE7
 GoodName=HSV Adventure Racing (A) [b1]
 CRC=72611D7D 9919BDD2
 CountPerOp=3
-CountPerScanline=1450
 
 [8C7AF37A3CB7306EBCCAC4029EB5C57D]
 GoodName=HSV Adventure Racing (A) [f1] (NTSC)
@@ -5426,7 +5413,6 @@ CRC=B20CC247 B879579A
 GoodName=HSV Adventure Racing (A)
 CRC=72611D7D 9919BDD2
 CountPerOp=3
-CountPerScanline=1450
 
 [3D4C7B11076BAFA4620BCC154C0EEEF3]
 GoodName=Hamster Monogatari 64 (J) [!]
@@ -7432,7 +7418,6 @@ SaveType=Eeprom 4KB
 Rumble=Yes
 Players=1
 Status=3
-CountPerScanline=1450
 
 [6B1E294A9199E6F22DBC6ABC59BD7568]
 GoodName=Lode Runner 3-D (E) (M5) [b1]
@@ -7446,7 +7431,6 @@ SaveType=Eeprom 4KB
 Rumble=Yes
 Players=1
 Status=3
-CountPerScanline=1400
 
 [D038813541589F0B3F1F900F4FD22C9B]
 GoodName=Lode Runner 3-D (U) [!]
@@ -7455,7 +7439,6 @@ SaveType=Eeprom 4KB
 Rumble=Yes
 Players=1
 Status=3
-CountPerScanline=1400
 
 [5FBA92D908B9962F26D389C85F6E88CF]
 GoodName=Lode Runner 3-D (U) [b1][f1] (PAL)
@@ -9682,7 +9665,6 @@ Players=4
 Rumble=Yes
 SaveType=Controller Pack
 CountPerOp=1
-CountPerScanline=500
 
 [76DB89759121710C416ECFB1736B5E39]
 GoodName=NBA Showtime - NBA on NBC (U) [f1] (Country Check)
@@ -10155,7 +10137,6 @@ CRC=2857674D CC4337DA
 Players=1
 Rumble=Yes
 SaveType=Controller Pack
-CountPerScanline=2200
 
 [60A2CFF1515D4C7902DDE32A6E01D411]
 GoodName=Nightmare Creatures (U) [b1]
@@ -10190,7 +10171,6 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
-CountPerScanline=2200
 
 [B2DF29627E0219A9C14605F46803C94C]
 GoodName=Nintendo All-Star! Dairantou Smash Brothers (J) [b1]
@@ -12156,7 +12136,6 @@ CRC=0AC61D39 ABFA03A6
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
-CountPerScanline=2200
 
 [207EFE58C7C221DBDFFF285AB80126C1]
 GoodName=Rugrats in Paris - The Movie (U) [!]
@@ -12164,7 +12143,6 @@ CRC=1FC21532 0B6466D4
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
-CountPerScanline=2200
 
 [F3515A45EC01D2C9FEAFBAB2B85D72C4]
 GoodName=Rugrats in Paris - The Movie (U) [T+Spa0.10]
@@ -13762,7 +13740,6 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
-CountPerScanline=2200
 
 [7F18A06BB16A507E23F9DD636B7046A6]
 GoodName=Super Smash Bros. (A) [f1]
@@ -13776,7 +13753,6 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
-CountPerScanline=2200
 
 [4D37726FDFEC039CB36E2AAE65B9727D]
 GoodName=Super Smash Bros. (E) (M3) [b1]
@@ -13795,7 +13771,6 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
-CountPerScanline=2200
 
 [508BE860974B75470851A2D25C0FCB36]
 GoodName=Super Smash Bros. (U) [b1]


### PR DESCRIPTION
When these were initially committed, I just copied the values from Project64. Given that that change broke Indiana Jones, it's probably best to remove these values. There is no evidence that they make any improvement, so it's safer to remove them.

At least now there is a core option to modify this value, so if someone is so inclined, they could test out different values to see if they make any difference for a particular game.