### PR TITLE
README.md URL fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mupen64Plus-Core README
 
-More documentation can be found on the [Mupen64Plus website] (http://mupen64plus.org/docs/)
+More documentation can be found on the [Mupen64Plus website](http://mupen64plus.org/docs/)
 and you can find a more complete README file on the legacy [Google Code](https://code.google.com/archive/p/mupen64plus/wikis/README.wiki) site.
 
 Mupen64Plus is based off of mupen64, originally created by Hacktarux. This


### PR DESCRIPTION
Fixed a small formatting error in the README file's markdown that was improperly linking to the Mupen64Plus site.