### PR TITLE
CountPerScanline=1600 for Twisted Edge

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -6637,6 +6637,7 @@ CRC=519EA4E1 EB7584E8
 Players=4
 SaveType=Controller Pack
 FixedAudioPos=1
+CountPerScanline=1600
 
 [CE9AE0AA6DBBF965B1F72BC3AA6A7CEF]
 GoodName=King Hill 64 - Extreme Snowboarding (J) [b1]
@@ -14741,6 +14742,7 @@ SaveType=Controller Pack
 Players=2
 Rumble=Yes
 FixedAudioPos=1
+CountPerScanline=1600
 
 [4F0E2AF205BEEB49270154810660FF37]
 GoodName=Twisted Edge Extreme Snowboarding (E) [b1]
@@ -14759,6 +14761,7 @@ Players=2
 Rumble=Yes
 SaveType=Controller Pack
 FixedAudioPos=1
+CountPerScanline=1600
 
 [0B0DF8EC747BF99F3A55A3300CE8BC0D]
 GoodName=U64 (Chrome) Demo by Horizon64 (PD) [a1]


### PR DESCRIPTION
Every now and then with Twisted Edge Snowboarding, you get an ear full of static instead of proper audio. Setting CountPerScanline=1600 makes it far less likely (it still happens on rare occasion).