### PR TITLE
Fix audio in Star Wars Episode I - Racer

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -13366,6 +13366,7 @@ RefMD5=3CB88B934572E7520F35E5458798775B
 GoodName=Star Wars Episode I - Racer (E) (M3) [!]
 CRC=53ED2DC4 06258002
 SaveType=Eeprom 16KB
+CountPerOp=1
 
 [8CC7E31925FBFA13A584F529E8912207]
 GoodName=Star Wars Episode I - Racer (E) (M3) [f1] (Save)
@@ -13376,6 +13377,7 @@ RefMD5=6EF9FED309F28BD59B605F128869AA00
 GoodName=Star Wars Episode I - Racer (J) [!]
 CRC=61F5B152 046122AB
 SaveType=Eeprom 16KB
+CountPerOp=1
 
 [CFA21E43DAC50DFF3122ABF3AF3511F8]
 GoodName=Star Wars Episode I - Racer (J) [b1]
@@ -13386,6 +13388,7 @@ RefMD5=7579AB0E79B1011479B88F2BF39D48E0
 GoodName=Star Wars Episode I - Racer (U) [!]
 CRC=72F70398 6556A98B
 SaveType=Eeprom 16KB
+CountPerOp=1
 
 [E4353B43CB4302B7A308A42D6BB04435]
 GoodName=Star Wars Episode I - Racer (U) [f1] (Save)


### PR DESCRIPTION
During the intro scene, there should be audio. There currently isn't.

Setting CountPerOp=1 fixes the audio (it's not just the intro scene that is missing the audio).

Project64 has the same issue (Counter Factor=1 is the default for them for this game, but if you set it to Counter Factor=2, you lose the audio)