### PR TITLE
Be more selective on which interrupts we can load or save states

### DIFF
--- a/src/device/r4300/mi_controller.c
+++ b/src/device/r4300/mi_controller.c
@@ -103,7 +103,9 @@ int write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 
         check_interrupt(r4300);
         cp0_update_count(r4300);
+        r4300->cp0.interrupt_unsafe_state = 1;
         if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt(r4300);
+        r4300->cp0.interrupt_unsafe_state = 0;
         break;
     }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1047,7 +1047,9 @@ DECLARE_INSTRUCTION(ERET)
     r4300->llbit = 0;
     check_interrupt(r4300);
     r4300->cp0.last_addr = PCADDR;
+    r4300->cp0.interrupt_unsafe_state = 1;
     if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
+    r4300->cp0.interrupt_unsafe_state = 0;
 }
 
 DECLARE_INSTRUCTION(SYNC)


### PR DESCRIPTION
This seems to fix the issue encountered in https://github.com/mupen64plus/mupen64plus-core/issues/294.

I have no idea if this is the correct fix or what kind of side effects it could have, but after making this change, I'm unable to reproduce the above issue.