### PR TITLE
Fix undefined behavior in the interpreter

### DIFF
--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -102,7 +102,7 @@ DECLARE_INSTRUCTION(RESERVED)
 DECLARE_INSTRUCTION(LB)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -116,7 +116,7 @@ DECLARE_INSTRUCTION(LB)
 DECLARE_INSTRUCTION(LBU)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -127,7 +127,7 @@ DECLARE_INSTRUCTION(LBU)
 DECLARE_INSTRUCTION(LH)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -141,7 +141,7 @@ DECLARE_INSTRUCTION(LH)
 DECLARE_INSTRUCTION(LHU)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -152,7 +152,7 @@ DECLARE_INSTRUCTION(LHU)
 DECLARE_INSTRUCTION(LL)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -167,7 +167,7 @@ DECLARE_INSTRUCTION(LL)
 DECLARE_INSTRUCTION(LW)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -181,7 +181,7 @@ DECLARE_INSTRUCTION(LW)
 DECLARE_INSTRUCTION(LWU)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -192,7 +192,7 @@ DECLARE_INSTRUCTION(LWU)
 DECLARE_INSTRUCTION(LWL)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     uint64_t word = 0;
     ADD_TO_PC(1);
@@ -223,7 +223,7 @@ DECLARE_INSTRUCTION(LWL)
 DECLARE_INSTRUCTION(LWR)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     uint64_t word = 0;
     ADD_TO_PC(1);
@@ -254,7 +254,7 @@ DECLARE_INSTRUCTION(LWR)
 DECLARE_INSTRUCTION(LD)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -265,7 +265,7 @@ DECLARE_INSTRUCTION(LD)
 DECLARE_INSTRUCTION(LDL)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     uint64_t word = 0;
     ADD_TO_PC(1);
@@ -294,7 +294,7 @@ DECLARE_INSTRUCTION(LDL)
 DECLARE_INSTRUCTION(LDR)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     uint64_t word = 0;
     ADD_TO_PC(1);
@@ -324,7 +324,7 @@ DECLARE_INSTRUCTION(LDR)
 DECLARE_INSTRUCTION(SB)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -336,7 +336,7 @@ DECLARE_INSTRUCTION(SB)
 DECLARE_INSTRUCTION(SH)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -348,7 +348,7 @@ DECLARE_INSTRUCTION(SH)
 DECLARE_INSTRUCTION(SC)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     if(r4300->llbit)
@@ -369,7 +369,7 @@ DECLARE_INSTRUCTION(SC)
 DECLARE_INSTRUCTION(SW)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -381,7 +381,7 @@ DECLARE_INSTRUCTION(SW)
 DECLARE_INSTRUCTION(SWL)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     uint64_t old_word = 0;
     ADD_TO_PC(1);
@@ -415,7 +415,7 @@ DECLARE_INSTRUCTION(SWL)
 DECLARE_INSTRUCTION(SWR)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     uint64_t old_word = 0;
     ADD_TO_PC(1);
@@ -448,7 +448,7 @@ DECLARE_INSTRUCTION(SWR)
 DECLARE_INSTRUCTION(SD)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     *r4300_address(r4300) = lsaddr;
@@ -460,7 +460,7 @@ DECLARE_INSTRUCTION(SD)
 DECLARE_INSTRUCTION(SDL)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     uint64_t old_word = 0;
     ADD_TO_PC(1);
@@ -494,7 +494,7 @@ DECLARE_INSTRUCTION(SDL)
 DECLARE_INSTRUCTION(SDR)
 {
     DECLARE_R4300
-    const uint32_t lsaddr = irs32 + iimmediate;
+    const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     uint64_t old_word = 0;
     ADD_TO_PC(1);
@@ -529,84 +529,84 @@ DECLARE_INSTRUCTION(SDR)
 DECLARE_INSTRUCTION(ADD)
 {
     DECLARE_R4300
-    rrd = SE32(rrs32 + rrt32);
+    rrd = SE32((uint32_t) rrs32 + (uint32_t) rrt32);
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ADDU)
 {
     DECLARE_R4300
-    rrd = SE32(rrs32 + rrt32);
+    rrd = SE32((uint32_t) rrs32 + (uint32_t) rrt32);
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ADDI)
 {
     DECLARE_R4300
-    irt = SE32(irs32 + iimmediate);
+    irt = SE32((uint32_t) irs32 + (uint32_t) iimmediate);
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(ADDIU)
 {
     DECLARE_R4300
-    irt = SE32(irs32 + iimmediate);
+    irt = SE32((uint32_t) irs32 + (uint32_t) iimmediate);
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DADD)
 {
     DECLARE_R4300
-    rrd = rrs + rrt;
+    rrd = (uint64_t) rrs + (uint64_t) rrt;
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DADDU)
 {
     DECLARE_R4300
-    rrd = rrs + rrt;
+    rrd = (uint64_t) rrs + (uint64_t) rrt;
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DADDI)
 {
     DECLARE_R4300
-    irt = irs + iimmediate;
+    irt = (uint64_t) irs + (uint64_t) iimmediate;
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DADDIU)
 {
     DECLARE_R4300
-    irt = irs + iimmediate;
+    irt = (uint64_t) irs + (uint64_t) iimmediate;
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SUB)
 {
     DECLARE_R4300
-    rrd = SE32(rrs32 - rrt32);
+    rrd = SE32((uint32_t) rrs32 - (uint32_t) rrt32);
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(SUBU)
 {
     DECLARE_R4300
-    rrd = SE32(rrs32 - rrt32);
+    rrd = SE32((uint32_t) rrs32 - (uint32_t) rrt32);
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DSUB)
 {
     DECLARE_R4300
-    rrd = rrs - rrt;
+    rrd = (uint64_t) rrs - (uint64_t) rrt;
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DSUBU)
 {
     DECLARE_R4300
-    rrd = rrs - rrt;
+    rrd = (uint64_t) rrs - (uint64_t) rrt;
     ADD_TO_PC(1);
 }
 
@@ -694,7 +694,7 @@ DECLARE_INSTRUCTION(NOR)
 DECLARE_INSTRUCTION(LUI)
 {
     DECLARE_R4300
-    irt = SE32(iimmediate << 16);
+    irt = SE32((uint32_t) iimmediate << 16);
     ADD_TO_PC(1);
 }
 
@@ -723,21 +723,21 @@ DECLARE_INSTRUCTION(SLLV)
 DECLARE_INSTRUCTION(DSLL)
 {
     DECLARE_R4300
-    rrd = rrt << rsa;
+    rrd = (uint64_t) rrt << rsa;
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DSLLV)
 {
     DECLARE_R4300
-    rrd = rrt << (rrs32 & 0x3F);
+    rrd = (uint64_t) rrt << (rrs32 & 0x3F);
     ADD_TO_PC(1);
 }
 
 DECLARE_INSTRUCTION(DSLL32)
 {
     DECLARE_R4300
-    rrd = rrt << (32 + rsa);
+    rrd = (uint64_t) rrt << (32 + rsa);
     ADD_TO_PC(1);
 }
 
@@ -817,7 +817,7 @@ DECLARE_INSTRUCTION(MULT)
 {
     DECLARE_R4300
     int64_t temp;
-    temp = rrs * rrt;
+    temp = (uint64_t) rrs * (uint64_t) rrt;
     *r4300_mult_hi(r4300) = temp >> 32;
     *r4300_mult_lo(r4300) = SE32(temp);
     ADD_TO_PC(1);

--- a/src/device/r4300/tlb.h
+++ b/src/device/r4300/tlb.h
@@ -30,14 +30,14 @@ struct r4300_core;
 struct tlb_entry
 {
    short mask;
-   int vpn2;
+   unsigned int vpn2;
    char g;
    unsigned char asid;
-   int pfn_even;
+   unsigned int pfn_even;
    char c_even;
    char d_even;
    char v_even;
-   int pfn_odd;
+   unsigned int pfn_odd;
    char c_odd;
    char d_odd;
    char v_odd;

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -466,16 +466,16 @@ int savestates_load_m64p(char *filepath)
     {
         g_dev.r4300.cp0.tlb.entries[i].mask = GETDATA(curr, short);
         curr += 2;
-        g_dev.r4300.cp0.tlb.entries[i].vpn2 = GETDATA(curr, int);
+        g_dev.r4300.cp0.tlb.entries[i].vpn2 = GETDATA(curr, unsigned int);
         g_dev.r4300.cp0.tlb.entries[i].g = GETDATA(curr, char);
         g_dev.r4300.cp0.tlb.entries[i].asid = GETDATA(curr, unsigned char);
         curr += 2;
-        g_dev.r4300.cp0.tlb.entries[i].pfn_even = GETDATA(curr, int);
+        g_dev.r4300.cp0.tlb.entries[i].pfn_even = GETDATA(curr, unsigned int);
         g_dev.r4300.cp0.tlb.entries[i].c_even = GETDATA(curr, char);
         g_dev.r4300.cp0.tlb.entries[i].d_even = GETDATA(curr, char);
         g_dev.r4300.cp0.tlb.entries[i].v_even = GETDATA(curr, char);
         curr++;
-        g_dev.r4300.cp0.tlb.entries[i].pfn_odd = GETDATA(curr, int);
+        g_dev.r4300.cp0.tlb.entries[i].pfn_odd = GETDATA(curr, unsigned int);
         g_dev.r4300.cp0.tlb.entries[i].c_odd = GETDATA(curr, char);
         g_dev.r4300.cp0.tlb.entries[i].d_odd = GETDATA(curr, char);
         g_dev.r4300.cp0.tlb.entries[i].v_odd = GETDATA(curr, char);
@@ -1220,16 +1220,16 @@ int savestates_save_m64p(char *filepath)
     {
         PUTDATA(curr, short, g_dev.r4300.cp0.tlb.entries[i].mask);
         PUTDATA(curr, short, 0);
-        PUTDATA(curr, int, g_dev.r4300.cp0.tlb.entries[i].vpn2);
+        PUTDATA(curr, unsigned int, g_dev.r4300.cp0.tlb.entries[i].vpn2);
         PUTDATA(curr, char, g_dev.r4300.cp0.tlb.entries[i].g);
         PUTDATA(curr, unsigned char, g_dev.r4300.cp0.tlb.entries[i].asid);
         PUTDATA(curr, short, 0);
-        PUTDATA(curr, int, g_dev.r4300.cp0.tlb.entries[i].pfn_even);
+        PUTDATA(curr, unsigned int, g_dev.r4300.cp0.tlb.entries[i].pfn_even);
         PUTDATA(curr, char, g_dev.r4300.cp0.tlb.entries[i].c_even);
         PUTDATA(curr, char, g_dev.r4300.cp0.tlb.entries[i].d_even);
         PUTDATA(curr, char, g_dev.r4300.cp0.tlb.entries[i].v_even);
         PUTDATA(curr, char, 0);
-        PUTDATA(curr, int, g_dev.r4300.cp0.tlb.entries[i].pfn_odd);
+        PUTDATA(curr, unsigned int, g_dev.r4300.cp0.tlb.entries[i].pfn_odd);
         PUTDATA(curr, char, g_dev.r4300.cp0.tlb.entries[i].c_odd);
         PUTDATA(curr, char, g_dev.r4300.cp0.tlb.entries[i].d_odd);
         PUTDATA(curr, char, g_dev.r4300.cp0.tlb.entries[i].v_odd);


### PR DESCRIPTION
Partially fixes #87, but there are probably more potential overflows lurking in there; I didn't go over it too thoroughly.

FYI: In C, integer overflow when adding and multiplying signed integers is undefined, as is shifting any integer by too high a width, and left-shifting a signed integer if it changes the sign.  GCC started performing optimizations based on these a decade ago, but those optimizations don't usually apply in any particular situation, so usually you just get away with it.

But on my system, with clang-802.0.42, Mario 64 actually fails to boot in the interpreter without this patch: it fails the ROM checksum test performed early on (at 0x800001AC).  (Not sure exactly which operation was responsible; I compiled with -fsanitize=undefined, fixed everything that made it crash under that and some nearby code, and now Mario 64 works.  However, all of the changes here should be correct/necessary.)