### PR TITLE
Fix M64P_GL_SWAP_CONTROL with SDL>=1.3 and no video extension

### DIFF
--- a/src/api/vidext.c
+++ b/src/api/vidext.c
@@ -395,9 +395,7 @@ static const GLAttrMapNode GLAttrMap[] = {
         { M64P_GL_GREEN_SIZE,   SDL_GL_GREEN_SIZE },
         { M64P_GL_BLUE_SIZE,    SDL_GL_BLUE_SIZE },
         { M64P_GL_ALPHA_SIZE,   SDL_GL_ALPHA_SIZE },
-#if SDL_VERSION_ATLEAST(1,3,0)
-        { M64P_GL_SWAP_CONTROL, SDL_RENDERER_PRESENTVSYNC },
-#else
+#if !SDL_VERSION_ATLEAST(1,3,0)
         { M64P_GL_SWAP_CONTROL, SDL_GL_SWAP_CONTROL },
 #endif
         { M64P_GL_MULTISAMPLEBUFFERS, SDL_GL_MULTISAMPLEBUFFERS },
@@ -420,6 +418,15 @@ EXPORT m64p_error CALL VidExt_GL_SetAttribute(m64p_GLattr Attr, int Value)
 
     if (!SDL_WasInit(SDL_INIT_VIDEO))
         return M64ERR_NOT_INIT;
+
+#if SDL_VERSION_ATLEAST(1,3,0)
+    if (Attr == M64P_GL_SWAP_CONTROL)
+    {
+        if (SDL_GL_SetSwapInterval(Value) != 0)
+            return M64ERR_SYSTEM_FAIL;
+        return M64ERR_SUCCESS;
+    }
+#endif
 
     /* translate the GL context type mask if necessary */
 #if SDL_VERSION_ATLEAST(2,0,0)
@@ -468,6 +475,14 @@ EXPORT m64p_error CALL VidExt_GL_GetAttribute(m64p_GLattr Attr, int *pValue)
 
     if (!SDL_WasInit(SDL_INIT_VIDEO))
         return M64ERR_NOT_INIT;
+
+#if SDL_VERSION_ATLEAST(1,3,0)
+    if (Attr == M64P_GL_SWAP_CONTROL)
+    {
+        *pValue = SDL_GL_GetSwapInterval();
+        return M64ERR_SUCCESS;
+    }
+#endif
 
     for (i = 0; i < mapSize; i++)
     {


### PR DESCRIPTION
It originally mapped to SDL_GL_SWAP_CONTROL, which was removed in SDL 1.3; whoever wrote this decided to replace it with SDL_RENDERER_PRESENTVSYNC.  However, SDL_RENDERER_PRESENTVSYNC is not a GL attribute: it's a setting used when creating a 2D renderer, which this code doesn't use at all.  If passed to SDL_GL_(Get|Set)Attribute, it'll be interpreted as the SDL_GLattr value which happens to have the same numeric value, 4, namely SDL_GL_BUFFER_SIZE.

This changes the code to use the functions SDL_GL_(Get|Set)SwapInterval instead.