### PR TITLE
Fix audio in RE2

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -1552,7 +1552,7 @@ GoodName=Biohazard 2 (J) [!]
 CRC=7EAE2488 9D40A35A
 SaveType=SRAM
 Players=1
-CountPerOp=1
+CountPerScanline=2200
 
 [13D7834291A311077B84B9A2816AF6FC]
 GoodName=Birthday Demo for Steve by Nep (PD) [b1]
@@ -11888,7 +11888,7 @@ CRC=9B500E8E E90550B3
 Players=1
 Rumble=Yes
 SaveType=SRAM
-CountPerOp=1
+CountPerScanline=2200
 
 [1ADD2C0217662B307CDFD876B35FBF7A]
 GoodName=Resident Evil 2 (U) (V1.1) [!]
@@ -11896,7 +11896,7 @@ CRC=AA18B1A5 07DB6AEB
 Players=1
 Rumble=Yes
 SaveType=SRAM
-CountPerOp=1
+CountPerScanline=2200
 
 [AD922DAE446A301E1AAFE1DFBAD75A2E]
 GoodName=Road Rash 64 (E) [!]


### PR DESCRIPTION
This fixes the audio in the FMV's in RE2. The voices are now back, and the audio is in sync with the video.

I tested the U version. GLideN64 + CXD4 (HLE video). 32-bit Mupen64Plus with new dynarec