### PR TITLE
Fix Twisted Edge audio

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -6636,6 +6636,7 @@ GoodName=King Hill 64 - Extreme Snowboarding (J) [!]
 CRC=519EA4E1 EB7584E8
 Players=4
 SaveType=Controller Pack
+FixedAudioPos=1
 
 [CE9AE0AA6DBBF965B1F72BC3AA6A7CEF]
 GoodName=King Hill 64 - Extreme Snowboarding (J) [b1]
@@ -14739,6 +14740,7 @@ CRC=E688A5B8 B14B3F18
 SaveType=Controller Pack
 Players=2
 Rumble=Yes
+FixedAudioPos=1
 
 [4F0E2AF205BEEB49270154810660FF37]
 GoodName=Twisted Edge Extreme Snowboarding (E) [b1]
@@ -14756,6 +14758,7 @@ CRC=BBC99D32 117DAA80
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
+FixedAudioPos=1
 
 [0B0DF8EC747BF99F3A55A3300CE8BC0D]
 GoodName=U64 (Chrome) Demo by Horizon64 (PD) [a1]

--- a/src/device/ai/ai_controller.h
+++ b/src/device/ai/ai_controller.h
@@ -60,6 +60,8 @@ struct ai_controller
     struct ri_controller* ri;
     struct vi_controller* vi;
     struct audio_out_backend* aout;
+    uint32_t fixed_audio_pos;
+    uint32_t audio_pos;
 };
 
 static uint32_t ai_reg(uint32_t address)
@@ -71,7 +73,7 @@ void init_ai(struct ai_controller* ai,
              struct r4300_core* r4300,
              struct ri_controller* ri,
              struct vi_controller* vi,
-             struct audio_out_backend* aout);
+             struct audio_out_backend* aout, unsigned int fixed_audio_pos);
 
 void poweron_ai(struct ai_controller* ai);
 

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -38,7 +38,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     /* ai */
-    struct audio_out_backend* aout,
+    struct audio_out_backend* aout, unsigned int fixed_audio_pos,
     /* pi */
     uint8_t* rom, size_t rom_size,
     struct storage_backend* flashram_storage,
@@ -74,7 +74,7 @@ void init_device(struct device* dev,
             emumode, count_per_op, no_compiled_jump);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
     init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri);
-    init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout);
+    init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, fixed_audio_pos);
     init_pi(&dev->pi, rom, rom_size, flashram_storage, sram_storage, &dev->r4300, &dev->ri, &dev->si.pif.cic);
     init_ri(&dev->ri, dram, dram_size);
     init_si(&dev->si,

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -63,7 +63,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     /* ai */
-    struct audio_out_backend* aout,
+    struct audio_out_backend* aout, unsigned int fixed_audio_pos,
     /* pi */
     uint8_t* rom, size_t rom_size,
     struct storage_backend* flashram_storage,

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1054,7 +1054,7 @@ m64p_error main_run(void)
                 emumode,
                 count_per_op,
                 no_compiled_jump,
-                &aout,
+                &aout, ROM_PARAMS.fixedaudiopos,
                 g_rom, g_rom_size,
                 &fla_storage,
                 &sra_storage,

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -51,6 +51,8 @@ enum { DEFAULT_COUNT_PER_SCANLINE = 1500 };
 enum { DEFAULT_COUNT_PER_OP = 2 };
 /* by default, alternate VI timing is disabled */
 enum { DEFAULT_ALTERNATE_VI_TIMING = 0 };
+/* by default, fixed audio position is disabled */
+enum { DEFAULT_FIXED_AUDIO_POS = 0 };
 
 static romdatabase_entry* ini_search_by_md5(md5_byte_t* md5);
 
@@ -177,6 +179,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.systemtype = rom_country_code_to_system_type(ROM_HEADER.Country_code);
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
     ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
+    ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
     ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.cheats = NULL;
 
@@ -196,6 +199,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = entry->rumble;
         ROM_PARAMS.countperop = entry->countperop;
         ROM_PARAMS.vitiming = entry->alternate_vi_timing;
+        ROM_PARAMS.fixedaudiopos = entry->fixed_audio_pos;
         ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.cheats = entry->cheats;
     }
@@ -209,6 +213,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = 0;
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
         ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
+        ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
         ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.cheats = NULL;
     }
@@ -436,7 +441,7 @@ void romdatabase_open(void)
             *next_search = (romdatabase_search*) malloc(sizeof(romdatabase_search));
             search = *next_search;
             next_search = &search->next_entry;
-            
+
             memset(search, 0, sizeof(romdatabase_search));
 
             search->entry.goodname = NULL;
@@ -450,6 +455,7 @@ void romdatabase_open(void)
             search->entry.rumble = 0;
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
             search->entry.alternate_vi_timing = DEFAULT_ALTERNATE_VI_TIMING;
+            search->entry.fixed_audio_pos = DEFAULT_FIXED_AUDIO_POS;
             search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.cheats = NULL;
             search->entry.set_flags = ROMDATABASE_ENTRY_NONE;
@@ -500,9 +506,13 @@ void romdatabase_open(void)
                     search->entry.alternate_vi_timing = 1;
                 }
             }
+            else if(!strcmp(l.name, "FixedAudioPos"))
+            {
+                search->entry.fixed_audio_pos = atoi(l.value);
+            }
             else if(!strcmp(l.name, "CountPerScanline"))
             {
-                 search->entry.count_per_scanline = atoi(l.value);
+                search->entry.count_per_scanline = atoi(l.value);
             }
             else if(!strcmp(l.name, "RefMD5"))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -53,6 +53,7 @@ typedef struct _rom_params
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
    int vitiming;
+   int fixedaudiopos;
    int countperscanline;
 } rom_params;
 
@@ -125,6 +126,7 @@ typedef struct
    unsigned char players; /* Local players 0-4, 2/3/4 way Netplay indicated by 5/6/7. */
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
    unsigned char alternate_vi_timing;
+   unsigned char fixed_audio_pos;
    int count_per_scanline;
    unsigned char countperop;
    uint32_t set_flags;


### PR DESCRIPTION
Fixes #285 

This is a combination of these 2 commits:
https://github.com/project64/project64/commit/f24c464f3f8783dd9fdbeeaa21b02658c1340ec3

https://github.com/Azimer/AziAudio/commit/7140f74be33615b4f9c62164e5e7e4d261cc6e48

Firstly, AI_LEN_REG should be a multiple of 8, so I modified ```get_remaining_dma_length``` accordingly. This may fix other audio issues if they exist, I'm not sure. This is what allowed the audio samples to start getting sent to the audio plugin.

Secondly, Twisted Edge has some strange behaviour with AI_DRAM_ADDR_REG, it points to the wrong address. The "FixedAudioPos" hack takes the first AI_DRAM_ADDR_REG value, and uses that for the rest of the game, ignoring future values.

I compared to Project64 and it sounds the same to me.