### PR TITLE
No g dev in interrupt

### DIFF
--- a/src/device/ai/ai_controller.c
+++ b/src/device/ai/ai_controller.c
@@ -202,8 +202,9 @@ int write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     return 0;
 }
 
-void ai_end_of_dma_event(struct ai_controller* ai)
+void ai_end_of_dma_event(void* opaque)
 {
+    struct ai_controller* ai = (struct ai_controller*)opaque;
     fifo_pop(ai);
     raise_rcp_interrupt(ai->r4300, MI_INTR_AI);
 }

--- a/src/device/ai/ai_controller.h
+++ b/src/device/ai/ai_controller.h
@@ -78,6 +78,6 @@ void poweron_ai(struct ai_controller* ai);
 int read_ai_regs(void* opaque, uint32_t address, uint32_t* value);
 int write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-void ai_end_of_dma_event(struct ai_controller* ai);
+void ai_end_of_dma_event(void* opaque);
 
 #endif

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -100,6 +100,11 @@ void poweron_device(struct device* dev)
     poweron_si(&dev->si);
     poweron_vi(&dev->vi);
     poweron_memory(&dev->mem);
+
+    /* XXX: somewhat cheating to put it here but not really other option.
+     * Proper fix would probably trigerring the first vi
+     * when VI_CONTROL_REG[1:0] is set to non zero value */
+    add_interrupt_event_count(&dev->r4300.cp0, VI_INT, dev->vi.next_vi);
 }
 
 void run_device(struct device* dev)

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -66,7 +66,8 @@ void init_device(struct device* dev,
         { &dev->sp,        rsp_interrupt_event         }, /* SP */
         { &dev->dp,        rdp_interrupt_event         }, /* DP */
         { &dev->r4300,     hw2_int_handler             }, /* HW2 */
-        { dev,             nmi_int_handler             }  /* NMI */
+        { dev,             nmi_int_handler             }, /* NMI */
+        { dev,             reset_hard_handler          }  /* reset_hard */
     };
 
     init_r4300(&dev->r4300, &dev->mem, &dev->ri, interrupt_handlers,

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -55,7 +55,22 @@ void init_device(struct device* dev,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline, unsigned int alternate_timing)
 {
-    init_r4300(&dev->r4300, &dev->mem, &dev->ri, emumode, count_per_op, no_compiled_jump);
+    struct interrupt_handler interrupt_handlers[] = {
+        { &dev->vi,        vi_vertical_interrupt_event }, /* VI */
+        { &dev->r4300,     compare_int_handler         }, /* COMPARE */
+        { &dev->r4300,     check_int_handler           }, /* CHECK */
+        { &dev->si,        si_end_of_dma_event         }, /* SI */
+        { &dev->pi,        pi_end_of_dma_event         }, /* PI */
+        { &dev->r4300.cp0, special_int_handler         }, /* SPECIAL */
+        { &dev->ai,        ai_end_of_dma_event         }, /* AI */
+        { &dev->sp,        rsp_interrupt_event         }, /* SP */
+        { &dev->dp,        rdp_interrupt_event         }, /* DP */
+        { &dev->r4300,     hw2_int_handler             }, /* HW2 */
+        { dev,             nmi_int_handler             }  /* NMI */
+    };
+
+    init_r4300(&dev->r4300, &dev->mem, &dev->ri, interrupt_handlers,
+            emumode, count_per_op, no_compiled_jump);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
     init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri);
     init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout);

--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -253,8 +253,9 @@ int write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     return 0;
 }
 
-void pi_end_of_dma_event(struct pi_controller* pi)
+void pi_end_of_dma_event(void* opaque)
 {
+    struct pi_controller* pi = (struct pi_controller*)opaque;
     pi->regs[PI_STATUS_REG] &= ~(PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY);
     raise_rcp_interrupt(pi->r4300, MI_INTR_PI);
 }

--- a/src/device/pi/pi_controller.h
+++ b/src/device/pi/pi_controller.h
@@ -84,6 +84,6 @@ void poweron_pi(struct pi_controller* pi);
 int read_pi_regs(void* opaque, uint32_t address, uint32_t* value);
 int write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-void pi_end_of_dma_event(struct pi_controller* pi);
+void pi_end_of_dma_event(void* opaque);
 
 #endif

--- a/src/device/pifbootrom/pifbootrom.c
+++ b/src/device/pifbootrom/pifbootrom.c
@@ -111,4 +111,5 @@ void pifbootrom_hle_execute(struct device* dev)
 
     /* XXX: should prepare execution of IPL3 in DMEM here :
      * e.g. jump to 0xa4000040 */
+    *r4300_cp0_last_addr(&dev->r4300.cp0) = 0xa4000040;
 }

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -89,7 +89,7 @@
          cp0_update_count(r4300); \
       } \
       r4300->cp0.last_addr = *r4300_pc(r4300); \
-      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(); \
+      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(r4300); \
    } \
    static void name##_OUT(void) \
    { \
@@ -121,7 +121,7 @@
          cp0_update_count(r4300); \
       } \
       r4300->cp0.last_addr = *r4300_pc(r4300); \
-      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(); \
+      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(r4300); \
    } \
    static void name##_IDLE(void) \
    { \

--- a/src/device/r4300/cp0.c
+++ b/src/device/r4300/cp0.c
@@ -73,6 +73,8 @@ void poweron_cp0(struct cp0* cp0)
     cp0->special_done = 0;
     cp0->last_addr = UINT32_C(0xbfc00000);
 
+    init_interrupt(cp0);
+
     poweron_tlb(&cp0->tlb);
 }
 

--- a/src/device/r4300/cp0.c
+++ b/src/device/r4300/cp0.c
@@ -37,12 +37,14 @@
 #endif
 
 /* global functions */
-void init_cp0(struct cp0* cp0, unsigned int count_per_op, struct new_dynarec_hot_state* new_dynarec_hot_state)
+void init_cp0(struct cp0* cp0, unsigned int count_per_op, struct new_dynarec_hot_state* new_dynarec_hot_state, const struct interrupt_handler* interrupt_handlers)
 {
     cp0->count_per_op = count_per_op;
 #if NEW_DYNAREC == NEW_DYNAREC_ARM
     cp0->new_dynarec_hot_state = new_dynarec_hot_state;
 #endif
+
+    memcpy(cp0->interrupt_handlers, interrupt_handlers, CP0_INTERRUPT_HANDLERS_COUNT*sizeof(*interrupt_handlers));
 }
 
 void poweron_cp0(struct cp0* cp0)

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -172,7 +172,7 @@ struct interrupt_handler
     void (*callback)(void*);
 };
 
-enum { CP0_INTERRUPT_HANDLERS_COUNT = 11 };
+enum { CP0_INTERRUPT_HANDLERS_COUNT = 12 };
 
 struct cp0
 {

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -166,6 +166,13 @@ struct interrupt_queue
     struct node* first;
 };
 
+struct interrupt_handler
+{
+    void* opaque;
+    void (*callback)(void*);
+};
+
+enum { CP0_INTERRUPT_HANDLERS_COUNT = 11 };
 
 struct cp0
 {
@@ -184,6 +191,8 @@ struct cp0
     unsigned int next_interrupt;
 #endif
 
+    struct interrupt_handler interrupt_handlers[CP0_INTERRUPT_HANDLERS_COUNT];
+
 #if NEW_DYNAREC == NEW_DYNAREC_ARM
 /* ARM dynarec uses a different memory layout */
     struct new_dynarec_hot_state* new_dynarec_hot_state;
@@ -197,7 +206,7 @@ struct cp0
     struct tlb tlb;
 };
 
-void init_cp0(struct cp0* cp0, unsigned int count_per_op, struct new_dynarec_hot_state* new_dynarec_hot_state);
+void init_cp0(struct cp0* cp0, unsigned int count_per_op, struct new_dynarec_hot_state* new_dynarec_hot_state, const struct interrupt_handler* interrupt_handlers);
 void poweron_cp0(struct cp0* cp0);
 
 uint32_t* r4300_cp0_regs(struct cp0* cp0);

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -507,8 +507,9 @@ void nmi_int_handler(void* opaque)
 }
 
 
-static void reset_hard(struct device* dev)
+void reset_hard_handler(void* opaque)
 {
+    struct device* dev = (struct device*)opaque;
     struct r4300_core* r4300 = &dev->r4300;
 
     poweron_device(dev);
@@ -556,7 +557,7 @@ void gen_interrupt(struct r4300_core* r4300)
 
         if (r4300->reset_hard_job)
         {
-            reset_hard(&g_dev);
+            call_interrupt_handler(&r4300->cp0, 11);
             return;
         }
     }

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -526,9 +526,8 @@ static void reset_hard(struct device* dev)
 }
 
 
-void gen_interrupt(void)
+void gen_interrupt(struct r4300_core* r4300)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
     unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
 

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -32,7 +32,7 @@ void init_interrupt(struct cp0* cp0);
 
 void raise_maskable_interrupt(struct r4300_core* r4300, uint32_t cause);
 
-void gen_interrupt(void);
+void gen_interrupt(struct r4300_core* r4300);
 void check_interrupt(struct r4300_core* r4300);
 
 void translate_event_queue(struct cp0* cp0, unsigned int base);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -45,6 +45,12 @@ int get_next_event_type(const struct interrupt_queue* q);
 int save_eventqueue_infos(struct cp0* cp0, char *buf);
 void load_eventqueue_infos(struct cp0* cp0, const char *buf);
 
+void compare_int_handler(void* opaque);
+void check_int_handler(void* opaque);
+void special_int_handler(void* opaque);
+void hw2_int_handler(void* opaque);
+void nmi_int_handler(void* opaque);
+
 #define VI_INT      0x001
 #define COMPARE_INT 0x002
 #define CHECK_INT   0x004

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -45,6 +45,8 @@ int get_next_event_type(const struct interrupt_queue* q);
 int save_eventqueue_infos(struct cp0* cp0, char *buf);
 void load_eventqueue_infos(struct cp0* cp0, const char *buf);
 
+void reset_hard_handler(void* opaque);
+
 void compare_int_handler(void* opaque);
 void check_int_handler(void* opaque);
 void special_int_handler(void* opaque);

--- a/src/device/r4300/mi_controller.c
+++ b/src/device/r4300/mi_controller.c
@@ -103,7 +103,7 @@ int write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 
         check_interrupt(r4300);
         cp0_update_count(r4300);
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt();
+        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt(r4300);
         break;
     }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1047,7 +1047,7 @@ DECLARE_INSTRUCTION(ERET)
     r4300->llbit = 0;
     check_interrupt(r4300);
     r4300->cp0.last_addr = PCADDR;
-    if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(); }
+    if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
 }
 
 DECLARE_INSTRUCTION(SYNC)
@@ -1368,7 +1368,7 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_COUNT_REG:
         cp0_update_count(r4300);
         r4300->cp0.interrupt_unsafe_state = 1;
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(); }
+        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
         r4300->cp0.interrupt_unsafe_state = 0;
         translate_event_queue(&r4300->cp0, rrt32);
         cp0_regs[CP0_COUNT_REG] = rrt32;
@@ -1394,7 +1394,7 @@ DECLARE_INSTRUCTION(MTC0)
         ADD_TO_PC(1);
         check_interrupt(r4300);
         r4300->cp0.interrupt_unsafe_state = 1;
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(); }
+        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
         r4300->cp0.interrupt_unsafe_state = 0;
         ADD_TO_PC(-1);
         break;

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -265,7 +265,7 @@ GLOBAL_FUNCTION(cc_interrupt):
     tst    r4, r4
     bne    .E4
 .E1:
-    bl     gen_interrupt
+    bl     dynarec_gen_interrupt
     mov    lr, r10
     ldr    r10, [fp, #fp_cp0_regs+36] /* Count */
     ldr    r0, [fp, #fp_next_interrupt]

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -5989,7 +5989,7 @@ static void do_ccstub(int n)
   emit_readword((int)&g_dev.r4300.new_dynarec_hot_state.last_count,ECX);
   emit_add(HOST_CCREG,ECX,EAX);
   emit_writeword(EAX,(int)&r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_COUNT_REG]);
-  emit_call((int)gen_interrupt);
+  emit_call((int)dynarec_gen_interrupt);
   emit_readword((int)&r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_COUNT_REG],HOST_CCREG);
   emit_readword((int)&g_dev.r4300.cp0.next_interrupt,EAX);
   emit_readword((int)&g_dev.r4300.new_dynarec_hot_state.pending_exception,EBX);

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -122,7 +122,7 @@ cextern base_addr
 cextern new_recompile_block
 cextern get_addr_ht
 cextern get_addr
-cextern gen_interrupt
+cextern dynarec_gen_interrupt
 cextern clean_blocks
 cextern invalidate_block
 cextern new_dynarec_check_interrupt
@@ -257,7 +257,7 @@ cc_interrupt:
     cmp     DWORD [find_local_data(g_dev_r4300_new_dynarec_hot_state_restore_candidate+esi)],    0
     jne     _E4
 _E1:
-    call    gen_interrupt
+    call    dynarec_gen_interrupt
     mov     esi,    [find_local_data(g_dev_r4300_cp0_regs+36)]
     mov     eax,    [find_local_data(g_dev_r4300_cp0_next_interrupt)]
     mov     edx,    [find_local_data(g_dev_r4300_new_dynarec_hot_state_pending_exception)]

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -78,7 +78,7 @@ static void InterpretOpcode(struct r4300_core* r4300);
          cp0_update_count(r4300); \
       } \
       r4300->cp0.last_addr = r4300->interp_PC.addr; \
-      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(); \
+      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(r4300); \
    } \
    static void name##_IDLE(struct r4300_core* r4300, uint32_t op) \
    { \

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -145,11 +145,6 @@ void run_r4300(struct r4300_core* r4300)
     memset(instr_count, 0, 131*sizeof(instr_count[0]));
 #endif
 
-    /* XXX: might go to r4300_poweron / soft_reset ? */
-    r4300->cp0.last_addr = 0xa4000040;
-    *r4300_cp0_next_interrupt(&r4300->cp0) = 624999;
-    init_interrupt(&r4300->cp0);
-
     if (r4300->emumode == EMUMODE_PURE_INTERPRETER)
     {
         DebugMessage(M64MSG_INFO, "Starting R4300 emulator: Pure Interpreter");

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -41,7 +41,7 @@
 #include <string.h>
 
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump)
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump)
 {
     struct new_dynarec_hot_state* new_dynarec_hot_state =
 #if NEW_DYNAREC == NEW_DYNAREC_ARM
@@ -51,7 +51,7 @@ void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controll
 #endif
 
     r4300->emumode = emumode;
-    init_cp0(&r4300->cp0, count_per_op, new_dynarec_hot_state);
+    init_cp0(&r4300->cp0, count_per_op, new_dynarec_hot_state, interrupt_handlers);
     init_cp1(&r4300->cp1, new_dynarec_hot_state);
 
     r4300->recomp.no_compiled_jump = no_compiled_jump;

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -198,7 +198,7 @@ struct r4300_core
     struct ri_controller* ri;
 };
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump);
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump);
 void poweron_r4300(struct r4300_core* r4300);
 
 void run_r4300(struct r4300_core* r4300);

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2641,6 +2641,12 @@ void dynarec_cp0_update_count(void)
     cp0_update_count(&g_dev.r4300);
 }
 
+/* Parameterless version of gen_interrupt to ease usage in dynarec. */
+void dynarec_gen_interrupt(void)
+{
+    gen_interrupt(&g_dev.r4300);
+}
+
 /**********************************************************************
  ************** allocate memory with executable bit set ***************
  **********************************************************************/

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -43,6 +43,7 @@ void dynarec_jump_to_address(void);
 void dynarec_exception_general(void);
 int dynarec_check_cop1_unusable(void);
 void dynarec_cp0_update_count(void);
+void dynarec_gen_interrupt(void);
 
 
 #if defined(PROFILE_R4300)

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -125,7 +125,7 @@ static void gencheck_interrupt(struct r4300_core* r4300, unsigned int instr_stru
     cmp_reg32_m32(EAX, &r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]);
     ja_rj(17);
     mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct(r4300))), instr_structure); // 10
-    mov_reg32_imm32(EAX, (unsigned int)gen_interrupt); // 5
+    mov_reg32_imm32(EAX, (unsigned int)dynarec_gen_interrupt); // 5
     call_reg32(EAX); // 2
 }
 
@@ -136,7 +136,7 @@ static void gencheck_interrupt_out(struct r4300_core* r4300, unsigned int addr)
     ja_rj(27);
     mov_m32_imm32((unsigned int*)(&r4300->fake_instr.addr), addr);
     mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct(r4300))), (unsigned int)(&r4300->fake_instr));
-    mov_reg32_imm32(EAX, (unsigned int)gen_interrupt);
+    mov_reg32_imm32(EAX, (unsigned int)dynarec_gen_interrupt);
     call_reg32(EAX);
 }
 
@@ -147,7 +147,7 @@ static void gencheck_interrupt_reg(struct r4300_core* r4300) // addr is in EAX
     ja_rj(22);
     mov_memoffs32_eax((unsigned int*)(&r4300->fake_instr.addr)); // 5
     mov_m32_imm32((unsigned int*)(&(*r4300_pc_struct(r4300))), (unsigned int)(&r4300->fake_instr)); // 10
-    mov_reg32_imm32(EAX, (unsigned int)gen_interrupt); // 5
+    mov_reg32_imm32(EAX, (unsigned int)dynarec_gen_interrupt); // 5
     call_reg32(EAX); // 2
 }
 

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -139,7 +139,7 @@ static void gencheck_interrupt(struct r4300_core* r4300, unsigned long long inst
 
     mov_reg64_imm64(RAX, (unsigned long long) instr_structure);
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX);
-    mov_reg64_imm64(RAX, (unsigned long long) gen_interrupt);
+    mov_reg64_imm64(RAX, (unsigned long long) dynarec_gen_interrupt);
     call_reg64(RAX);
 
     jump_end_rel8();
@@ -155,7 +155,7 @@ static void gencheck_interrupt_out(struct r4300_core* r4300, unsigned int addr)
     mov_m32rel_imm32((unsigned int*)(&r4300->fake_instr.addr), addr);
     mov_reg64_imm64(RAX, (unsigned long long) (&r4300->fake_instr));
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX);
-    mov_reg64_imm64(RAX, (unsigned long long) gen_interrupt);
+    mov_reg64_imm64(RAX, (unsigned long long) dynarec_gen_interrupt);
     call_reg64(RAX);
 
     jump_end_rel8();
@@ -171,7 +171,7 @@ static void gencheck_interrupt_reg(struct r4300_core* r4300) // addr is in EAX
     mov_m32rel_xreg32((unsigned int*)(&r4300->fake_instr.addr), EAX);
     mov_reg64_imm64(RAX, (unsigned long long) (&r4300->fake_instr));
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX);
-    mov_reg64_imm64(RAX, (unsigned long long) gen_interrupt);
+    mov_reg64_imm64(RAX, (unsigned long long) dynarec_gen_interrupt);
     call_reg64(RAX);
 
     jump_end_rel8();

--- a/src/device/rdp/rdp_core.c
+++ b/src/device/rdp/rdp_core.c
@@ -139,8 +139,10 @@ int write_dps_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
     return 0;
 }
 
-void rdp_interrupt_event(struct rdp_core* dp)
+void rdp_interrupt_event(void* opaque)
 {
+    struct rdp_core* dp = (struct rdp_core*)opaque;
+
     dp->dpc_regs[DPC_STATUS_REG] &= ~DPC_STATUS_FREEZE;
     dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_XBUS_DMEM_DMA
         | DPC_STATUS_CBUF_READY;

--- a/src/device/rdp/rdp_core.h
+++ b/src/device/rdp/rdp_core.h
@@ -104,6 +104,6 @@ int write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 int read_dps_regs(void* opaque, uint32_t address, uint32_t* value);
 int write_dps_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-void rdp_interrupt_event(struct rdp_core* dp);
+void rdp_interrupt_event(void* opaque);
 
 #endif

--- a/src/device/rsp/rsp_core.c
+++ b/src/device/rsp/rsp_core.c
@@ -345,9 +345,10 @@ void do_SP_Task(struct rsp_core* sp)
     }
 }
 
-void rsp_interrupt_event(struct rsp_core* sp)
+void rsp_interrupt_event(void* opaque)
 {
-    if(!sp->rsp_task_locked)
+    struct rsp_core* sp = (struct rsp_core*)opaque;
+    if (!sp->rsp_task_locked)
     {
         /* XXX: assume task has fully completed */
         sp->regs[SP_STATUS_REG] |=

--- a/src/device/rsp/rsp_core.h
+++ b/src/device/rsp/rsp_core.h
@@ -119,6 +119,6 @@ int write_rsp_regs2(void* opaque, uint32_t address, uint32_t value, uint32_t mas
 
 void do_SP_Task(struct rsp_core* sp);
 
-void rsp_interrupt_event(struct rsp_core* sp);
+void rsp_interrupt_event(void* opaque);
 
 #endif

--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -164,8 +164,9 @@ int write_si_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     return 0;
 }
 
-void si_end_of_dma_event(struct si_controller* si)
+void si_end_of_dma_event(void* opaque)
 {
+    struct si_controller* si = (struct si_controller*)opaque;
     main_check_inputs();
 
     si->pif.ram[0x3f] = 0x0;

--- a/src/device/si/si_controller.h
+++ b/src/device/si/si_controller.h
@@ -77,6 +77,6 @@ void poweron_si(struct si_controller* si);
 int read_si_regs(void* opaque, uint32_t address, uint32_t* value);
 int write_si_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-void si_end_of_dma_event(struct si_controller* si);
+void si_end_of_dma_event(void* opaque);
 
 #endif

--- a/src/device/vi/vi_controller.c
+++ b/src/device/vi/vi_controller.c
@@ -136,8 +136,9 @@ int write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     return 0;
 }
 
-void vi_vertical_interrupt_event(struct vi_controller* vi)
+void vi_vertical_interrupt_event(void* opaque)
 {
+    struct vi_controller* vi = (struct vi_controller*)opaque;
     gfx.updateScreen();
 
     /* allow main module to do things on VI event */

--- a/src/device/vi/vi_controller.h
+++ b/src/device/vi/vi_controller.h
@@ -79,6 +79,6 @@ void poweron_vi(struct vi_controller* vi);
 int read_vi_regs(void* opaque, uint32_t address, uint32_t* value);
 int write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-void vi_vertical_interrupt_event(struct vi_controller* vi);
+void vi_vertical_interrupt_event(void* opaque);
 
 #endif


### PR DESCRIPTION
Remove usage of g_dev in interrupt. The tricky commit is the last one which reworks how the first VI is triggered. This is because, the code which handle initialization, reset, NMI, pifbootrom, ... is quite bad. But I guess that's will be for another PR.