### PR TITLE
Fix reading CP0_RANDOM_REG

### DIFF
--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1354,15 +1354,15 @@ DECLARE_INSTRUCTION(MFC0)
     switch(rfs)
     {
     case CP0_RANDOM_REG:
-        DebugMessage(M64MSG_ERROR, "MFC0 instruction reading un-implemented Random register");
-        *r4300_stop(r4300)=1;
+        cp0_update_count(r4300);
+        cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/2 % (32 - cp0_regs[CP0_WIRED_REG]))
+            + cp0_regs[CP0_WIRED_REG];
         break;
     case CP0_COUNT_REG:
         cp0_update_count(r4300);
-        /* fall through */
-    default:
-        rrt = SE32(cp0_regs[rfs]);
+        break;
     }
+    rrt = SE32(cp0_regs[rfs]);
     ADD_TO_PC(1);
 }
 


### PR DESCRIPTION
From the r4300i datasheet:
>  This register will decrement on every instruction executed. The values range between a low value determined by the TLB Wired register, and an upper bound of TLBENTRIES-1. The TLB Random register is used to specify the entry in the TLB affected by the TLBWR instruction

Right now, CP0_RANDOM_REG is only updated before a TLB Write (https://github.com/loganmc10/mupen64plus-core/blob/b3b5d5cae1ba97013a54ad8b9410a725b67449aa/src/device/r4300/mips_instructions.def#L1332-L1334) because that is the only time it is really useful.

However, the value can also be read from, so this change updates the value of CP0_RANDOM_REG before it is read.

Fixes https://github.com/mupen64plus/mupen64plus-core/issues/309