### PR TITLE
Trust plugins to trigger SP interrupts

### DIFF
--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -148,11 +148,6 @@ void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count)
 
     if (get_event(&cp0->q, type)) {
         DebugMessage(M64MSG_WARNING, "two events of type 0x%x in interrupt queue", type);
-        /* FIXME: hack-fix for freezing in Perfect Dark
-         * http://code.google.com/p/mupen64plus/issues/detail?id=553
-         * https://github.com/mupen64plus-ae/mupen64plus-ae/commit/802d8f81d46705d64694d7a34010dc5f35787c7d
-         */
-        return;
     }
 
     event = alloc_node(&cp0->q.pool);

--- a/src/device/rdp/rdp_core.c
+++ b/src/device/rdp/rdp_core.c
@@ -143,10 +143,6 @@ void rdp_interrupt_event(void* opaque)
 {
     struct rdp_core* dp = (struct rdp_core*)opaque;
 
-    dp->dpc_regs[DPC_STATUS_REG] &= ~DPC_STATUS_FREEZE;
-    dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_XBUS_DMEM_DMA
-        | DPC_STATUS_CBUF_READY;
-
     raise_rcp_interrupt(dp->r4300, MI_INTR_DP);
 }
 


### PR DESCRIPTION
This is based on work by @bsmiles32 in https://github.com/bsmiles32/mupen64plus-core/commit/a1b6df0800dd86936b8500cb7b731b10ee8d79ac, brought on by debugging https://github.com/mupen64plus/mupen64plus-core/issues/181

I've tested this ever so briefly on a few games like Super Mario 64 and World Driver Champ. I'm just posting this here to get some feedback and perhaps some testing.

I've also posed a few questions in comments in the code that I was a little unclear on, I'd appreciate if anyone has some insight on those lines.