### PR TITLE
Avoid usage of global variable g_delay_si.

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -52,6 +52,7 @@ void init_device(struct device* dev,
     struct gb_cart* gb_carts,
     uint16_t eeprom_id, struct storage_backend* eeprom_storage,
     struct clock_backend* clock,
+    unsigned int delay_si,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline, unsigned int alternate_timing)
 {
@@ -85,7 +86,8 @@ void init_device(struct device* dev,
         eeprom_id, eeprom_storage,
         clock,
         rom + 0x40,
-        &dev->r4300, &dev->ri);
+        &dev->r4300, &dev->ri,
+        delay_si);
     init_vi(&dev->vi, vi_clock, expected_refresh_rate, count_per_scanline, alternate_timing, &dev->r4300);
 }
 

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -77,6 +77,7 @@ void init_device(struct device* dev,
     struct gb_cart* gb_carts,
     uint16_t eeprom_id, struct storage_backend* eeprom_storage,
     struct clock_backend* clock,
+    unsigned int delay_si,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline, unsigned int alternate_timing);
 

--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -28,7 +28,7 @@
 #include "device/memory/memory.h"
 #include "device/r4300/r4300_core.h"
 #include "device/ri/ri_controller.h"
-#include "main/main.h"
+#include "main/main.h" /* required for main_check_inputs */
 
 enum
 {
@@ -55,7 +55,7 @@ static void dma_si_write(struct si_controller* si)
     update_pif_write(si);
     cp0_update_count(si->r4300);
 
-    if (g_delay_si) {
+    if (si->delay_si) {
         add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
     } else {
         si->regs[SI_STATUS_REG] |= SI_STATUS_INTERRUPT;
@@ -82,7 +82,7 @@ static void dma_si_read(struct si_controller* si)
 
     cp0_update_count(si->r4300);
 
-    if (g_delay_si) {
+    if (si->delay_si) {
         add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
     } else {
         si->regs[SI_STATUS_REG] |= SI_STATUS_INTERRUPT;
@@ -101,10 +101,12 @@ void init_si(struct si_controller* si,
              struct clock_backend* clock,
              const uint8_t* ipl3,
              struct r4300_core* r4300,
-             struct ri_controller* ri)
+             struct ri_controller* ri,
+             unsigned int delay_si)
 {
     si->r4300 = r4300;
     si->ri = ri;
+    si->delay_si = delay_si;
 
     init_pif(&si->pif,
         cins,

--- a/src/device/si/si_controller.h
+++ b/src/device/si/si_controller.h
@@ -52,6 +52,8 @@ struct si_controller
 
     struct r4300_core* r4300;
     struct ri_controller* ri;
+
+    unsigned int delay_si;
 };
 
 static uint32_t si_reg(uint32_t address)
@@ -70,7 +72,8 @@ void init_si(struct si_controller* si,
              struct clock_backend* clock,
              const uint8_t* ipl3,
              struct r4300_core* r4300,
-             struct ri_controller* ri);
+             struct ri_controller* ri,
+             unsigned int delay_si);
 
 void poweron_si(struct si_controller* si);
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -117,8 +117,6 @@ char* g_gb_rom_files[GAME_CONTROLLERS_COUNT] = {
 #endif
 };
 
-int g_delay_si = 0;
-
 int g_gs_vi_counter = 0;
 
 /** static (local) variables **/
@@ -943,6 +941,7 @@ static void init_gb_ram(void* opaque, struct storage_backend* storage)
 m64p_error main_run(void)
 {
     size_t i;
+    unsigned int delay_si;
     unsigned int count_per_op;
     unsigned int emumode;
     int alternate_vi_timing, count_per_scanline;
@@ -974,7 +973,7 @@ m64p_error main_run(void)
 #ifdef NEW_DYNAREC
     stop_after_jal = ConfigGetParamBool(g_CoreConfig, "DisableSpecRecomp");
 #endif
-    g_delay_si = ConfigGetParamBool(g_CoreConfig, "DelaySI");
+    delay_si = ConfigGetParamBool(g_CoreConfig, "DelaySI");
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
     alternate_vi_timing = ConfigGetParamInt(g_CoreConfig, "ViTiming");
     count_per_scanline  = ConfigGetParamInt(g_CoreConfig, "CountPerScanline");
@@ -1065,6 +1064,7 @@ m64p_error main_run(void)
                 gb_carts,
                 (ROM_SETTINGS.savetype != EEPROM_16KB) ? 0x8000 : 0xc000, &eep_storage,
                 &clock,
+                delay_si,
                 vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype), count_per_scanline, alternate_vi_timing);
 
     // Attach rom to plugins

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -48,8 +48,6 @@ extern char* g_gb_rom_files[GAME_CONTROLLERS_COUNT];
 
 extern m64p_frame_callback g_FrameCallback;
 
-extern int g_delay_si;
-
 extern int g_gs_vi_counter;
 
 const char* get_savestatepath(void);


### PR DESCRIPTION
One less global variable used inside the emulation core.