### PR TITLE
Pass pointer to fcr31 around in fpu.h functions to avoid usage of g_dev.

### DIFF
--- a/src/device/r4300/fpu.h
+++ b/src/device/r4300/fpu.h
@@ -25,15 +25,13 @@
 #include <math.h>
 #include <stdint.h>
 
-#include "main/main.h"
-
 #ifdef _MSC_VER
-  #define M64P_FPU_INLINE static __inline
-  #include <float.h>
+#define M64P_FPU_INLINE static __inline
+#include <float.h>
 
-  typedef enum { FE_TONEAREST = 0, FE_TOWARDZERO, FE_UPWARD, FE_DOWNWARD } eRoundType;
-  static void fesetround(eRoundType RoundType)
-  {
+typedef enum { FE_TONEAREST = 0, FE_TOWARDZERO, FE_UPWARD, FE_DOWNWARD } eRoundType;
+static void fesetround(eRoundType RoundType)
+{
     static const unsigned int msRound[4] = { _RC_NEAR, _RC_CHOP, _RC_UP, _RC_DOWN };
 #if defined(__x86_64__)
     _controlfp(msRound[RoundType], _MCW_RC);
@@ -41,420 +39,472 @@
     unsigned int oldX87, oldSSE2;
     __control87_2(msRound[RoundType], _MCW_RC, &oldX87, &oldSSE2);
 #endif
-  }
-  static __inline double round(double x) { return floor(x + 0.5); }
-  static __inline float roundf(float x) { return (float) floor(x + 0.5); }
-  static __inline double trunc(double x) { return (double) (int) x; }
-  static __inline float truncf(float x) { return (float) (int) x; }
-  #define isnan _isnan
+}
+static __inline double round(double x) { return floor(x + 0.5); }
+static __inline float  roundf(float x) { return (float)floor(x + 0.5); }
+static __inline double trunc(double x) { return (double)(int)x; }
+static __inline float  truncf(float x) { return (float)(int)x; }
+#define isnan _isnan
 #else
-  #define M64P_FPU_INLINE static inline
-  #include <fenv.h>
+#define M64P_FPU_INLINE static inline
+#include <fenv.h>
 #endif
 
 #define FCR31_CMP_BIT UINT32_C(0x800000)
 
 
-M64P_FPU_INLINE void set_rounding(void)
+M64P_FPU_INLINE void set_rounding(const uint32_t* fcr31)
 {
-  switch((*r4300_cp1_fcr31(&g_dev.r4300.cp1)) & 3) {
-  case 0: /* Round to nearest, or to even if equidistant */
-    fesetround(FE_TONEAREST);
-    break;
-  case 1: /* Truncate (toward 0) */
-    fesetround(FE_TOWARDZERO);
-    break;
-  case 2: /* Round up (toward +Inf) */
-    fesetround(FE_UPWARD);
-    break;
-  case 3: /* Round down (toward -Inf) */
-    fesetround(FE_DOWNWARD);
-    break;
-  }
+    switch(*fcr31 & 3) {
+    case 0: /* Round to nearest, or to even if equidistant */
+        fesetround(FE_TONEAREST);
+        break;
+    case 1: /* Truncate (toward 0) */
+        fesetround(FE_TOWARDZERO);
+        break;
+    case 2: /* Round up (toward +Inf) */
+        fesetround(FE_UPWARD);
+        break;
+    case 3: /* Round down (toward -Inf) */
+        fesetround(FE_DOWNWARD);
+        break;
+    }
 }
 
-M64P_FPU_INLINE void cvt_s_w(const int32_t *source,float *dest)
+M64P_FPU_INLINE void cvt_s_w(const uint32_t* fcr31, const int32_t* source, float* dest)
 {
-  set_rounding();
-  *dest = (float) *source;
+    set_rounding(fcr31);
+    *dest = (float)*source;
 }
-M64P_FPU_INLINE void cvt_d_w(const int32_t *source,double *dest)
+M64P_FPU_INLINE void cvt_d_w(const int32_t* source, double* dest)
 {
-  *dest = (double) *source;
+    *dest = (double)*source;
 }
-M64P_FPU_INLINE void cvt_s_l(const int64_t *source,float *dest)
+M64P_FPU_INLINE void cvt_s_l(const uint32_t* fcr31, const int64_t* source, float* dest)
 {
-  set_rounding();
-  *dest = (float) *source;
+    set_rounding(fcr31);
+    *dest = (float)*source;
 }
-M64P_FPU_INLINE void cvt_d_l(const int64_t *source,double *dest)
+M64P_FPU_INLINE void cvt_d_l(const uint32_t* fcr31, const int64_t* source, double* dest)
 {
-  set_rounding();
-  *dest = (double) *source;
+    set_rounding(fcr31);
+    *dest = (double)*source;
 }
-M64P_FPU_INLINE void cvt_d_s(const float *source,double *dest)
+M64P_FPU_INLINE void cvt_d_s(const float* source, double* dest)
 {
-  *dest = (double) *source;
+    *dest = (double)*source;
 }
-M64P_FPU_INLINE void cvt_s_d(const double *source,float *dest)
+M64P_FPU_INLINE void cvt_s_d(const uint32_t* fcr31, const double* source, float* dest)
 {
-  set_rounding();
-  *dest = (float) *source;
-}
-
-M64P_FPU_INLINE void round_l_s(const float *source,int64_t *dest)
-{
-  *dest = (int64_t) roundf(*source);
-}
-M64P_FPU_INLINE void round_w_s(const float *source,int32_t *dest)
-{
-  *dest = (int32_t) roundf(*source);
-}
-M64P_FPU_INLINE void trunc_l_s(const float *source,int64_t *dest)
-{
-  *dest = (int64_t) truncf(*source);
-}
-M64P_FPU_INLINE void trunc_w_s(const float *source,int32_t *dest)
-{
-  *dest = (int32_t) truncf(*source);
-}
-M64P_FPU_INLINE void ceil_l_s(const float *source,int64_t *dest)
-{
-  *dest = (int64_t) ceilf(*source);
-}
-M64P_FPU_INLINE void ceil_w_s(const float *source,int32_t *dest)
-{
-  *dest = (int32_t) ceilf(*source);
-}
-M64P_FPU_INLINE void floor_l_s(const float *source,int64_t *dest)
-{
-  *dest = (int64_t) floorf(*source);
-}
-M64P_FPU_INLINE void floor_w_s(const float *source,int32_t *dest)
-{
-  *dest = (int32_t) floorf(*source);
+    set_rounding(fcr31);
+    *dest = (float)*source;
 }
 
-M64P_FPU_INLINE void round_l_d(const double *source,int64_t *dest)
+M64P_FPU_INLINE void round_l_s(const float* source, int64_t* dest)
 {
-  *dest = (int64_t) round(*source);
+    *dest = (int64_t)roundf(*source);
 }
-M64P_FPU_INLINE void round_w_d(const double *source,int32_t *dest)
+M64P_FPU_INLINE void round_w_s(const float* source, int32_t* dest)
 {
-  *dest = (int32_t) round(*source);
+    *dest = (int32_t)roundf(*source);
 }
-M64P_FPU_INLINE void trunc_l_d(const double *source,int64_t *dest)
+M64P_FPU_INLINE void trunc_l_s(const float* source, int64_t* dest)
 {
-  *dest = (int64_t) trunc(*source);
+    *dest = (int64_t)truncf(*source);
 }
-M64P_FPU_INLINE void trunc_w_d(const double *source,int32_t *dest)
+M64P_FPU_INLINE void trunc_w_s(const float* source, int32_t* dest)
 {
-  *dest = (int32_t) trunc(*source);
+    *dest = (int32_t)truncf(*source);
 }
-M64P_FPU_INLINE void ceil_l_d(const double *source,int64_t *dest)
+M64P_FPU_INLINE void ceil_l_s(const float* source, int64_t* dest)
 {
-  *dest = (int64_t) ceil(*source);
+    *dest = (int64_t)ceilf(*source);
 }
-M64P_FPU_INLINE void ceil_w_d(const double *source,int32_t *dest)
+M64P_FPU_INLINE void ceil_w_s(const float* source, int32_t* dest)
 {
-  *dest = (int32_t) ceil(*source);
+    *dest = (int32_t)ceilf(*source);
 }
-M64P_FPU_INLINE void floor_l_d(const double *source,int64_t *dest)
+M64P_FPU_INLINE void floor_l_s(const float* source, int64_t* dest)
 {
-  *dest = (int64_t) floor(*source);
+    *dest = (int64_t)floorf(*source);
 }
-M64P_FPU_INLINE void floor_w_d(const double *source,int32_t *dest)
+M64P_FPU_INLINE void floor_w_s(const float* source, int32_t* dest)
 {
-  *dest = (int32_t) floor(*source);
-}
-
-M64P_FPU_INLINE void cvt_w_s(const float *source,int32_t *dest)
-{
-  switch((*r4300_cp1_fcr31(&g_dev.r4300.cp1))&3)
-  {
-    case 0: round_w_s(source,dest);return;
-    case 1: trunc_w_s(source,dest);return;
-    case 2: ceil_w_s(source,dest);return;
-    case 3: floor_w_s(source,dest);return;
-  }
-}
-M64P_FPU_INLINE void cvt_w_d(const double *source,int32_t *dest)
-{
-  switch((*r4300_cp1_fcr31(&g_dev.r4300.cp1))&3)
-  {
-    case 0: round_w_d(source,dest);return;
-    case 1: trunc_w_d(source,dest);return;
-    case 2: ceil_w_d(source,dest);return;
-    case 3: floor_w_d(source,dest);return;
-  }
-}
-M64P_FPU_INLINE void cvt_l_s(const float *source,int64_t *dest)
-{
-  switch((*r4300_cp1_fcr31(&g_dev.r4300.cp1))&3)
-  {
-    case 0: round_l_s(source,dest);return;
-    case 1: trunc_l_s(source,dest);return;
-    case 2: ceil_l_s(source,dest);return;
-    case 3: floor_l_s(source,dest);return;
-  }
-}
-M64P_FPU_INLINE void cvt_l_d(const double *source,int64_t *dest)
-{
-  switch((*r4300_cp1_fcr31(&g_dev.r4300.cp1))&3)
-  {
-    case 0: round_l_d(source,dest);return;
-    case 1: trunc_l_d(source,dest);return;
-    case 2: ceil_l_d(source,dest);return;
-    case 3: floor_l_d(source,dest);return;
-  }
+    *dest = (int32_t)floorf(*source);
 }
 
-M64P_FPU_INLINE void c_f_s()
+M64P_FPU_INLINE void round_l_d(const double* source, int64_t* dest)
 {
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) &= ~FCR31_CMP_BIT;
+    *dest = (int64_t)round(*source);
 }
-M64P_FPU_INLINE void c_un_s(const float *source,const float *target)
+M64P_FPU_INLINE void round_w_d(const double* source, int32_t* dest)
 {
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1))=(isnan(*source) || isnan(*target)) ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    *dest = (int32_t)round(*source);
 }
-                          
-M64P_FPU_INLINE void c_eq_s(const float *source,const float *target)
+M64P_FPU_INLINE void trunc_l_d(const double* source, int64_t* dest)
 {
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source==*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    *dest = (int64_t)trunc(*source);
 }
-M64P_FPU_INLINE void c_ueq_s(const float *source,const float *target)
+M64P_FPU_INLINE void trunc_w_d(const double* source, int32_t* dest)
 {
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))|=FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source==*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    *dest = (int32_t)trunc(*source);
 }
-
-M64P_FPU_INLINE void c_olt_s(const float *source,const float *target)
+M64P_FPU_INLINE void ceil_l_d(const double* source, int64_t* dest)
 {
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    *dest = (int64_t)ceil(*source);
 }
-M64P_FPU_INLINE void c_ult_s(const float *source,const float *target)
+M64P_FPU_INLINE void ceil_w_d(const double* source, int32_t* dest)
 {
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))|=FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    *dest = (int32_t)ceil(*source);
 }
-
-M64P_FPU_INLINE void c_ole_s(const float *source,const float *target)
+M64P_FPU_INLINE void floor_l_d(const double* source, int64_t* dest)
 {
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<=*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    *dest = (int64_t)floor(*source);
 }
-M64P_FPU_INLINE void c_ule_s(const float *source,const float *target)
+M64P_FPU_INLINE void floor_w_d(const double* source, int32_t* dest)
 {
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))|=FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<=*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    *dest = (int32_t)floor(*source);
 }
 
-M64P_FPU_INLINE void c_sf_s(const float *source,const float *target)
+M64P_FPU_INLINE void cvt_w_s(const uint32_t* fcr31, const float* source, int32_t* dest)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;
+    switch(*fcr31 & 3)
+    {
+    case 0: round_w_s(source, dest); return;
+    case 1: trunc_w_s(source, dest); return;
+    case 2: ceil_w_s (source, dest); return;
+    case 3: floor_w_s(source, dest); return;
+    }
 }
-M64P_FPU_INLINE void c_ngle_s(const float *source,const float *target)
+M64P_FPU_INLINE void cvt_w_d(const uint32_t* fcr31, const double* source, int32_t* dest)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;
+    switch(*fcr31 & 3)
+    {
+    case 0: round_w_d(source, dest); return;
+    case 1: trunc_w_d(source, dest); return;
+    case 2: ceil_w_d (source, dest); return;
+    case 3: floor_w_d(source, dest); return;
+    }
 }
-
-M64P_FPU_INLINE void c_seq_s(const float *source,const float *target)
+M64P_FPU_INLINE void cvt_l_s(const uint32_t* fcr31, const float* source, int64_t* dest)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source==*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    switch(*fcr31 & 3)
+    {
+    case 0: round_l_s(source, dest); return;
+    case 1: trunc_l_s(source, dest); return;
+    case 2: ceil_l_s (source, dest); return;
+    case 3: floor_l_s(source, dest); return;
+    }
 }
-M64P_FPU_INLINE void c_ngl_s(const float *source,const float *target)
+M64P_FPU_INLINE void cvt_l_d(const uint32_t* fcr31, const double* source, int64_t* dest)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source==*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-
-M64P_FPU_INLINE void c_lt_s(const float *source,const float *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-M64P_FPU_INLINE void c_nge_s(const float *source,const float *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-
-M64P_FPU_INLINE void c_le_s(const float *source,const float *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<=*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-M64P_FPU_INLINE void c_ngt_s(const float *source,const float *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<=*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    switch(*fcr31 & 3)
+    {
+    case 0: round_l_d(source, dest); return;
+    case 1: trunc_l_d(source, dest); return;
+    case 2: ceil_l_d (source, dest); return;
+    case 3: floor_l_d(source, dest); return;
+    }
 }
 
-M64P_FPU_INLINE void c_f_d()
+M64P_FPU_INLINE void c_f_s(uint32_t* fcr31)
 {
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) &= ~FCR31_CMP_BIT;
+    *fcr31 &= ~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void c_un_d(const double *source,const double *target)
+M64P_FPU_INLINE void c_un_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1))=(isnan(*source) || isnan(*target)) ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-                          
-M64P_FPU_INLINE void c_eq_d(const double *source,const double *target)
-{
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source==*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-M64P_FPU_INLINE void c_ueq_d(const double *source,const double *target)
-{
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))|=FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source==*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    *fcr31 = (isnan(*source) || isnan(*target))
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
 
-M64P_FPU_INLINE void c_olt_d(const double *source,const double *target)
+M64P_FPU_INLINE void c_eq_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    if (isnan(*source) || isnan(*target)) { *fcr31 &= ~FCR31_CMP_BIT; return; }
+    *fcr31 = (*source == *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void c_ult_d(const double *source,const double *target)
+M64P_FPU_INLINE void c_ueq_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))|=FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-
-M64P_FPU_INLINE void c_ole_d(const double *source,const double *target)
-{
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<=*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-M64P_FPU_INLINE void c_ule_d(const double *source,const double *target)
-{
-  if (isnan(*source) || isnan(*target)) {(*r4300_cp1_fcr31(&g_dev.r4300.cp1))|=FCR31_CMP_BIT;return;}
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<=*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    if (isnan(*source) || isnan(*target)) { *fcr31 |= FCR31_CMP_BIT; return; }
+    *fcr31 = (*source == *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
 
-M64P_FPU_INLINE void c_sf_d(const double *source,const double *target)
+M64P_FPU_INLINE void c_olt_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;
+    if (isnan(*source) || isnan(*target)) { *fcr31 &= ~FCR31_CMP_BIT; return; }
+    *fcr31 = (*source < *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void c_ngle_d(const double *source,const double *target)
+M64P_FPU_INLINE void c_ult_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&=~FCR31_CMP_BIT;
-}
-
-M64P_FPU_INLINE void c_seq_d(const double *source,const double *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source==*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-M64P_FPU_INLINE void c_ngl_d(const double *source,const double *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source==*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    if (isnan(*source) || isnan(*target)) { *fcr31 |= FCR31_CMP_BIT; return; }
+    *fcr31 = (*source < *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
 
-M64P_FPU_INLINE void c_lt_d(const double *source,const double *target)
+M64P_FPU_INLINE void c_ole_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    if (isnan(*source) || isnan(*target)) { *fcr31 &= ~FCR31_CMP_BIT; return; }
+    *fcr31 = (*source <= *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void c_nge_d(const double *source,const double *target)
+M64P_FPU_INLINE void c_ule_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-
-M64P_FPU_INLINE void c_le_d(const double *source,const double *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<=*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
-}
-M64P_FPU_INLINE void c_ngt_d(const double *source,const double *target)
-{
-  //if (isnan(*source) || isnan(*target)) // FIXME - exception
-  (*r4300_cp1_fcr31(&g_dev.r4300.cp1)) = *source<=*target ? (*r4300_cp1_fcr31(&g_dev.r4300.cp1))|FCR31_CMP_BIT : (*r4300_cp1_fcr31(&g_dev.r4300.cp1))&~FCR31_CMP_BIT;
+    if (isnan(*source) || isnan(*target)) { *fcr31 |= FCR31_CMP_BIT; return; }
+    *fcr31 = (*source <= *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 &~ FCR31_CMP_BIT);
 }
 
+M64P_FPU_INLINE void c_sf_s(uint32_t* fcr31, const float* source, const float* target)
+{
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 &= ~FCR31_CMP_BIT;
+}
+M64P_FPU_INLINE void c_ngle_s(uint32_t* fcr31, const float* source, const float* target)
+{
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 &= ~FCR31_CMP_BIT;
+}
 
-M64P_FPU_INLINE void add_s(const float *source1,const float *source2,float *target)
+M64P_FPU_INLINE void c_seq_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  set_rounding();
-  *target=(*source1)+(*source2);
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source == *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 &~ FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void sub_s(const float *source1,const float *source2,float *target)
+M64P_FPU_INLINE void c_ngl_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  set_rounding();
-  *target=(*source1)-(*source2);
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source == *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void mul_s(const float *source1,const float *source2,float *target)
+
+M64P_FPU_INLINE void c_lt_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  set_rounding();
-  *target=(*source1)*(*source2);
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source < *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void div_s(const float *source1,const float *source2,float *target)
+M64P_FPU_INLINE void c_nge_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  set_rounding();
-  *target=(*source1)/(*source2);
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source < *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void sqrt_s(const float *source,float *target)
+
+M64P_FPU_INLINE void c_le_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  set_rounding();
-  *target=sqrtf(*source);
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source <= *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void abs_s(const float *source,float *target)
+M64P_FPU_INLINE void c_ngt_s(uint32_t* fcr31, const float* source, const float* target)
 {
-  *target=fabsf(*source);
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source <= *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void mov_s(const float *source,float *target)
+
+M64P_FPU_INLINE void c_f_d(uint32_t* fcr31)
 {
-  *target=*source;
+    *fcr31 &= ~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void neg_s(const float *source,float *target)
+M64P_FPU_INLINE void c_un_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  *target=-(*source);
+    *fcr31 = (isnan(*source) || isnan(*target))
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void add_d(const double *source1,const double *source2,double *target)
+
+M64P_FPU_INLINE void c_eq_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  set_rounding();
-  *target=(*source1)+(*source2);
+    if (isnan(*source) || isnan(*target)) { *fcr31 &= ~FCR31_CMP_BIT; return; }
+    *fcr31 = (*source == *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void sub_d(const double *source1,const double *source2,double *target)
+M64P_FPU_INLINE void c_ueq_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  set_rounding();
-  *target=(*source1)-(*source2);
+    if (isnan(*source) || isnan(*target)) { *fcr31 |= FCR31_CMP_BIT; return; }
+    *fcr31 = (*source == *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void mul_d(const double *source1,const double *source2,double *target)
+
+M64P_FPU_INLINE void c_olt_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  set_rounding();
-  *target=(*source1)*(*source2);
+    if (isnan(*source) || isnan(*target)) { *fcr31 &= ~FCR31_CMP_BIT; return; }
+    *fcr31 = (*source < *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void div_d(const double *source1,const double *source2,double *target)
+M64P_FPU_INLINE void c_ult_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  set_rounding();
-  *target=(*source1)/(*source2);
+    if (isnan(*source) || isnan(*target)) { *fcr31 |= FCR31_CMP_BIT; return; }
+    *fcr31 = (*source < *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void sqrt_d(const double *source,double *target)
+
+M64P_FPU_INLINE void c_ole_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  set_rounding();
-  *target=sqrt(*source);
+    if (isnan(*source) || isnan(*target)) { *fcr31 &= ~FCR31_CMP_BIT; return; }
+    *fcr31 = (*source <= *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void abs_d(const double *source,double *target)
+M64P_FPU_INLINE void c_ule_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  *target=fabs(*source);
+    if (isnan(*source) || isnan(*target)) { *fcr31 |= FCR31_CMP_BIT; return; }
+    *fcr31 = (*source <= *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
 }
-M64P_FPU_INLINE void mov_d(const double *source,double *target)
+
+M64P_FPU_INLINE void c_sf_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  *target=*source;
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 &= ~FCR31_CMP_BIT;
 }
-M64P_FPU_INLINE void neg_d(const double *source,double *target)
+M64P_FPU_INLINE void c_ngle_d(uint32_t* fcr31, const double* source, const double* target)
 {
-  *target=-(*source);
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 &= ~FCR31_CMP_BIT;
+}
+
+M64P_FPU_INLINE void c_seq_d(uint32_t* fcr31, const double* source, const double* target)
+{
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source == *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
+}
+M64P_FPU_INLINE void c_ngl_d(uint32_t* fcr31, const double* source, const double* target)
+{
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source == *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
+}
+
+M64P_FPU_INLINE void c_lt_d(uint32_t* fcr31, const double* source, const double* target)
+{
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source < *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
+}
+M64P_FPU_INLINE void c_nge_d(uint32_t* fcr31, const double* source, const double* target)
+{
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source < *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
+}
+
+M64P_FPU_INLINE void c_le_d(uint32_t* fcr31, const double* source, const double* target)
+{
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source <= *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
+}
+M64P_FPU_INLINE void c_ngt_d(uint32_t* fcr31, const double* source, const double* target)
+{
+    //if (isnan(*source) || isnan(*target)) // FIXME - exception
+    *fcr31 = (*source <= *target)
+        ? (*fcr31 |  FCR31_CMP_BIT)
+        : (*fcr31 & ~FCR31_CMP_BIT);
+}
+
+
+M64P_FPU_INLINE void add_s(const uint32_t* fcr31, const float* source1, const float* source2, float* target)
+{
+    set_rounding(fcr31);
+    *target = *source1 + *source2;
+}
+M64P_FPU_INLINE void sub_s(const uint32_t* fcr31, const float* source1, const float* source2, float* target)
+{
+    set_rounding(fcr31);
+    *target = *source1 - *source2;
+}
+M64P_FPU_INLINE void mul_s(const uint32_t* fcr31, const float* source1, const float* source2, float* target)
+{
+    set_rounding(fcr31);
+    *target = *source1 * *source2;
+}
+M64P_FPU_INLINE void div_s(const uint32_t* fcr31, const float* source1, const float* source2, float* target)
+{
+    set_rounding(fcr31);
+    *target = *source1 / *source2;
+}
+M64P_FPU_INLINE void sqrt_s(const uint32_t* fcr31, const float* source, float* target)
+{
+    set_rounding(fcr31);
+    *target = sqrtf(*source);
+}
+M64P_FPU_INLINE void abs_s(const float* source, float* target)
+{
+    *target = fabsf(*source);
+}
+M64P_FPU_INLINE void mov_s(const float* source, float* target)
+{
+    *target = *source;
+}
+M64P_FPU_INLINE void neg_s(const float* source, float* target)
+{
+    *target = - *source;
+}
+M64P_FPU_INLINE void add_d(const uint32_t* fcr31, const double* source1, const double* source2, double* target)
+{
+    set_rounding(fcr31);
+    *target = *source1 + *source2;
+}
+M64P_FPU_INLINE void sub_d(const uint32_t* fcr31, const double* source1, const double* source2, double* target)
+{
+    set_rounding(fcr31);
+    *target = *source1 - *source2;
+}
+M64P_FPU_INLINE void mul_d(const uint32_t* fcr31, const double* source1, const double* source2, double* target)
+{
+    set_rounding(fcr31);
+    *target = *source1 * *source2;
+}
+M64P_FPU_INLINE void div_d(const uint32_t* fcr31, const double* source1, const double* source2, double* target)
+{
+    set_rounding(fcr31);
+    *target = *source1 / *source2;
+}
+M64P_FPU_INLINE void sqrt_d(const uint32_t* fcr31, const double* source, double* target)
+{
+    set_rounding(fcr31);
+    *target = sqrt(*source);
+}
+M64P_FPU_INLINE void abs_d(const double* source, double* target)
+{
+    *target = fabs(*source);
+}
+M64P_FPU_INLINE void mov_d(const double* source, double* target)
+{
+    *target = *source;
+}
+M64P_FPU_INLINE void neg_d(const double* source, double* target)
+{
+    *target =- *source;
 }
 
 #endif /* M64P_DEVICE_R4300_FPU_H */

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -50,6 +50,7 @@
 #include "fpu.h"
 #include "r4300_core.h"
 #include "device/memory/memory.h"
+#include "device/ri/ri_controller.h"
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -1572,7 +1573,7 @@ DECLARE_INSTRUCTION(ADD_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    add_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    add_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1580,7 +1581,7 @@ DECLARE_INSTRUCTION(ADD_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    add_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
+    add_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1592,7 +1593,7 @@ DECLARE_INSTRUCTION(DIV_S)
     {
         DebugMessage(M64MSG_ERROR, "DIV_S by 0");
     }
-    div_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    div_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1609,7 +1610,7 @@ DECLARE_INSTRUCTION(DIV_D)
         DebugMessage(M64MSG_ERROR, "DIV_D by 0");
         //return;
     }
-    div_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
+    div_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1633,7 +1634,7 @@ DECLARE_INSTRUCTION(MUL_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    mul_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    mul_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1641,7 +1642,7 @@ DECLARE_INSTRUCTION(MUL_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    mul_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
+    mul_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1665,7 +1666,7 @@ DECLARE_INSTRUCTION(SQRT_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    sqrt_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    sqrt_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1673,7 +1674,7 @@ DECLARE_INSTRUCTION(SQRT_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    sqrt_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
+    sqrt_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1681,7 +1682,7 @@ DECLARE_INSTRUCTION(SUB_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    sub_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    sub_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1689,7 +1690,7 @@ DECLARE_INSTRUCTION(SUB_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    sub_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
+    sub_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1825,7 +1826,7 @@ DECLARE_INSTRUCTION(CVT_S_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    cvt_s_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    cvt_s_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1833,7 +1834,7 @@ DECLARE_INSTRUCTION(CVT_S_W)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    cvt_s_w((int32_t*) (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    cvt_s_w(r4300_cp1_fcr31(&r4300->cp1), (int32_t*) (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1841,7 +1842,7 @@ DECLARE_INSTRUCTION(CVT_S_L)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    cvt_s_l((int64_t*) (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    cvt_s_l(r4300_cp1_fcr31(&r4300->cp1), (int64_t*) (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1865,7 +1866,7 @@ DECLARE_INSTRUCTION(CVT_D_L)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    cvt_d_l((int64_t*) (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
+    cvt_d_l(r4300_cp1_fcr31(&r4300->cp1), (int64_t*) (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1873,7 +1874,7 @@ DECLARE_INSTRUCTION(CVT_W_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    cvt_w_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (int32_t*) (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    cvt_w_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (int32_t*) (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1881,7 +1882,7 @@ DECLARE_INSTRUCTION(CVT_W_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    cvt_w_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (int32_t*) (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
+    cvt_w_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (int32_t*) (r4300_cp1_regs_simple(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1889,7 +1890,7 @@ DECLARE_INSTRUCTION(CVT_L_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    cvt_l_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (int64_t*) (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
+    cvt_l_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (int64_t*) (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1897,7 +1898,7 @@ DECLARE_INSTRUCTION(CVT_L_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    cvt_l_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (int64_t*) (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
+    cvt_l_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (int64_t*) (r4300_cp1_regs_double(&r4300->cp1))[cffd]);
     ADD_TO_PC(1);
 }
 
@@ -1907,7 +1908,7 @@ DECLARE_INSTRUCTION(C_F_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_f_s();
+    c_f_s(r4300_cp1_fcr31(&r4300->cp1));
     ADD_TO_PC(1);
 }
 
@@ -1915,7 +1916,7 @@ DECLARE_INSTRUCTION(C_F_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_f_d();
+    c_f_d(r4300_cp1_fcr31(&r4300->cp1));
     ADD_TO_PC(1);
 }
 
@@ -1923,7 +1924,7 @@ DECLARE_INSTRUCTION(C_UN_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_un_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_un_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1931,7 +1932,7 @@ DECLARE_INSTRUCTION(C_UN_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_un_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_un_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1939,7 +1940,7 @@ DECLARE_INSTRUCTION(C_EQ_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_eq_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_eq_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1947,7 +1948,7 @@ DECLARE_INSTRUCTION(C_EQ_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_eq_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_eq_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1955,7 +1956,7 @@ DECLARE_INSTRUCTION(C_UEQ_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_ueq_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_ueq_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1963,7 +1964,7 @@ DECLARE_INSTRUCTION(C_UEQ_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_ueq_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_ueq_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1971,7 +1972,7 @@ DECLARE_INSTRUCTION(C_OLT_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_olt_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_olt_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1979,7 +1980,7 @@ DECLARE_INSTRUCTION(C_OLT_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_olt_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_olt_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1987,7 +1988,7 @@ DECLARE_INSTRUCTION(C_ULT_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_ult_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_ult_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -1995,7 +1996,7 @@ DECLARE_INSTRUCTION(C_ULT_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_ult_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_ult_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2003,7 +2004,7 @@ DECLARE_INSTRUCTION(C_OLE_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_ole_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_ole_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2011,7 +2012,7 @@ DECLARE_INSTRUCTION(C_OLE_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_ole_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_ole_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2019,7 +2020,7 @@ DECLARE_INSTRUCTION(C_ULE_S)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_ule_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_ule_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2027,7 +2028,7 @@ DECLARE_INSTRUCTION(C_ULE_D)
 {
     DECLARE_R4300
     if (check_cop1_unusable(r4300)) { return; }
-    c_ule_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_ule_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2040,7 +2041,7 @@ DECLARE_INSTRUCTION(C_SF_S)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_sf_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_sf_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2052,7 +2053,7 @@ DECLARE_INSTRUCTION(C_SF_D)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_sf_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_sf_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2065,7 +2066,7 @@ DECLARE_INSTRUCTION(C_NGLE_S)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_ngle_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_ngle_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2077,7 +2078,7 @@ DECLARE_INSTRUCTION(C_NGLE_D)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_ngle_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_ngle_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2090,7 +2091,7 @@ DECLARE_INSTRUCTION(C_SEQ_S)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_seq_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_seq_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2102,7 +2103,7 @@ DECLARE_INSTRUCTION(C_SEQ_D)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_seq_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_seq_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2115,7 +2116,7 @@ DECLARE_INSTRUCTION(C_NGL_S)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_ngl_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_ngl_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2127,7 +2128,7 @@ DECLARE_INSTRUCTION(C_NGL_D)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_ngl_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_ngl_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2140,7 +2141,7 @@ DECLARE_INSTRUCTION(C_LT_S)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_lt_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_lt_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2153,7 +2154,7 @@ DECLARE_INSTRUCTION(C_LT_D)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_lt_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_lt_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2166,7 +2167,7 @@ DECLARE_INSTRUCTION(C_NGE_S)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_nge_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_nge_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2179,7 +2180,7 @@ DECLARE_INSTRUCTION(C_NGE_D)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_nge_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_nge_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2192,7 +2193,7 @@ DECLARE_INSTRUCTION(C_LE_S)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_le_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_le_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2205,7 +2206,7 @@ DECLARE_INSTRUCTION(C_LE_D)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_le_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_le_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2218,7 +2219,7 @@ DECLARE_INSTRUCTION(C_NGT_S)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_ngt_s((r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
+    c_ngt_s(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_simple(&r4300->cp1))[cffs], (r4300_cp1_regs_simple(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }
 
@@ -2231,6 +2232,6 @@ DECLARE_INSTRUCTION(C_NGT_D)
         DebugMessage(M64MSG_ERROR, "Invalid operation exception in C opcode");
         *r4300_stop(r4300)=1;
     }
-    c_ngt_d((r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
+    c_ngt_d(r4300_cp1_fcr31(&r4300->cp1), (r4300_cp1_regs_double(&r4300->cp1))[cffs], (r4300_cp1_regs_double(&r4300->cp1))[cfft]);
     ADD_TO_PC(1);
 }

--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -3722,8 +3722,9 @@ static void fconv_assemble_arm(int i,struct regstat *i_regs)
   save_regs(reglist);
   
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x20) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_s_w);
   }
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x21) {
@@ -3732,13 +3733,15 @@ static void fconv_assemble_arm(int i,struct regstat *i_regs)
     emit_call((int)cvt_d_w);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x20) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_s_l);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x21) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_d_l);
   }
   
@@ -3748,29 +3751,34 @@ static void fconv_assemble_arm(int i,struct regstat *i_regs)
     emit_call((int)cvt_d_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x24) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_w_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x25) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_l_s);
   }
   
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x20) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_s_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x24) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_w_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x25) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_l_d);
   }
   
@@ -3945,8 +3953,9 @@ static void fcomp_assemble(int i,struct regstat *i_regs)
   reglist&=~(1<<fs);
   save_regs(reglist);
   if(opcode2[i]==0x10) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>16)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>16)&0x1f],ARG3_REG);
     if((source[i]&0x3f)==0x30) emit_call((int)c_f_s);
     if((source[i]&0x3f)==0x31) emit_call((int)c_un_s);
     if((source[i]&0x3f)==0x32) emit_call((int)c_eq_s);
@@ -3965,8 +3974,9 @@ static void fcomp_assemble(int i,struct regstat *i_regs)
     if((source[i]&0x3f)==0x3f) emit_call((int)c_ngt_s);
   }
   if(opcode2[i]==0x11) {
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>16)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
+    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>16)&0x1f],ARG3_REG);
     if((source[i]&0x3f)==0x30) emit_call((int)c_f_d);
     if((source[i]&0x3f)==0x31) emit_call((int)c_un_d);
     if((source[i]&0x3f)==0x32) emit_call((int)c_eq_d);
@@ -4137,12 +4147,23 @@ static void float_assemble(int i,struct regstat *i_regs)
   }
   if(opcode2[i]==0x10) { // Single precision
     save_regs(reglist);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
-    if((source[i]&0x3f)<4) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>16)&0x1f],ARG2_REG);
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
-    }else{
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
+    switch(source[i]&0x3f)
+    {
+      case 0x00: case 0x01: case 0x02: case 0x03:
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>16)&0x1f],ARG3_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG4_REG);
+        break;
+     case 0x04:
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
+        break;
+     case 0x05: case 0x06: case 0x07:
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
+        break;
     }
     switch(source[i]&0x3f)
     {
@@ -4159,12 +4180,24 @@ static void float_assemble(int i,struct regstat *i_regs)
   }
   if(opcode2[i]==0x11) { // Double precision
     save_regs(reglist);
-    emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
-    if((source[i]&0x3f)<4) {
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>16)&0x1f],ARG2_REG);
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
-    }else{
-      emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
+
+    switch(source[i]&0x3f)
+    {
+      case 0x00: case 0x01: case 0x02: case 0x03:
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>16)&0x1f],ARG3_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG4_REG);
+        break;
+     case 0x04:
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.fcr31,ARG1_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
+        break;
+     case 0x05: case 0x06: case 0x07:
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
+        emit_readword((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
+        break;
     }
     switch(source[i]&0x3f)
     {

--- a/src/device/r4300/new_dynarec/x86/assem_x86.c
+++ b/src/device/r4300/new_dynarec/x86/assem_x86.c
@@ -3736,6 +3736,7 @@ static void fconv_assemble_x86(int i,struct regstat *i_regs)
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x20) {
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>> 6)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     emit_call((int)cvt_s_w);
   }
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x21) {
@@ -3746,11 +3747,13 @@ static void fconv_assemble_x86(int i,struct regstat *i_regs)
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x20) {
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>> 6)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     emit_call((int)cvt_s_l);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x21) {
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>> 6)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     emit_call((int)cvt_d_l);
   }
   
@@ -3762,27 +3765,32 @@ static void fconv_assemble_x86(int i,struct regstat *i_regs)
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x24) {
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>> 6)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     emit_call((int)cvt_w_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x25) {
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>> 6)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     emit_call((int)cvt_l_s);
   }
   
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x20) {
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>> 6)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     emit_call((int)cvt_s_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x24) {
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>> 6)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     emit_call((int)cvt_w_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x25) {
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>> 6)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     emit_call((int)cvt_l_d);
   }
   
@@ -3957,6 +3965,7 @@ static void fcomp_assemble(int i,struct regstat *i_regs)
   if(opcode2[i]==0x10) {
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>>16)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     if((source[i]&0x3f)==0x30) emit_call((int)c_f_s);
     if((source[i]&0x3f)==0x31) emit_call((int)c_un_s);
     if((source[i]&0x3f)==0x32) emit_call((int)c_eq_s);
@@ -3977,6 +3986,7 @@ static void fcomp_assemble(int i,struct regstat *i_regs)
   if(opcode2[i]==0x11) {
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>16)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     if((source[i]&0x3f)==0x30) emit_call((int)c_f_d);
     if((source[i]&0x3f)==0x31) emit_call((int)c_un_d);
     if((source[i]&0x3f)==0x32) emit_call((int)c_eq_d);
@@ -4117,6 +4127,8 @@ static void float_assemble(int i,struct regstat *i_regs)
     if((source[i]&0x3f)<4)
       emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>>16)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_simple(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    if((source[i]&0x3f)<=4)
+      emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     switch(source[i]&0x3f)
     {
       case 0x00: emit_call((int)add_s);break;
@@ -4137,6 +4149,8 @@ static void float_assemble(int i,struct regstat *i_regs)
     if((source[i]&0x3f)<4)
       emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>16)&0x1f]);
     emit_pushmem((int)&r4300_cp1_regs_double(&g_dev.r4300.cp1)[(source[i]>>11)&0x1f]);
+    if((source[i]&0x3f)<=4)
+      emit_pushmem((int)r4300_cp1_fcr31(&g_dev.r4300.cp1));
     switch(source[i]&0x3f)
     {
       case 0x00: emit_call((int)add_d);break;


### PR DESCRIPTION
Another step toward global variable free emulation code.