### PR TITLE
Remove memd

### DIFF
--- a/src/device/ai/ai_controller.c
+++ b/src/device/ai/ai_controller.c
@@ -164,7 +164,7 @@ void poweron_ai(struct ai_controller* ai)
     ai->delayed_carry = 0;
 }
 
-int read_ai_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_ai_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct ai_controller* ai = (struct ai_controller*)opaque;
     uint32_t reg = ai_reg(address);
@@ -184,11 +184,9 @@ int read_ai_regs(void* opaque, uint32_t address, uint32_t* value)
     {
         *value = ai->regs[reg];
     }
-
-    return 0;
 }
 
-int write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct ai_controller* ai = (struct ai_controller*)opaque;
     uint32_t reg = ai_reg(address);
@@ -198,11 +196,11 @@ int write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     case AI_LEN_REG:
         masked_write(&ai->regs[AI_LEN_REG], value, mask);
         fifo_push(ai);
-        return 0;
+        return;
 
     case AI_STATUS_REG:
         clear_rcp_interrupt(ai->r4300, MI_INTR_AI);
-        return 0;
+        return;
 
     case AI_BITRATE_REG:
     case AI_DACRATE_REG:
@@ -211,12 +209,10 @@ int write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
             ai->samples_format_changed = 1;
 
         masked_write(&ai->regs[reg], value, mask);
-        return 0;
+        return;
     }
 
     masked_write(&ai->regs[reg], value, mask);
-
-    return 0;
 }
 
 void ai_end_of_dma_event(void* opaque)

--- a/src/device/ai/ai_controller.h
+++ b/src/device/ai/ai_controller.h
@@ -77,8 +77,8 @@ void init_ai(struct ai_controller* ai,
 
 void poweron_ai(struct ai_controller* ai);
 
-int read_ai_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_ai_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void ai_end_of_dma_event(void* opaque);
 

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -45,22 +45,20 @@
 #include <stddef.h>
 #include <stdint.h>
 
-typedef int (*readfn)(void*,uint32_t,uint32_t*);
-typedef int (*writefn)(void*,uint32_t,uint32_t,uint32_t);
+typedef void (*readfn)(void*,uint32_t,uint32_t*);
+typedef void (*writefn)(void*,uint32_t,uint32_t,uint32_t);
 
 
-static int readw(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
+static void readw(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
 {
     uint32_t w;
-    int result = read_word(opaque, (address & ~0x3), &w);
+    read_word(opaque, (address & ~0x3), &w);
     *value = w;
-
-    return result;
 }
 
-static int writew(writefn write_word, void* opaque, uint32_t address, uint32_t value, uint32_t wmask)
+static void writew(writefn write_word, void* opaque, uint32_t address, uint32_t value, uint32_t wmask)
 {
-    return write_word(opaque, (address & ~0x3), value, wmask);
+    write_word(opaque, (address & ~0x3), value, wmask);
 }
 
 
@@ -293,7 +291,7 @@ static void writemem_with_bp_checks(void)
     check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 4,
             M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE);
 
-    return g_dev.mem.saved_writemem[*r4300_address(&g_dev.r4300)>>16]();
+    g_dev.mem.saved_writemem[*r4300_address(&g_dev.r4300)>>16]();
 }
 
 void activate_memory_break_read(struct memory* mem, uint32_t address)

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -58,30 +58,11 @@ static int readw(readfn read_word, void* opaque, uint32_t address, uint64_t* val
     return result;
 }
 
-static int readd(readfn read_word, void* opaque, uint32_t address, uint64_t* value)
-{
-    uint32_t w[2];
-    int result =
-    read_word(opaque, address    , &w[0]);
-    read_word(opaque, address + 4, &w[1]);
-    *value = ((uint64_t)w[0] << 32) | w[1];
-
-    return result;
-}
-
 static int writew(writefn write_word, void* opaque, uint32_t address, uint32_t value, uint32_t wmask)
 {
     return write_word(opaque, (address & ~0x3), value, wmask);
 }
 
-static int writed(writefn write_word, void* opaque, uint32_t address, uint64_t value)
-{
-    int result =
-    write_word(opaque, address    , (uint32_t) (value >> 32), ~0U);
-    write_word(opaque, address + 4, (uint32_t) (value      ), ~0U);
-
-    return result;
-}
 
 
 static void read_nothing(void)
@@ -90,17 +71,7 @@ static void read_nothing(void)
     *g_dev.r4300.rdword = (*g_dev.r4300.rdword << 16) | *g_dev.r4300.rdword;
 }
 
-static void read_nothingd(void)
-{
-    *g_dev.r4300.rdword = *r4300_address(&g_dev.r4300) & 0xFFFF;
-    *g_dev.r4300.rdword = (*g_dev.r4300.rdword << 16) | *g_dev.r4300.rdword;
-}
-
 static void write_nothing(void)
-{
-}
-
-static void write_nothingd(void)
 {
 }
 
@@ -113,15 +84,6 @@ static void read_nomem(void)
     read_word_in_memory();
 }
 
-static void read_nomemd(void)
-{
-    struct r4300_core* r4300 = &g_dev.r4300;
-
-    *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),0);
-    if (*r4300_address(r4300) == 0x00000000) return;
-    read_dword_in_memory();
-}
-
 static void write_nomem(void)
 {
     struct r4300_core* r4300 = &g_dev.r4300;
@@ -132,35 +94,14 @@ static void write_nomem(void)
     write_word_in_memory();
 }
 
-static void write_nomemd(void)
-{
-    struct r4300_core* r4300 = &g_dev.r4300;
-
-    invalidate_r4300_cached_code(r4300, *r4300_address(r4300), 8);
-    *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),1);
-    if (*r4300_address(r4300) == 0x00000000) return;
-    write_dword_in_memory();
-}
-
-
 void read_rdram(void)
 {
     readw(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-void read_rdramd(void)
-{
-    readd(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 void write_rdram(void)
 {
     writew(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-void write_rdramd(void)
-{
-    writed(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -169,19 +110,9 @@ void read_rdramFB(void)
     readw(read_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-void read_rdramFBd(void)
-{
-    readd(read_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 void write_rdramFB(void)
 {
     writew(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-void write_rdramFBd(void)
-{
-    writed(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -190,19 +121,9 @@ static void read_rdramreg(void)
     readw(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rdramregd(void)
-{
-    readd(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_rdramreg(void)
 {
     writew(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rdramregd(void)
-{
-    writed(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -211,19 +132,9 @@ static void read_rspmem(void)
     readw(read_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rspmemd(void)
-{
-    readd(read_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_rspmem(void)
 {
     writew(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rspmemd(void)
-{
-    writed(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -232,19 +143,9 @@ static void read_rspreg(void)
     readw(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rspregd(void)
-{
-    readd(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_rspreg(void)
 {
     writew(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rspregd(void)
-{
-    writed(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -253,19 +154,9 @@ static void read_rspreg2(void)
     readw(read_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rspreg2d(void)
-{
-    readd(read_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_rspreg2(void)
 {
     writew(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rspreg2d(void)
-{
-    writed(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -274,19 +165,9 @@ static void read_dp(void)
     readw(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_dpd(void)
-{
-    readd(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_dp(void)
 {
     writew(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_dpd(void)
-{
-    writed(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -295,19 +176,9 @@ static void read_dps(void)
     readw(read_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_dpsd(void)
-{
-    readd(read_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_dps(void)
 {
     writew(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_dpsd(void)
-{
-    writed(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -316,19 +187,9 @@ static void read_mi(void)
     readw(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_mid(void)
-{
-    readd(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 void write_mi(void)
 {
     writew(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-void write_mid(void)
-{
-    writed(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -337,19 +198,9 @@ static void read_vi(void)
     readw(read_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_vid(void)
-{
-    readd(read_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_vi(void)
 {
     writew(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_vid(void)
-{
-    writed(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -358,19 +209,9 @@ static void read_ai(void)
     readw(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_aid(void)
-{
-    readd(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_ai(void)
 {
     writew(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_aid(void)
-{
-    writed(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -379,19 +220,9 @@ static void read_pi(void)
     readw(read_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_pid(void)
-{
-    readd(read_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_pi(void)
 {
     writew(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_pid(void)
-{
-    writed(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -400,19 +231,9 @@ static void read_ri(void)
     readw(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_rid(void)
-{
-    readd(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_ri(void)
 {
     writew(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_rid(void)
-{
-    writed(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
@@ -421,19 +242,9 @@ static void read_si(void)
     readw(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_sid(void)
-{
-    readd(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_si(void)
 {
     writew(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_sid(void)
-{
-    writed(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 static void read_pi_flashram_status(void)
@@ -441,30 +252,15 @@ static void read_pi_flashram_status(void)
     readw(read_flashram_status, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_pi_flashram_statusd(void)
-{
-    readd(read_flashram_status, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_pi_flashram_command(void)
 {
     writew(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_pi_flashram_commandd(void)
-{
-    writed(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 
 static void read_rom(void)
 {
     readw(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
-static void read_romd(void)
-{
-    readd(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_rom(void)
@@ -478,19 +274,9 @@ static void read_pif(void)
     readw(read_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
-static void read_pifd(void)
-{
-    readd(read_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
-}
-
 static void write_pif(void)
 {
     writew(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
-}
-
-static void write_pifd(void)
-{
-    writed(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wdword(&g_dev.r4300));
 }
 
 #ifdef DBG
@@ -502,28 +288,12 @@ static void readmem_with_bp_checks(void)
     g_dev.mem.saved_readmem[*r4300_address(&g_dev.r4300)>>16]();
 }
 
-static void readmemd_with_bp_checks(void)
-{
-    check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 8,
-            M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ);
-
-    g_dev.mem.saved_readmemd[*r4300_address(&g_dev.r4300)>>16]();
-}
-
 static void writemem_with_bp_checks(void)
 {
     check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 4,
             M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE);
 
     return g_dev.mem.saved_writemem[*r4300_address(&g_dev.r4300)>>16]();
-}
-
-static void writememd_with_bp_checks(void)
-{
-    check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 8,
-            M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE);
-
-    return g_dev.mem.saved_writememd[*r4300_address(&g_dev.r4300)>>16]();
 }
 
 void activate_memory_break_read(struct memory* mem, uint32_t address)
@@ -533,9 +303,7 @@ void activate_memory_break_read(struct memory* mem, uint32_t address)
     if (mem->saved_readmem[region] == NULL)
     {
         mem->saved_readmem [region] = mem->readmem [region];
-        mem->saved_readmemd[region] = mem->readmemd[region];
         mem->readmem [region] = readmem_with_bp_checks;
-        mem->readmemd[region] = readmemd_with_bp_checks;
     }
 }
 
@@ -546,9 +314,7 @@ void deactivate_memory_break_read(struct memory* mem, uint32_t address)
     if (mem->saved_readmem[region] != NULL)
     {
         mem->readmem [region] = mem->saved_readmem [region];
-        mem->readmemd[region] = mem->saved_readmemd[region];
         mem->saved_readmem [region] = NULL;
-        mem->saved_readmemd[region] = NULL;
     }
 }
 
@@ -559,9 +325,7 @@ void activate_memory_break_write(struct memory* mem, uint32_t address)
     if (mem->saved_writemem[region] == NULL)
     {
         mem->saved_writemem [region] = mem->writemem [region];
-        mem->saved_writememd[region] = mem->writememd[region];
         mem->writemem [region] = writemem_with_bp_checks;
-        mem->writememd[region] = writememd_with_bp_checks;
     }
 }
 
@@ -572,9 +336,7 @@ void deactivate_memory_break_write(struct memory* mem, uint32_t address)
     if (mem->saved_writemem[region] != NULL)
     {
         mem->writemem [region] = mem->saved_writemem [region];
-        mem->writememd[region] = mem->saved_writememd[region];
         mem->saved_writemem [region] = NULL;
-        mem->saved_writememd[region] = NULL;
     }
 }
 
@@ -584,8 +346,8 @@ int get_memory_type(struct memory* mem, uint32_t address)
 }
 #endif
 
-#define R(x) read_ ## x, read_ ## x ## d
-#define W(x) write_ ## x, write_ ## x ## d
+#define R(x) read_ ## x
+#define W(x) write_ ## x
 #define RW(x) R(x), W(x)
 
 void poweron_memory(struct memory* mem)
@@ -744,8 +506,7 @@ void poweron_memory(struct memory* mem)
     for(i = 0; i < (g_dev.pi.cart_rom.rom_size >> 16); ++i)
     {
         map_region(mem, 0x9000+i, M64P_MEM_ROM, R(rom), W(nothing));
-        map_region(mem, 0xb000+i, M64P_MEM_ROM, R(rom),
-                   write_rom, write_nothingd);
+        map_region(mem, 0xb000+i, M64P_MEM_ROM, R(rom), W(rom));
     }
     for(i = (g_dev.pi.cart_rom.rom_size >> 16); i < 0xfc0; ++i)
     {
@@ -775,45 +536,37 @@ static void map_region_t(struct memory* mem, uint16_t region, int type)
 
 static void map_region_r(struct memory* mem,
         uint16_t region,
-        void (*read32)(void),
-        void (*read64)(void))
+        void (*read32)(void))
 {
 #ifdef DBG
     if (lookup_breakpoint(((uint32_t)region << 16), 0x10000,
                           M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ) != -1)
     {
         mem->saved_readmem [region] = read32;
-        mem->saved_readmemd[region] = read64;
         mem->readmem [region] = readmem_with_bp_checks;
-        mem->readmemd[region] = readmemd_with_bp_checks;
     }
     else
 #endif
     {
         mem->readmem [region] = read32;
-        mem->readmemd[region] = read64;
     }
 }
 
 static void map_region_w(struct memory* mem,
         uint16_t region,
-        void (*write32)(void),
-        void (*write64)(void))
+        void (*write32)(void))
 {
 #ifdef DBG
     if (lookup_breakpoint(((uint32_t)region << 16), 0x10000,
                           M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE) != -1)
     {
         mem->saved_writemem [region] = write32;
-        mem->saved_writememd[region] = write64;
         mem->writemem [region] = writemem_with_bp_checks;
-        mem->writememd[region] = writememd_with_bp_checks;
     }
     else
 #endif
     {
         mem->writemem [region] = write32;
-        mem->writememd[region] = write64;
     }
 }
 
@@ -821,13 +574,11 @@ void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
                 void (*read32)(void),
-                void (*read64)(void),
-                void (*write32)(void),
-                void (*write64)(void))
+                void (*write32)(void))
 {
     map_region_t(mem, region, type);
-    map_region_r(mem, region, read32, read64);
-    map_region_w(mem, region, write32, write64);
+    map_region_r(mem, region, read32);
+    map_region_w(mem, region, write32);
 }
 
 uint32_t *fast_mem_access(uint32_t address)

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -79,21 +79,12 @@ static void write_nothing(void)
 
 static void read_nomem(void)
 {
-    struct r4300_core* r4300 = (struct r4300_core*)get_opaque();
-
-    *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300), 0);
-    if (*r4300_address(r4300) == 0x00000000) return;
-    read_word_in_memory();
+    readw(read_tlb_mem, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_nomem(void)
 {
-    struct r4300_core* r4300 = (struct r4300_core*)get_opaque();
-
-    invalidate_r4300_cached_code(r4300, *r4300_address(r4300), 4);
-    *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),1);
-    if (*r4300_address(r4300) == 0x00000000) return;
-    write_word_in_memory();
+    writew(write_tlb_mem, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 void read_rdram(void)

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -61,7 +61,11 @@ static void writew(writefn write_word, void* opaque, uint32_t address, uint32_t 
     write_word(opaque, (address & ~0x3), value, wmask);
 }
 
-
+/* XXX: temporary helper function */
+static void* get_opaque(void)
+{
+    return g_dev.mem.opaque[*r4300_address(&g_dev.r4300) >> 16];
+}
 
 static void read_nothing(void)
 {
@@ -75,7 +79,7 @@ static void write_nothing(void)
 
 static void read_nomem(void)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
+    struct r4300_core* r4300 = (struct r4300_core*)get_opaque();
 
     *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300), 0);
     if (*r4300_address(r4300) == 0x00000000) return;
@@ -84,7 +88,7 @@ static void read_nomem(void)
 
 static void write_nomem(void)
 {
-    struct r4300_core* r4300 = &g_dev.r4300;
+    struct r4300_core* r4300 = (struct r4300_core*)get_opaque();
 
     invalidate_r4300_cached_code(r4300, *r4300_address(r4300), 4);
     *r4300_address(r4300) = virtual_to_physical_address(r4300, *r4300_address(r4300),1);
@@ -94,204 +98,218 @@ static void write_nomem(void)
 
 void read_rdram(void)
 {
-    readw(read_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_rdram_dram, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 void write_rdram(void)
 {
-    writew(write_rdram_dram, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_rdram_dram, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 void read_rdramFB(void)
 {
-    readw(read_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_rdram_fb, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 void write_rdramFB(void)
 {
-    writew(write_rdram_fb, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_rdram_fb, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_rdramreg(void)
 {
-    readw(read_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_rdram_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_rdramreg(void)
 {
-    writew(write_rdram_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_rdram_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_rspmem(void)
 {
-    readw(read_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_rsp_mem, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_rspmem(void)
 {
-    writew(write_rsp_mem, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_rsp_mem, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_rspreg(void)
 {
-    readw(read_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_rsp_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_rspreg(void)
 {
-    writew(write_rsp_regs, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_rsp_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_rspreg2(void)
 {
-    readw(read_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_rsp_regs2, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_rspreg2(void)
 {
-    writew(write_rsp_regs2, &g_dev.sp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_rsp_regs2, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_dp(void)
 {
-    readw(read_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_dpc_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_dp(void)
 {
-    writew(write_dpc_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_dpc_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_dps(void)
 {
-    readw(read_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_dps_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_dps(void)
 {
-    writew(write_dps_regs, &g_dev.dp, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_dps_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_mi(void)
 {
-    readw(read_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_mi_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 void write_mi(void)
 {
-    writew(write_mi_regs, &g_dev.r4300, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_mi_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_vi(void)
 {
-    readw(read_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_vi_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_vi(void)
 {
-    writew(write_vi_regs, &g_dev.vi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_vi_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_ai(void)
 {
-    readw(read_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_ai_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_ai(void)
 {
-    writew(write_ai_regs, &g_dev.ai, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_ai_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_pi(void)
 {
-    readw(read_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_pi_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_pi(void)
 {
-    writew(write_pi_regs, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_pi_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_ri(void)
 {
-    readw(read_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_ri_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_ri(void)
 {
-    writew(write_ri_regs, &g_dev.ri, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_ri_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_si(void)
 {
-    readw(read_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_si_regs, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_si(void)
 {
-    writew(write_si_regs, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_si_regs, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 static void read_pi_flashram_status(void)
 {
-    readw(read_flashram_status, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_flashram_status, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+}
+
+static void write_pi_flashram_status(void)
+{
+    writew(write_flashram_status, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+}
+
+static void read_pi_flashram_command(void)
+{
+    readw(read_flashram_command, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_pi_flashram_command(void)
 {
-    writew(write_flashram_command, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_flashram_command, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_rom(void)
 {
-    readw(read_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_cart_rom, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_rom(void)
 {
-    writew(write_cart_rom, &g_dev.pi, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_cart_rom, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 
 static void read_pif(void)
 {
-    readw(read_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
+    readw(read_pif_ram, get_opaque(), *r4300_address(&g_dev.r4300), g_dev.r4300.rdword);
 }
 
 static void write_pif(void)
 {
-    writew(write_pif_ram, &g_dev.si, *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
+    writew(write_pif_ram, get_opaque(), *r4300_address(&g_dev.r4300), *r4300_wword(&g_dev.r4300), *r4300_wmask(&g_dev.r4300));
 }
 
 #ifdef DBG
 static void readmem_with_bp_checks(void)
 {
-    check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 4,
+    struct r4300_core* r4300 = (struct r4300_core*)get_opaque();
+
+    check_breakpoints_on_mem_access(*r4300_pc(r4300)-0x4, *r4300_address(r4300), 4,
             M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_READ);
 
-    g_dev.mem.saved_readmem[*r4300_address(&g_dev.r4300)>>16]();
+    r4300->mem->saved_readmem[*r4300_address(r4300)>>16]();
 }
 
 static void writemem_with_bp_checks(void)
 {
-    check_breakpoints_on_mem_access(*r4300_pc(&g_dev.r4300)-0x4, *r4300_address(&g_dev.r4300), 4,
+    struct r4300_core* r4300 = (struct r4300_core*)get_opaque();
+
+    check_breakpoints_on_mem_access(*r4300_pc(r4300)-0x4, *r4300_address(r4300), 4,
             M64P_BKP_FLAG_ENABLED | M64P_BKP_FLAG_WRITE);
 
-    g_dev.mem.saved_writemem[*r4300_address(&g_dev.r4300)>>16]();
+    r4300->mem->saved_writemem[*r4300_address(r4300)>>16]();
 }
 
 void activate_memory_break_read(struct memory* mem, uint32_t address)
@@ -300,8 +318,14 @@ void activate_memory_break_read(struct memory* mem, uint32_t address)
 
     if (mem->saved_readmem[region] == NULL)
     {
-        mem->saved_readmem [region] = mem->readmem [region];
-        mem->readmem [region] = readmem_with_bp_checks;
+        /* only change opaque value if memory_break_write is not active */
+        if (mem->saved_writemem[region] == NULL) {
+            mem->saved_opaque[region] = mem->opaque[region];
+            mem->opaque[region] = &g_dev.r4300;
+        }
+
+        mem->saved_readmem[region] = mem->readmem[region];
+        mem->readmem[region] = readmem_with_bp_checks;
     }
 }
 
@@ -311,8 +335,14 @@ void deactivate_memory_break_read(struct memory* mem, uint32_t address)
 
     if (mem->saved_readmem[region] != NULL)
     {
-        mem->readmem [region] = mem->saved_readmem [region];
-        mem->saved_readmem [region] = NULL;
+        /* only restore opaque value if memory_break_write is not active */
+        if (mem->saved_writemem[region] == NULL) {
+            mem->opaque[region] = mem->saved_opaque[region];
+            mem->saved_opaque[region] = NULL;
+        }
+
+        mem->readmem[region] = mem->saved_readmem[region];
+        mem->saved_readmem[region] = NULL;
     }
 }
 
@@ -322,8 +352,14 @@ void activate_memory_break_write(struct memory* mem, uint32_t address)
 
     if (mem->saved_writemem[region] == NULL)
     {
-        mem->saved_writemem [region] = mem->writemem [region];
-        mem->writemem [region] = writemem_with_bp_checks;
+        /* only change opaque value if memory_break_read is not active */
+        if (mem->saved_readmem[region] == NULL) {
+            mem->saved_opaque[region] = mem->opaque[region];
+            mem->opaque[region] = &g_dev.r4300;
+        }
+
+        mem->saved_writemem[region] = mem->writemem[region];
+        mem->writemem[region] = writemem_with_bp_checks;
     }
 }
 
@@ -333,8 +369,14 @@ void deactivate_memory_break_write(struct memory* mem, uint32_t address)
 
     if (mem->saved_writemem[region] != NULL)
     {
-        mem->writemem [region] = mem->saved_writemem [region];
-        mem->saved_writemem [region] = NULL;
+        /* only restore opaque value if memory_break_read is not active */
+        if (mem->saved_readmem[region] == NULL) {
+            mem->opaque[region] = mem->saved_opaque[region];
+            mem->saved_opaque[region] = NULL;
+        }
+
+        mem->writemem[region] = mem->saved_writemem[region];
+        mem->saved_writemem[region] = NULL;
     }
 }
 
@@ -353,6 +395,7 @@ void poweron_memory(struct memory* mem)
     int i;
 
 #ifdef DBG
+    memset(mem->saved_opaque, 0, 0x10000*sizeof(mem->saved_opaque[0]));
     memset(mem->saved_readmem, 0, 0x10000*sizeof(mem->saved_readmem[0]));
     memset(mem->saved_writemem, 0, 0x10000*sizeof(mem->saved_writemem[0]));
 #endif
@@ -360,165 +403,165 @@ void poweron_memory(struct memory* mem)
     /* clear mappings */
     for(i = 0; i < 0x10000; ++i)
     {
-        map_region(mem, i, M64P_MEM_NOMEM, RW(nomem));
+        map_region(mem, i, M64P_MEM_NOMEM, &g_dev.r4300, RW(nomem));
     }
 
     /* map RDRAM */
     for(i = 0; i < /*0x40*/0x80; ++i)
     {
-        map_region(mem, 0x8000+i, M64P_MEM_RDRAM, RW(rdram));
-        map_region(mem, 0xa000+i, M64P_MEM_RDRAM, RW(rdram));
+        map_region(mem, 0x8000+i, M64P_MEM_RDRAM, &g_dev.ri, RW(rdram));
+        map_region(mem, 0xa000+i, M64P_MEM_RDRAM, &g_dev.ri, RW(rdram));
     }
     for(i = /*0x40*/0x80; i < 0x3f0; ++i)
     {
-        map_region(mem, 0x8000+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa000+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map RDRAM registers */
-    map_region(mem, 0x83f0, M64P_MEM_RDRAMREG, RW(rdramreg));
-    map_region(mem, 0xa3f0, M64P_MEM_RDRAMREG, RW(rdramreg));
+    map_region(mem, 0x83f0, M64P_MEM_RDRAMREG, &g_dev.ri, RW(rdramreg));
+    map_region(mem, 0xa3f0, M64P_MEM_RDRAMREG, &g_dev.ri, RW(rdramreg));
     for(i = 1; i < 0x10; ++i)
     {
-        map_region(mem, 0x83f0+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa3f0+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x83f0+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa3f0+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map RSP memory */
-    map_region(mem, 0x8400, M64P_MEM_RSPMEM, RW(rspmem));
-    map_region(mem, 0xa400, M64P_MEM_RSPMEM, RW(rspmem));
+    map_region(mem, 0x8400, M64P_MEM_RSPMEM, &g_dev.sp, RW(rspmem));
+    map_region(mem, 0xa400, M64P_MEM_RSPMEM, &g_dev.sp, RW(rspmem));
     for(i = 1; i < 0x4; ++i)
     {
-        map_region(mem, 0x8400+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa400+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8400+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa400+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map RSP registers (1) */
-    map_region(mem, 0x8404, M64P_MEM_RSPREG, RW(rspreg));
-    map_region(mem, 0xa404, M64P_MEM_RSPREG, RW(rspreg));
+    map_region(mem, 0x8404, M64P_MEM_RSPREG, &g_dev.sp, RW(rspreg));
+    map_region(mem, 0xa404, M64P_MEM_RSPREG, &g_dev.sp, RW(rspreg));
     for(i = 0x5; i < 0x8; ++i)
     {
-        map_region(mem, 0x8400+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa400+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8400+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa400+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map RSP registers (2) */
-    map_region(mem, 0x8408, M64P_MEM_RSP, RW(rspreg2));
-    map_region(mem, 0xa408, M64P_MEM_RSP, RW(rspreg2));
+    map_region(mem, 0x8408, M64P_MEM_RSP, &g_dev.sp, RW(rspreg2));
+    map_region(mem, 0xa408, M64P_MEM_RSP, &g_dev.sp, RW(rspreg2));
     for(i = 0x9; i < 0x10; ++i)
     {
-        map_region(mem, 0x8400+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa400+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8400+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa400+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map DPC registers */
-    map_region(mem, 0x8410, M64P_MEM_DP, RW(dp));
-    map_region(mem, 0xa410, M64P_MEM_DP, RW(dp));
+    map_region(mem, 0x8410, M64P_MEM_DP, &g_dev.dp, RW(dp));
+    map_region(mem, 0xa410, M64P_MEM_DP, &g_dev.dp, RW(dp));
     for(i = 1; i < 0x10; ++i)
     {
-        map_region(mem, 0x8410+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa410+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8410+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa410+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map DPS registers */
-    map_region(mem, 0x8420, M64P_MEM_DPS, RW(dps));
-    map_region(mem, 0xa420, M64P_MEM_DPS, RW(dps));
+    map_region(mem, 0x8420, M64P_MEM_DPS, &g_dev.dp, RW(dps));
+    map_region(mem, 0xa420, M64P_MEM_DPS, &g_dev.dp, RW(dps));
     for(i = 1; i < 0x10; ++i)
     {
-        map_region(mem, 0x8420+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa420+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8420+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa420+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map MI registers */
-    map_region(mem, 0x8430, M64P_MEM_MI, RW(mi));
-    map_region(mem, 0xa430, M64P_MEM_MI, RW(mi));
+    map_region(mem, 0x8430, M64P_MEM_MI, &g_dev.r4300, RW(mi));
+    map_region(mem, 0xa430, M64P_MEM_MI, &g_dev.r4300, RW(mi));
     for(i = 1; i < 0x10; ++i)
     {
-        map_region(mem, 0x8430+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa430+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8430+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa430+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map VI registers */
-    map_region(mem, 0x8440, M64P_MEM_VI, RW(vi));
-    map_region(mem, 0xa440, M64P_MEM_VI, RW(vi));
+    map_region(mem, 0x8440, M64P_MEM_VI, &g_dev.vi, RW(vi));
+    map_region(mem, 0xa440, M64P_MEM_VI, &g_dev.vi, RW(vi));
     for(i = 1; i < 0x10; ++i)
     {
-        map_region(mem, 0x8440+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa440+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8440+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa440+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map AI registers */
-    map_region(mem, 0x8450, M64P_MEM_AI, RW(ai));
-    map_region(mem, 0xa450, M64P_MEM_AI, RW(ai));
+    map_region(mem, 0x8450, M64P_MEM_AI, &g_dev.ai, RW(ai));
+    map_region(mem, 0xa450, M64P_MEM_AI, &g_dev.ai, RW(ai));
     for(i = 1; i < 0x10; ++i)
     {
-        map_region(mem, 0x8450+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa450+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8450+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa450+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map PI registers */
-    map_region(mem, 0x8460, M64P_MEM_PI, RW(pi));
-    map_region(mem, 0xa460, M64P_MEM_PI, RW(pi));
+    map_region(mem, 0x8460, M64P_MEM_PI, &g_dev.pi, RW(pi));
+    map_region(mem, 0xa460, M64P_MEM_PI, &g_dev.pi, RW(pi));
     for(i = 1; i < 0x10; ++i)
     {
-        map_region(mem, 0x8460+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa460+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8460+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa460+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map RI registers */
-    map_region(mem, 0x8470, M64P_MEM_RI, RW(ri));
-    map_region(mem, 0xa470, M64P_MEM_RI, RW(ri));
+    map_region(mem, 0x8470, M64P_MEM_RI, &g_dev.ri, RW(ri));
+    map_region(mem, 0xa470, M64P_MEM_RI, &g_dev.ri, RW(ri));
     for(i = 1; i < 0x10; ++i)
     {
-        map_region(mem, 0x8470+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa470+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8470+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa470+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map SI registers */
-    map_region(mem, 0x8480, M64P_MEM_SI, RW(si));
-    map_region(mem, 0xa480, M64P_MEM_SI, RW(si));
+    map_region(mem, 0x8480, M64P_MEM_SI, &g_dev.si, RW(si));
+    map_region(mem, 0xa480, M64P_MEM_SI, &g_dev.si, RW(si));
     for(i = 0x481; i < 0x500; ++i)
     {
-        map_region(mem, 0x8000+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa000+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     for(i = 0x500; i < 0x800; ++i)
     {
-        map_region(mem, 0x8000+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa000+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map flashram/sram */
-    map_region(mem, 0x8800, M64P_MEM_FLASHRAMSTAT, R(pi_flashram_status), W(nothing));
-    map_region(mem, 0xa800, M64P_MEM_FLASHRAMSTAT, R(pi_flashram_status), W(nothing));
-    map_region(mem, 0x8801, M64P_MEM_NOTHING, R(nothing), W(pi_flashram_command));
-    map_region(mem, 0xa801, M64P_MEM_NOTHING, R(nothing), W(pi_flashram_command));
+    map_region(mem, 0x8800, M64P_MEM_FLASHRAMSTAT, &g_dev.pi, RW(pi_flashram_status));
+    map_region(mem, 0xa800, M64P_MEM_FLASHRAMSTAT, &g_dev.pi, RW(pi_flashram_status));
+    map_region(mem, 0x8801, M64P_MEM_NOTHING, &g_dev.pi, RW(pi_flashram_command));
+    map_region(mem, 0xa801, M64P_MEM_NOTHING, &g_dev.pi, RW(pi_flashram_command));
     for(i = 0x802; i < 0x1000; ++i)
     {
-        map_region(mem, 0x8000+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xa000+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x8000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xa000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map cart ROM */
     for(i = 0; i < (g_dev.pi.cart_rom.rom_size >> 16); ++i)
     {
-        map_region(mem, 0x9000+i, M64P_MEM_ROM, R(rom), W(nothing));
-        map_region(mem, 0xb000+i, M64P_MEM_ROM, R(rom), W(rom));
+        map_region(mem, 0x9000+i, M64P_MEM_ROM, &g_dev.pi, R(rom), W(nothing));
+        map_region(mem, 0xb000+i, M64P_MEM_ROM, &g_dev.pi, R(rom), W(rom));
     }
     for(i = (g_dev.pi.cart_rom.rom_size >> 16); i < 0xfc0; ++i)
     {
-        map_region(mem, 0x9000+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xb000+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x9000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xb000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 
     /* map PIF RAM */
-    map_region(mem, 0x9fc0, M64P_MEM_PIF, RW(pif));
-    map_region(mem, 0xbfc0, M64P_MEM_PIF, RW(pif));
+    map_region(mem, 0x9fc0, M64P_MEM_PIF, &g_dev.si, RW(pif));
+    map_region(mem, 0xbfc0, M64P_MEM_PIF, &g_dev.si, RW(pif));
     for(i = 0xfc1; i < 0x1000; ++i)
     {
-        map_region(mem, 0x9000+i, M64P_MEM_NOTHING, RW(nothing));
-        map_region(mem, 0xb000+i, M64P_MEM_NOTHING, RW(nothing));
+        map_region(mem, 0x9000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
+        map_region(mem, 0xb000+i, M64P_MEM_NOTHING, &g_dev.r4300, RW(nothing));
     }
 }
 
@@ -530,6 +573,24 @@ static void map_region_t(struct memory* mem, uint16_t region, int type)
     (void)region;
     (void)type;
 #endif
+}
+
+static void map_region_o(struct memory* mem,
+        uint16_t region,
+        void* opaque)
+{
+#ifdef DBG
+    if (lookup_breakpoint(((uint32_t)region << 16), 0x10000,
+                          M64P_BKP_FLAG_ENABLED) != -1)
+    {
+        mem->saved_opaque[region] = opaque;
+        mem->opaque[region] = &g_dev.r4300;
+    }
+    else
+#endif
+    {
+        mem->opaque[region] = opaque;
+    }
 }
 
 static void map_region_r(struct memory* mem,
@@ -571,10 +632,12 @@ static void map_region_w(struct memory* mem,
 void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
+                void* opaque,
                 void (*read32)(void),
                 void (*write32)(void))
 {
     map_region_t(mem, region, type);
+    map_region_o(mem, region, opaque);
     map_region_r(mem, region, read32);
     map_region_w(mem, region, write32);
 }

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -26,11 +26,13 @@
 
 struct memory
 {
+    void* opaque[0x10000];
     void (*readmem[0x10000])(void);
     void (*writemem[0x10000])(void);
 
 #ifdef DBG
     int memtype[0x10000];
+    void* saved_opaque[0x10000];
     void (*saved_readmem [0x10000])(void);
     void (*saved_writemem [0x10000])(void);
 #endif
@@ -71,6 +73,7 @@ void poweron_memory(struct memory* mem);
 void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
+                void* opaque,
                 void (*read32)(void),
                 void (*write32)(void));
 

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -27,16 +27,12 @@
 struct memory
 {
     void (*readmem[0x10000])(void);
-    void (*readmemd[0x10000])(void);
     void (*writemem[0x10000])(void);
-    void (*writememd[0x10000])(void);
 
 #ifdef DBG
     int memtype[0x10000];
     void (*saved_readmem [0x10000])(void);
-    void (*saved_readmemd[0x10000])(void);
     void (*saved_writemem [0x10000])(void);
-    void (*saved_writememd[0x10000])(void);
 #endif
 };
 
@@ -76,19 +72,13 @@ void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
                 void (*read32)(void),
-                void (*read64)(void),
-                void (*write32)(void),
-                void (*write64)(void));
+                void (*write32)(void));
 
 /* XXX: cannot make them static because of dynarec + rdp fb */
 void read_rdram(void);
-void read_rdramd(void);
 void write_rdram(void);
-void write_rdramd(void);
 void read_rdramFB(void);
-void read_rdramFBd(void);
 void write_rdramFB(void);
-void write_rdramFBd(void);
 
 /* Returns a pointer to a block of contiguous memory
  * Can access RDRAM, SP_DMEM, SP_IMEM and ROM, using TLB if necessary

--- a/src/device/pi/cart_rom.c
+++ b/src/device/pi/cart_rom.c
@@ -37,7 +37,7 @@ void poweron_cart_rom(struct cart_rom* cart_rom)
 }
 
 
-int read_cart_rom(void* opaque, uint32_t address, uint32_t* value)
+void read_cart_rom(void* opaque, uint32_t address, uint32_t* value)
 {
     struct pi_controller* pi = (struct pi_controller*)opaque;
     uint32_t addr = rom_address(address);
@@ -51,16 +51,12 @@ int read_cart_rom(void* opaque, uint32_t address, uint32_t* value)
     {
         *value = *(uint32_t*)(pi->cart_rom.rom + addr);
     }
-
-    return 0;
 }
 
-int write_cart_rom(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_cart_rom(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct pi_controller* pi = (struct pi_controller*)opaque;
     pi->cart_rom.last_write = value & mask;
     pi->cart_rom.rom_written = 1;
-
-    return 0;
 }
 

--- a/src/device/pi/cart_rom.h
+++ b/src/device/pi/cart_rom.h
@@ -44,7 +44,7 @@ void init_cart_rom(struct cart_rom* cart_rom,
 
 void poweron_cart_rom(struct cart_rom* cart_rom);
 
-int read_cart_rom(void* opaque, uint32_t address, uint32_t* value);
-int write_cart_rom(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_cart_rom(void* opaque, uint32_t address, uint32_t* value);
+void write_cart_rom(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 #endif

--- a/src/device/pi/flashram.c
+++ b/src/device/pi/flashram.c
@@ -133,6 +133,15 @@ void read_flashram_status(void* opaque, uint32_t address, uint32_t* value)
     *value = pi->flashram.status >> 32;
 }
 
+void write_flashram_status(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+{
+}
+
+void read_flashram_command(void* opaque, uint32_t address, uint32_t* value)
+{
+    *value = 0;
+}
+
 void write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct pi_controller* pi = (struct pi_controller*)opaque;

--- a/src/device/pi/flashram.c
+++ b/src/device/pi/flashram.c
@@ -119,36 +119,32 @@ void format_flashram(uint8_t* flash)
     memset(flash, 0xff, FLASHRAM_SIZE);
 }
 
-int read_flashram_status(void* opaque, uint32_t address, uint32_t* value)
+void read_flashram_status(void* opaque, uint32_t address, uint32_t* value)
 {
     struct pi_controller* pi = (struct pi_controller*)opaque;
 
     if ((pi->use_flashram == -1) || ((address & 0xffff) != 0))
     {
         DebugMessage(M64MSG_ERROR, "unknown read in read_flashram_status()");
-        return -1;
+        return;
     }
 
     pi->use_flashram = 1;
     *value = pi->flashram.status >> 32;
-
-    return 0;
 }
 
-int write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct pi_controller* pi = (struct pi_controller*)opaque;
 
     if ((pi->use_flashram == -1) || ((address & 0xffff) != 0))
     {
         DebugMessage(M64MSG_ERROR, "unknown write in write_flashram_command()");
-        return -1;
+        return;
     }
 
     pi->use_flashram = 1;
     flashram_command(pi, value & mask);
-
-    return 0;
 }
 
 

--- a/src/device/pi/flashram.h
+++ b/src/device/pi/flashram.h
@@ -56,8 +56,8 @@ void poweron_flashram(struct flashram* flashram);
 
 void format_flashram(uint8_t* flash);
 
-int read_flashram_status(void* opaque, uint32_t address, uint32_t* value);
-int write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_flashram_status(void* opaque, uint32_t address, uint32_t* value);
+void write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void dma_read_flashram(struct pi_controller* pi);
 void dma_write_flashram(struct pi_controller* pi);

--- a/src/device/pi/flashram.h
+++ b/src/device/pi/flashram.h
@@ -57,6 +57,8 @@ void poweron_flashram(struct flashram* flashram);
 void format_flashram(uint8_t* flash);
 
 void read_flashram_status(void* opaque, uint32_t address, uint32_t* value);
+void write_flashram_status(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_flashram_command(void* opaque, uint32_t address, uint32_t* value);
 void write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void dma_read_flashram(struct pi_controller* pi);

--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -192,17 +192,15 @@ void poweron_pi(struct pi_controller* pi)
     poweron_flashram(&pi->flashram);
 }
 
-int read_pi_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_pi_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct pi_controller* pi = (struct pi_controller*)opaque;
     uint32_t reg = pi_reg(address);
 
     *value = pi->regs[reg];
-
-    return 0;
 }
 
-int write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct pi_controller* pi = (struct pi_controller*)opaque;
     uint32_t reg = pi_reg(address);
@@ -212,17 +210,17 @@ int write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     case PI_RD_LEN_REG:
         masked_write(&pi->regs[PI_RD_LEN_REG], value, mask);
         dma_pi_read(pi);
-        return 0;
+        return;
 
     case PI_WR_LEN_REG:
         masked_write(&pi->regs[PI_WR_LEN_REG], value, mask);
         dma_pi_write(pi);
-        return 0;
+        return;
 
     case PI_STATUS_REG:
         if (value & mask & 2)
             clear_rcp_interrupt(pi->r4300, MI_INTR_PI);
-        return 0;
+        return;
 
     case PI_BSD_DOM1_LAT_REG:
     case PI_BSD_DOM1_PWD_REG:
@@ -233,12 +231,10 @@ int write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     case PI_BSD_DOM2_PGS_REG:
     case PI_BSD_DOM2_RLS_REG:
         masked_write(&pi->regs[reg], value & 0xff, mask);
-        return 0;
+        return;
     }
 
     masked_write(&pi->regs[reg], value, mask);
-
-    return 0;
 }
 
 void pi_end_of_dma_event(void* opaque)

--- a/src/device/pi/pi_controller.h
+++ b/src/device/pi/pi_controller.h
@@ -85,8 +85,8 @@ void init_pi(struct pi_controller* pi,
 
 void poweron_pi(struct pi_controller* pi);
 
-int read_pi_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_pi_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void pi_end_of_dma_event(void* opaque);
 

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -140,11 +140,11 @@
       else name(); \
    }
 
-#define CHECK_MEMORY() \
-   if (!r4300->cached_interp.invalid_code[*r4300_address(r4300)>>12]) \
-      if (r4300->cached_interp.blocks[*r4300_address(r4300)>>12]->block[(*r4300_address(r4300)&0xFFF)/4].ops != \
+#define CHECK_MEMORY(addr) \
+   if (!r4300->cached_interp.invalid_code[addr>>12]) \
+      if (r4300->cached_interp.blocks[addr>>12]->block[(addr&0xFFF)/4].ops != \
           r4300->current_instruction_table.NOTCOMPILED) \
-         r4300->cached_interp.invalid_code[*r4300_address(r4300)>>12] = 1;
+         r4300->cached_interp.invalid_code[addr>>12] = 1;
 
 // two functions are defined from the macros above but never used
 // these prototype declarations will prevent a warning

--- a/src/device/r4300/mi_controller.c
+++ b/src/device/r4300/mi_controller.c
@@ -72,17 +72,15 @@ void poweron_mi(struct mi_controller* mi)
 }
 
 
-int read_mi_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_mi_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct r4300_core* r4300 = (struct r4300_core*)opaque;
     uint32_t reg = mi_reg(address);
 
     *value = r4300->mi.regs[reg];
-
-    return 0;
 }
 
-int write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct r4300_core* r4300 = (struct r4300_core*)opaque;
     uint32_t reg = mi_reg(address);
@@ -106,8 +104,6 @@ int write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
         if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt(r4300);
         break;
     }
-
-    return 0;
 }
 
 /* interrupt execution is immediate (if not masked) */

--- a/src/device/r4300/mi_controller.h
+++ b/src/device/r4300/mi_controller.h
@@ -58,8 +58,8 @@ static uint32_t mi_reg(uint32_t address)
 
 void poweron_mi(struct mi_controller* mi);
 
-int read_mi_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_mi_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void raise_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr);
 void signal_rcp_interrupt(struct r4300_core* r4300, uint32_t mi_intr);

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -338,11 +338,10 @@ DECLARE_INSTRUCTION(SW)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
-    *r4300_wword(r4300) = (uint32_t) *lsrtp;
-    *r4300_wmask(r4300) = ~UINT32_C(0);
-    write_word_in_memory();
-    CHECK_MEMORY();
+
+    if (r4300_write_aligned_word(r4300, lsaddr, (uint32_t)*lsrtp, ~UINT32_C(0))) {
+        CHECK_MEMORY();
+    }
 }
 
 DECLARE_INSTRUCTION(SWL)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -42,9 +42,8 @@
  * If likely is nonzero, the delay slot is only executed if the jump is taken.
  * If cop1 is nonzero, a COP1 unusable check will be done.
  *
- * CHECK_MEMORY(): A snippet to be run after a store instruction,
- *                 to check if the store affected executable blocks.
- *                 The memory address of the store is in the 'address' global.
+ * CHECK_MEMORY(addr): A snippet to be run after a store instruction,
+ *                     to check if the store affected executable blocks.
  */
 
 #include "fpu.h"
@@ -294,7 +293,7 @@ DECLARE_INSTRUCTION(SB)
     unsigned int shift = bshift(lsaddr);
 
     if (r4300_write_aligned_word(r4300, lsaddr, (uint32_t)*lsrtp << shift, UINT32_C(0xff) << shift)) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -307,7 +306,7 @@ DECLARE_INSTRUCTION(SH)
     unsigned int shift = hshift(lsaddr);
 
     if (r4300_write_aligned_word(r4300, lsaddr, (uint32_t)*lsrtp << shift, UINT32_C(0xffff) << shift)) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -321,7 +320,7 @@ DECLARE_INSTRUCTION(SC)
     if (r4300->llbit)
     {
         if (r4300_write_aligned_word(r4300, lsaddr, (uint32_t)*lsrtp, ~UINT32_C(0))) {
-            CHECK_MEMORY();
+            CHECK_MEMORY(*r4300_address(r4300));
             r4300->llbit = 0;
             *lsrtp = 1;
         }
@@ -340,7 +339,7 @@ DECLARE_INSTRUCTION(SW)
     ADD_TO_PC(1);
 
     if (r4300_write_aligned_word(r4300, lsaddr, (uint32_t)*lsrtp, ~UINT32_C(0))) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -356,7 +355,7 @@ DECLARE_INSTRUCTION(SWL)
     uint32_t value = ((uint32_t)*lsrtp >> shift);
 
     if (r4300_write_aligned_word(r4300, lsaddr & ~UINT32_C(0x3), value, mask)) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -372,7 +371,7 @@ DECLARE_INSTRUCTION(SWR)
     uint32_t value = ((uint32_t)*lsrtp << shift);
 
     if (r4300_write_aligned_word(r4300, lsaddr & ~UINT32_C(0x3), value, mask)) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -384,7 +383,7 @@ DECLARE_INSTRUCTION(SD)
     ADD_TO_PC(1);
 
     if (r4300_write_aligned_dword(r4300, lsaddr, (uint64_t)*lsrtp, ~UINT64_C(0))) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -400,7 +399,7 @@ DECLARE_INSTRUCTION(SDL)
     uint64_t value = ((uint64_t)*lsrtp >> shift);
 
     if (r4300_write_aligned_dword(r4300, lsaddr & ~UINT32_C(0x7), value, mask)) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -416,7 +415,7 @@ DECLARE_INSTRUCTION(SDR)
     uint64_t value = ((uint64_t)*lsrtp << shift);
 
     if (r4300_write_aligned_dword(r4300, lsaddr & ~UINT32_C(0x7), value, mask)) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -1309,7 +1308,7 @@ DECLARE_INSTRUCTION(SWC1)
     ADD_TO_PC(1);
 
     if (r4300_write_aligned_word(r4300, lslfaddr, *((uint32_t*)(r4300_cp1_regs_simple(&r4300->cp1))[lslfft]), ~UINT32_C(0))) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 
@@ -1322,7 +1321,7 @@ DECLARE_INSTRUCTION(SDC1)
     ADD_TO_PC(1);
 
     if (r4300_write_aligned_dword(r4300, lslfaddr, *((uint64_t*)(r4300_cp1_regs_double(&r4300->cp1))[lslfft]), ~UINT64_C(0))) {
-        CHECK_MEMORY();
+        CHECK_MEMORY(*r4300_address(r4300));
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -214,29 +214,14 @@ DECLARE_INSTRUCTION(LWL)
     DECLARE_R4300
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
-    uint64_t word = 0;
     ADD_TO_PC(1);
-    if ((lsaddr & 3) == 0)
-    {
-        *r4300_address(r4300) = lsaddr;
-        r4300->rdword = (uint64_t*) lsrtp;
-        read_word_in_memory();
-        if (*r4300_address(r4300))
-            *lsrtp = SE32(*lsrtp);
-    }
-    else
-    {
-        *r4300_address(r4300) = lsaddr & UINT32_C(0xFFFFFFFC);
-        r4300->rdword = &word;
-        read_word_in_memory();
-        if (*r4300_address(r4300))
-        {
-            /* How many low bits do we want to preserve from the old value? */
-            uint32_t old_mask = BITS_BELOW_MASK32((lsaddr & 3) * 8);
-            /* How many bits up do we want to add the low bits of the new value in? */
-            int new_shift = (lsaddr & 3) * 8;
-            *lsrtp = SE32(((uint32_t) *lsrtp & old_mask) | ((uint32_t) word << new_shift));
-        }
+
+    unsigned int shift = (lsaddr & 3) * 8;
+    uint32_t mask = BITS_BELOW_MASK32((lsaddr & 3) * 8);
+    uint32_t value;
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = SE32(((uint32_t)*lsrtp & mask) | ((uint32_t)value << shift));
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1320,10 +1320,10 @@ DECLARE_INSTRUCTION(SDC1)
     const uint32_t lslfaddr = (uint32_t) r4300_regs(r4300)[lfbase] + lfoffset;
     if (check_cop1_unusable(r4300)) { return; }
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lslfaddr;
-    *r4300_wdword(r4300) = *((uint64_t*) (r4300_cp1_regs_double(&r4300->cp1))[lslfft]);
-    write_dword_in_memory();
-    CHECK_MEMORY();
+
+    if (r4300_write_aligned_dword(r4300, lslfaddr, *((uint64_t*)(r4300_cp1_regs_double(&r4300->cp1))[lslfft]), ~UINT64_C(0))) {
+        CHECK_MEMORY();
+    }
 }
 
 DECLARE_INSTRUCTION(MFC1)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -365,33 +365,14 @@ DECLARE_INSTRUCTION(SWR)
     DECLARE_R4300
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
-    uint64_t old_word = 0;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr & UINT32_C(0xFFFFFFFC);
-    if ((lsaddr & 3) == 3)
-    {
-        *r4300_wword(r4300) = (uint32_t) *lsrtp;
-        *r4300_wmask(r4300) = ~UINT32_C(0);
-        write_word_in_memory();
+
+    unsigned int shift = (3 - (lsaddr & 3)) * 8;
+    uint32_t mask = BITS_ABOVE_MASK32((3 - (lsaddr & 3)) * 8);
+    uint32_t value = ((uint32_t)*lsrtp << shift);
+
+    if (r4300_write_aligned_word(r4300, lsaddr & ~UINT32_C(0x3), value, mask)) {
         CHECK_MEMORY();
-    }
-    else
-    {
-        r4300->rdword = &old_word;
-        read_word_in_memory();
-        if (*r4300_address(r4300))
-        {
-            /* How many low bits do we want to preserve from what was in memory
-             * before? */
-            int32_t old_mask = BITS_BELOW_MASK32((3 - (lsaddr & 3)) * 8);
-            /* How many bits up do we need to shift the register to store some
-             * of its low bits into the high bits of the memory word? */
-            int new_shift = (3 - (lsaddr & 3)) * 8;
-            *r4300_wword(r4300) = ((uint32_t) old_word & old_mask) | ((uint32_t) *lsrtp << new_shift);
-            *r4300_wmask(r4300) = ~UINT32_C(0);
-            write_word_in_memory();
-            CHECK_MEMORY();
-        }
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -174,11 +174,10 @@ DECLARE_INSTRUCTION(LL)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
-    r4300->rdword = (uint64_t*) lsrtp;
-    read_word_in_memory();
-    if (*r4300_address(r4300)) {
-        *lsrtp = SE32(*lsrtp);
+    uint32_t value;
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = SE32(value);
         r4300->llbit = 1;
     }
 }

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1307,11 +1307,10 @@ DECLARE_INSTRUCTION(SWC1)
     const uint32_t lslfaddr = (uint32_t) r4300_regs(r4300)[lfbase] + lfoffset;
     if (check_cop1_unusable(r4300)) { return; }
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lslfaddr;
-    *r4300_wword(r4300) = *((uint32_t*)(r4300_cp1_regs_simple(&r4300->cp1))[lslfft]);
-    *r4300_wmask(r4300) = ~UINT32_C(0);
-    write_word_in_memory();
-    CHECK_MEMORY();
+
+    if (r4300_write_aligned_word(r4300, lslfaddr, *((uint32_t*)(r4300_cp1_regs_simple(&r4300->cp1))[lslfft]), ~UINT32_C(0))) {
+        CHECK_MEMORY();
+    }
 }
 
 DECLARE_INSTRUCTION(SDC1)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -160,13 +160,11 @@ DECLARE_INSTRUCTION(LHU)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
+    uint32_t value;
     unsigned int shift = hshift(lsaddr);
-    *r4300_address(r4300) = lsaddr;
-    r4300->rdword = (uint64_t*) lsrtp;
-    read_word_in_memory();
-    if (*r4300_address(r4300)) {
-        *lsrtp >>= shift;
-        *lsrtp &= 0xffff;
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = (value >> shift) & 0xffff;
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -188,11 +188,10 @@ DECLARE_INSTRUCTION(LW)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
-    r4300->rdword = (uint64_t*) lsrtp;
-    read_word_in_memory();
-    if (*r4300_address(r4300)) {
-        *lsrtp = SE32(*lsrtp);
+    uint32_t value;
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = SE32(value);
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -317,15 +317,14 @@ DECLARE_INSTRUCTION(SC)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    if(r4300->llbit)
+
+    if (r4300->llbit)
     {
-        *r4300_address(r4300) = lsaddr;
-        *r4300_wword(r4300) = (uint32_t) *lsrtp;
-        *r4300_wmask(r4300) = ~UINT32_C(0);
-        write_word_in_memory();
-        CHECK_MEMORY();
-        r4300->llbit = 0;
-        *lsrtp = 1;
+        if (r4300_write_aligned_word(r4300, lsaddr, (uint32_t)*lsrtp, ~UINT32_C(0))) {
+            CHECK_MEMORY();
+            r4300->llbit = 0;
+            *lsrtp = 1;
+        }
     }
     else
     {

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -118,14 +118,11 @@ DECLARE_INSTRUCTION(LB)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
+    uint32_t value;
     unsigned int shift = bshift(lsaddr);
-    *r4300_address(r4300) = lsaddr;
-    r4300->rdword = (uint64_t*) lsrtp;
-    read_word_in_memory();
-    if (*r4300_address(r4300)) {
-        *lsrtp >>= shift;
-        *lsrtp &= 0xff;
-        *lsrtp = SE8(*lsrtp);
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = SE8((value >> shift) & 0xff);
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -292,11 +292,10 @@ DECLARE_INSTRUCTION(SB)
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     unsigned int shift = bshift(lsaddr);
-    *r4300_address(r4300) = lsaddr;
-    *r4300_wword(r4300) = (uint32_t)*lsrtp << shift;
-    *r4300_wmask(r4300) = UINT32_C(0xff) << shift;
-    write_word_in_memory();
-    CHECK_MEMORY();
+
+    if (r4300_write_aligned_word(r4300, lsaddr, (uint32_t)*lsrtp << shift, UINT32_C(0xff) << shift)) {
+        CHECK_MEMORY();
+    }
 }
 
 DECLARE_INSTRUCTION(SH)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1296,9 +1296,8 @@ DECLARE_INSTRUCTION(LDC1)
     const uint32_t lslfaddr = (uint32_t) r4300_regs(r4300)[lfbase] + lfoffset;
     if (check_cop1_unusable(r4300)) { return; }
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lslfaddr;
-    r4300->rdword = (uint64_t*) (r4300_cp1_regs_double(&r4300->cp1))[lslfft];
-    read_dword_in_memory();
+
+    r4300_read_aligned_dword(r4300, lslfaddr, (uint64_t*)r4300_cp1_regs_double(&r4300->cp1)[lslfft]);
 }
 
 DECLARE_INSTRUCTION(SWC1)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -382,10 +382,10 @@ DECLARE_INSTRUCTION(SD)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
-    *r4300_wdword(r4300) = *lsrtp;
-    write_dword_in_memory();
-    CHECK_MEMORY();
+
+    if (r4300_write_aligned_dword(r4300, lsaddr, (uint64_t)*lsrtp, ~UINT64_C(0))) {
+        CHECK_MEMORY();
+    }
 }
 
 DECLARE_INSTRUCTION(SDL)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -201,9 +201,12 @@ DECLARE_INSTRUCTION(LWU)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
-    r4300->rdword = (uint64_t*) lsrtp;
-    read_word_in_memory();
+
+    uint32_t value;
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = value;
+    }
 }
 
 DECLARE_INSTRUCTION(LWL)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -247,9 +247,8 @@ DECLARE_INSTRUCTION(LD)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr;
-    r4300->rdword = (uint64_t*) lsrtp;
-    read_dword_in_memory();
+
+    r4300_read_aligned_dword(r4300, lsaddr, (uint64_t*)lsrtp);
 }
 
 DECLARE_INSTRUCTION(LDL)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -305,11 +305,10 @@ DECLARE_INSTRUCTION(SH)
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
     unsigned int shift = hshift(lsaddr);
-    *r4300_address(r4300) = lsaddr;
-    *r4300_wword(r4300) = (uint32_t)*lsrtp << shift;
-    *r4300_wmask(r4300) = UINT32_C(0xffff) << shift;
-    write_word_in_memory();
-    CHECK_MEMORY();
+
+    if (r4300_write_aligned_word(r4300, lsaddr, (uint32_t)*lsrtp << shift, UINT32_C(0xffff) << shift)) {
+        CHECK_MEMORY();
+    }
 }
 
 DECLARE_INSTRUCTION(SC)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1283,15 +1283,10 @@ DECLARE_INSTRUCTION(LWC1)
     DECLARE_R4300
     const unsigned char lslfft = lfft;
     const uint32_t lslfaddr = (uint32_t) r4300_regs(r4300)[lfbase] + lfoffset;
-    uint64_t temp;
     if (check_cop1_unusable(r4300)) { return; }
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lslfaddr;
-    r4300->rdword = &temp;
-    read_word_in_memory();
-    if (*r4300_address(r4300)) {
-        *((uint32_t*)(r4300_cp1_regs_simple(&r4300->cp1))[lslfft]) = (uint32_t) *r4300->rdword;
-    }
+
+    r4300_read_aligned_word(r4300, lslfaddr, (uint32_t*)r4300_cp1_regs_simple(&r4300->cp1)[lslfft]);
 }
 
 DECLARE_INSTRUCTION(LDC1)

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -132,13 +132,11 @@ DECLARE_INSTRUCTION(LBU)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
+    uint32_t value;
     unsigned int shift = bshift(lsaddr);
-    *r4300_address(r4300) = lsaddr;
-    r4300->rdword = (uint64_t*) lsrtp;
-    read_word_in_memory();
-    if (*r4300_address(r4300)) {
-        *lsrtp >>= shift;
-        *lsrtp &= 0xff;
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = (value >> shift) & 0xff;
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -409,31 +409,14 @@ DECLARE_INSTRUCTION(SDR)
     DECLARE_R4300
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
-    uint64_t old_word = 0;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr & UINT32_C(0xFFFFFFF8);
-    if ((lsaddr & 7) == 7)
-    {
-        *r4300_wdword(r4300) = *lsrtp;
-        write_dword_in_memory();
+
+    unsigned int shift = (7 - (lsaddr & 7)) * 8;
+    uint64_t mask = BITS_ABOVE_MASK64((7 - (lsaddr & 7)) * 8);
+    uint64_t value = ((uint64_t)*lsrtp << shift);
+
+    if (r4300_write_aligned_dword(r4300, lsaddr & ~UINT32_C(0x7), value, mask)) {
         CHECK_MEMORY();
-    }
-    else
-    {
-        r4300->rdword = &old_word;
-        read_dword_in_memory();
-        if (*r4300_address(r4300))
-        {
-            /* How many low bits do we want to preserve from what was in memory
-             * before? */
-            uint64_t old_mask = BITS_BELOW_MASK64((7 - (lsaddr & 7)) * 8);
-            /* How many bits up do we need to shift the register to store some
-             * of its low bits into the high bits of the memory word? */
-            int new_shift = (7 - (lsaddr & 7)) * 8;
-            *r4300_wdword(r4300) = (old_word & old_mask) | (*lsrtp << new_shift);
-            write_dword_in_memory();
-            CHECK_MEMORY();
-        }
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -256,27 +256,14 @@ DECLARE_INSTRUCTION(LDL)
     DECLARE_R4300
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
-    uint64_t word = 0;
     ADD_TO_PC(1);
-    if ((lsaddr & 7) == 0)
-    {
-        *r4300_address(r4300) = lsaddr;
-        r4300->rdword = (uint64_t*) lsrtp;
-        read_dword_in_memory();
-    }
-    else
-    {
-        *r4300_address(r4300) = lsaddr & UINT32_C(0xFFFFFFF8);
-        r4300->rdword = &word;
-        read_dword_in_memory();
-        if (*r4300_address(r4300))
-        {
-            /* How many low bits do we want to preserve from the old value? */
-            uint64_t old_mask = BITS_BELOW_MASK64((lsaddr & 7) * 8);
-            /* How many bits up do we want to add the low bits of the new value in? */
-            int new_shift = (lsaddr & 7) * 8;
-            *lsrtp = (*lsrtp & old_mask) | (word << new_shift);
-        }
+
+    unsigned int shift = (lsaddr & 7) * 8;
+    uint64_t mask = BITS_BELOW_MASK64((lsaddr & 7) * 8);
+    uint64_t value;
+
+    if (r4300_read_aligned_dword(r4300, lsaddr & ~UINT32_C(7), &value)) {
+        *lsrtp = ((uint64_t)*lsrtp & mask) | (value << shift);
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -230,29 +230,14 @@ DECLARE_INSTRUCTION(LWR)
     DECLARE_R4300
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
-    uint64_t word = 0;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr & UINT32_C(0xFFFFFFFC);
-    if ((lsaddr & 3) == 3)
-    {
-        r4300->rdword = (uint64_t*) lsrtp;
-        read_word_in_memory();
-        if (*r4300_address(r4300)) {
-            *lsrtp = SE32(*lsrtp);
-        }
-    }
-    else
-    {
-        r4300->rdword = &word;
-        read_word_in_memory();
-        if (*r4300_address(r4300))
-        {
-            /* How many high bits do we want to preserve from the old value? */
-            uint32_t old_mask = BITS_ABOVE_MASK32(((lsaddr & 3) + 1) * 8);
-            /* How many bits down do we want to add the new value in? */
-            int new_shift = (3 - (lsaddr & 3)) * 8;
-            *lsrtp = SE32(((uint32_t) *lsrtp & old_mask) | ((uint32_t) word >> new_shift));
-        }
+
+    unsigned int shift = (3 - (lsaddr & 3)) * 8;
+    uint32_t mask = BITS_ABOVE_MASK32(((lsaddr & 3) + 1) * 8);
+    uint32_t value;
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = SE32(((uint32_t)*lsrtp & mask) | ((uint32_t)value >> shift));
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -272,26 +272,14 @@ DECLARE_INSTRUCTION(LDR)
     DECLARE_R4300
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
-    uint64_t word = 0;
     ADD_TO_PC(1);
-    *r4300_address(r4300) = lsaddr & UINT32_C(0xFFFFFFF8);
-    if ((lsaddr & 7) == 7)
-    {
-        r4300->rdword = (uint64_t*) lsrtp;
-        read_dword_in_memory();
-    }
-    else
-    {
-        r4300->rdword = &word;
-        read_dword_in_memory();
-        if (*r4300_address(r4300))
-        {
-            /* How many high bits do we want to preserve from the old value? */
-            uint64_t old_mask = BITS_ABOVE_MASK64(((lsaddr & 7) + 1) * 8);
-            /* How many bits down do we want to add the high bits of the new value in? */
-            int new_shift = (7 - (lsaddr & 7)) * 8;
-            *lsrtp = (*lsrtp & old_mask) | (word >> new_shift);
-        }
+
+    unsigned int shift = (7 - (lsaddr & 7)) * 8;
+    uint64_t mask = BITS_ABOVE_MASK64(((lsaddr & 7) + 1) * 8);
+    uint64_t value;
+
+    if (r4300_read_aligned_dword(r4300, lsaddr & ~UINT32_C(7), &value)) {
+        *lsrtp = ((uint64_t)*lsrtp & mask) | (value >> shift);
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -393,32 +393,14 @@ DECLARE_INSTRUCTION(SDL)
     DECLARE_R4300
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
-    uint64_t old_word = 0;
     ADD_TO_PC(1);
-    if ((lsaddr & 7) == 0)
-    {
-        *r4300_address(r4300) = lsaddr;
-        *r4300_wdword(r4300) = *lsrtp;
-        write_dword_in_memory();
+
+    unsigned int shift = (lsaddr & 7) * 8;
+    uint64_t mask = BITS_BELOW_MASK64((8 - (lsaddr & 7)) * 8);
+    uint64_t value = ((uint64_t)*lsrtp >> shift);
+
+    if (r4300_write_aligned_dword(r4300, lsaddr & ~UINT32_C(0x7), value, mask)) {
         CHECK_MEMORY();
-    }
-    else
-    {
-        *r4300_address(r4300) = lsaddr & UINT32_C(0xFFFFFFF8);
-        r4300->rdword = &old_word;
-        read_dword_in_memory();
-        if (*r4300_address(r4300))
-        {
-            /* How many high bits do we want to preserve from what was in memory
-             * before? */
-            uint64_t old_mask = BITS_ABOVE_MASK64((8 - (lsaddr & 7)) * 8);
-            /* How many bits down do we need to shift the register to store some
-             * of its high bits into the low bits of the memory word? */
-            int new_shift = (lsaddr & 7) * 8;
-            *r4300_wdword(r4300) = (old_word & old_mask) | ((uint64_t) *lsrtp >> new_shift);
-            write_dword_in_memory();
-            CHECK_MEMORY();
-        }
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -146,14 +146,11 @@ DECLARE_INSTRUCTION(LH)
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
     ADD_TO_PC(1);
+    uint32_t value;
     unsigned int shift = hshift(lsaddr);
-    *r4300_address(r4300) = lsaddr;
-    r4300->rdword = (uint64_t*) lsrtp;
-    read_word_in_memory();
-    if (*r4300_address(r4300)) {
-        *lsrtp >>= shift;
-        *lsrtp &= 0xffff;
-        *lsrtp = SE16(*lsrtp);
+
+    if (r4300_read_aligned_word(r4300, lsaddr, &value)) {
+        *lsrtp = SE16((value >> shift) & 0xffff);
     }
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -349,34 +349,14 @@ DECLARE_INSTRUCTION(SWL)
     DECLARE_R4300
     const uint32_t lsaddr = (uint32_t) irs32 + (uint32_t) iimmediate;
     int64_t *lsrtp = &irt;
-    uint64_t old_word = 0;
     ADD_TO_PC(1);
-    if ((lsaddr & 3) == 0)
-    {
-        *r4300_address(r4300) = lsaddr;
-        *r4300_wword(r4300) = (uint32_t) *lsrtp;
-        *r4300_wmask(r4300) = ~UINT32_C(0);
-        write_word_in_memory();
+
+    unsigned int shift = (lsaddr & 3) * 8;
+    uint32_t mask = BITS_BELOW_MASK32((4 - (lsaddr & 3)) * 8);
+    uint32_t value = ((uint32_t)*lsrtp >> shift);
+
+    if (r4300_write_aligned_word(r4300, lsaddr & ~UINT32_C(0x3), value, mask)) {
         CHECK_MEMORY();
-    }
-    else
-    {
-        *r4300_address(r4300) = lsaddr & UINT32_C(0xFFFFFFFC);
-        r4300->rdword = &old_word;
-        read_word_in_memory();
-        if (*r4300_address(r4300))
-        {
-            /* How many high bits do we want to preserve from what was in memory
-             * before? */
-            uint32_t old_mask = BITS_ABOVE_MASK32((4 - (lsaddr & 3)) * 8);
-            /* How many bits down do we need to shift the register to store some
-             * of its high bits into the low bits of the memory word? */
-            int new_shift = (lsaddr & 3) * 8;
-            *r4300_wword(r4300) = ((uint32_t) old_word & old_mask) | ((uint32_t) *lsrtp >> new_shift);
-            *r4300_wmask(r4300) = ~UINT32_C(0);
-            write_word_in_memory();
-            CHECK_MEMORY();
-        }
     }
 }
 

--- a/src/device/r4300/new_dynarec/arm/linkage_arm.S
+++ b/src/device/r4300/new_dynarec/arm/linkage_arm.S
@@ -390,62 +390,62 @@ GLOBAL_FUNCTION(new_dyna_start):
 
 GLOBAL_FUNCTION(invalidate_addr_r0):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r0, #12    
+    lsr    r0, r0, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r1):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r1, #12    
+    lsr    r0, r1, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r2):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r2, #12    
+    lsr    r0, r2, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r3):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r3, #12    
+    lsr    r0, r3, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r4):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r4, #12    
+    lsr    r0, r4, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r5):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r5, #12    
+    lsr    r0, r5, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r6):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r6, #12    
+    lsr    r0, r6, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r7):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r7, #12    
+    lsr    r0, r7, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r8):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r8, #12    
+    lsr    r0, r8, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r9):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r9, #12    
+    lsr    r0, r9, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r10):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r10, #12    
+    lsr    r0, r10, #12
     b      invalidate_addr_call
 
 GLOBAL_FUNCTION(invalidate_addr_r12):
     stmia  fp, {r0, r1, r2, r3, r12, lr}
-    lsr    r0, r12, #12    
+    lsr    r0, r12, #12
 
 LOCAL_FUNCTION(invalidate_addr_call):
     bl     invalidate_block

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -184,13 +184,9 @@ void fp_exception_ds(void);
 void jump_syscall(void);
 void jump_eret(void);
 void read_nomem_new(void);
-void read_nomemd_new(void);
 void write_nomem_new(void);
-void write_nomemd_new(void);
 void write_rdram_new(void);
-void write_rdramd_new(void);
 void write_mi_new(void);
-void write_mid_new(void);
 
 /* interpreted opcode */
 static void div64(int64_t dividend,int64_t divisor);

--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -32,7 +32,7 @@
     %macro  cglobal 1
       global  %1
     %endmacro
-    
+
     %macro  cextern 1
       extern  %1
     %endmacro

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -95,7 +95,7 @@ static void InterpretOpcode(struct r4300_core* r4300);
       } \
       else name(r4300, op); \
    }
-#define CHECK_MEMORY()
+#define CHECK_MEMORY(addr)
 
 #define RD_OF(op)      (((op) >> 11) & 0x1F)
 #define RS_OF(op)      (((op) >> 21) & 0x1F)

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -312,6 +312,46 @@ uint64_t* r4300_wdword(struct r4300_core* r4300)
 #endif
 }
 
+/* Read aligned word from memory.
+ * address may not be word-aligned for byte or hword accesses.
+ * In such case, readw (in memory.c) takes care of word alignment.
+ * FIXME: implementation relies on parameterless memory function
+ * and associated address,rdword variables.
+ */
+int r4300_read_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_t* value)
+{
+    uint64_t* rdword = r4300->rdword;
+    uint64_t dummy;
+
+    *r4300_address(r4300) = address;
+    r4300->rdword = &dummy;
+    r4300->mem->readmem[address >> 16]();
+    r4300->rdword = rdword;
+
+    int success = (*r4300_address(r4300) != 0);
+
+    if (success) {
+        *value = (uint32_t)dummy;
+    }
+
+    return success;
+}
+
+/* Write aligned word to memory.
+ * address may not be word-aligned for byte or hword accesses.
+ * In such case, writew (in memory.c) takes care of word alignment.
+ * FIXME: implementation relies on parameterless memory function
+ * and associated address,word,mask variables.
+ */
+int r4300_write_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_t value, uint32_t mask)
+{
+    *r4300_address(r4300) = address;
+    *r4300_wword(r4300) = value;
+    *r4300_wmask(r4300) = mask;
+    r4300->mem->writemem[address >> 16]();
+
+    return (*r4300_address(r4300) != 0);
+}
 
 void invalidate_r4300_cached_code(struct r4300_core* r4300, uint32_t address, size_t size)
 {

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -231,9 +231,6 @@ int r4300_read_aligned_dword(struct r4300_core* r4300, uint32_t address, uint64_
 int r4300_write_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_t value, uint32_t mask);
 int r4300_write_aligned_dword(struct r4300_core* r4300, uint32_t address, uint64_t value, uint64_t mask);
 
-#define read_word_in_memory()   r4300->mem->readmem  [*r4300_address(r4300)>>16]()
-#define write_word_in_memory()  r4300->mem->writemem [*r4300_address(r4300)>>16]()
-
 /* Allow cached/dynarec r4300 implementations to invalidate
  * their cached code at [address, address+size]
  *

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -226,6 +226,9 @@ uint32_t* r4300_wmask(struct r4300_core* r4300);
 uint32_t* r4300_wword(struct r4300_core* r4300);
 uint64_t* r4300_wdword(struct r4300_core* r4300);
 
+int r4300_read_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_t* value);
+int r4300_write_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_t value, uint32_t mask);
+
 #define read_word_in_memory()   r4300->mem->readmem  [*r4300_address(r4300)>>16]()
 #define read_dword_in_memory()  r4300->mem->readmemd [*r4300_address(r4300)>>16]()
 #define write_word_in_memory()  r4300->mem->writemem [*r4300_address(r4300)>>16]()

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -227,7 +227,9 @@ uint32_t* r4300_wword(struct r4300_core* r4300);
 uint64_t* r4300_wdword(struct r4300_core* r4300);
 
 int r4300_read_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_t* value);
+int r4300_read_aligned_dword(struct r4300_core* r4300, uint32_t address, uint64_t* value);
 int r4300_write_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_t value, uint32_t mask);
+int r4300_write_aligned_dword(struct r4300_core* r4300, uint32_t address, uint64_t value, uint64_t mask);
 
 #define read_word_in_memory()   r4300->mem->readmem  [*r4300_address(r4300)>>16]()
 #define read_dword_in_memory()  r4300->mem->readmemd [*r4300_address(r4300)>>16]()

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -232,9 +232,7 @@ int r4300_write_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_
 int r4300_write_aligned_dword(struct r4300_core* r4300, uint32_t address, uint64_t value, uint64_t mask);
 
 #define read_word_in_memory()   r4300->mem->readmem  [*r4300_address(r4300)>>16]()
-#define read_dword_in_memory()  r4300->mem->readmemd [*r4300_address(r4300)>>16]()
 #define write_word_in_memory()  r4300->mem->writemem [*r4300_address(r4300)>>16]()
-#define write_dword_in_memory() r4300->mem->writememd[*r4300_address(r4300)>>16]()
 
 /* Allow cached/dynarec r4300 implementations to invalidate
  * their cached code at [address, address+size]

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2646,6 +2646,27 @@ void dynarec_gen_interrupt(void)
     gen_interrupt(&g_dev.r4300);
 }
 
+/* Parameterless version of read_aligned_dword to ease usage in dynarec. */
+int dynarec_read_aligned_dword(void)
+{
+    return r4300_read_aligned_dword(
+        &g_dev.r4300,
+        *r4300_address(&g_dev.r4300),
+        (uint64_t*)g_dev.r4300.rdword);
+}
+
+/* Parameterless version of write_aligned_dword to ease usage in dynarec. */
+int dynarec_write_aligned_dword(void)
+{
+    return r4300_write_aligned_dword(
+        &g_dev.r4300,
+        *r4300_address(&g_dev.r4300),
+        *r4300_wdword(&g_dev.r4300),
+        ~UINT64_C(0)); /* NOTE: in dynarec, we only need all-one masks */
+}
+
+
+
 /**********************************************************************
  ************** allocate memory with executable bit set ***************
  **********************************************************************/

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -2646,6 +2646,32 @@ void dynarec_gen_interrupt(void)
     gen_interrupt(&g_dev.r4300);
 }
 
+/* Parameterless version of read_aligned_word to ease usage in dynarec. */
+int dynarec_read_aligned_word(void)
+{
+    uint32_t value;
+
+    int result = r4300_read_aligned_word(
+        &g_dev.r4300,
+        *r4300_address(&g_dev.r4300),
+        &value);
+
+    if (result)
+        *g_dev.r4300.rdword = value;
+
+    return result;
+}
+
+/* Parameterless version of write_aligned_word to ease usage in dynarec. */
+int dynarec_write_aligned_word(void)
+{
+    return r4300_write_aligned_word(
+        &g_dev.r4300,
+        *r4300_address(&g_dev.r4300),
+        *r4300_wword(&g_dev.r4300),
+        *r4300_wmask(&g_dev.r4300));
+}
+
 /* Parameterless version of read_aligned_dword to ease usage in dynarec. */
 int dynarec_read_aligned_dword(void)
 {

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -44,6 +44,8 @@ void dynarec_exception_general(void);
 int dynarec_check_cop1_unusable(void);
 void dynarec_cp0_update_count(void);
 void dynarec_gen_interrupt(void);
+int dynarec_read_aligned_word(void);
+int dynarec_write_aligned_word(void);
 int dynarec_read_aligned_dword(void);
 int dynarec_write_aligned_dword(void);
 

--- a/src/device/r4300/recomp.h
+++ b/src/device/r4300/recomp.h
@@ -44,6 +44,8 @@ void dynarec_exception_general(void);
 int dynarec_check_cop1_unusable(void);
 void dynarec_cp0_update_count(void);
 void dynarec_gen_interrupt(void);
+int dynarec_read_aligned_dword(void);
+int dynarec_write_aligned_dword(void);
 
 
 #if defined(PROFILE_R4300)

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -24,6 +24,7 @@
 #include "api/m64p_types.h"
 #include "device/r4300/exception.h"
 #include "device/r4300/r4300_core.h"
+#include "device/memory/memory.h"
 #include "main/rom.h"
 #include "main/main.h"
 
@@ -164,4 +165,29 @@ uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address,
 
     //return 0x80000000;
     return 0x00000000;
+}
+
+
+/* FIXME: still uses r4300_address to indicate TLB translation failure */
+void read_tlb_mem(void* opaque, uint32_t address, uint32_t* value)
+{
+    struct r4300_core* r4300 = (struct r4300_core*)opaque;
+
+    *r4300_address(r4300) = virtual_to_physical_address(r4300, address, 0);
+    if (*r4300_address(r4300) == 0x00000000) { return; }
+
+    r4300_read_aligned_word(r4300, *r4300_address(r4300), value);
+}
+
+/* FIXME: still uses r4300_address to indicate TLB translation failure */
+void write_tlb_mem(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+{
+    struct r4300_core* r4300 = (struct r4300_core*)opaque;
+
+    invalidate_r4300_cached_code(r4300, address, 4);
+
+    *r4300_address(r4300) = virtual_to_physical_address(r4300, address, 1);
+    if (*r4300_address(r4300) == 0x00000000) { return; }
+
+    r4300_write_aligned_word(r4300, *r4300_address(r4300), value, mask);
 }

--- a/src/device/r4300/tlb.h
+++ b/src/device/r4300/tlb.h
@@ -66,4 +66,7 @@ void tlb_map(struct tlb* tlb, size_t entry);
 
 uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address, int w);
 
+void read_tlb_mem(void* opaque, uint32_t address, uint32_t* value);
+void write_tlb_mem(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+
 #endif /* M64P_DEVICE_R4300_TLB_H */

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -721,7 +721,7 @@ void gensh(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(79);
+    je_rj(68);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     /* if non RDRAM write,
@@ -731,14 +731,12 @@ void gensh(struct r4300_core* r4300)
     xor_reg32_imm32(ECX, 2); // 6
     shl_reg32_imm8(ECX, 3); // 3
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
-    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     shl_reg32_cl(EDX); // 2
     mov_m32_reg32((unsigned int *)(r4300_wword(r4300)), EDX); // 6
     mov_reg32_imm32(EDX, 0xffff); // 5
     shl_reg32_cl(EDX); // 2
     mov_m32_reg32((unsigned int *)(r4300_wmask(r4300)), EDX); // 6
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writemem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_write_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300_address(r4300))); // 5
     jmp_imm_short(18); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -385,7 +385,7 @@ void genlh(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(112);
+    je_rj(101);
 
     mov_m32_imm32((unsigned int *)&(*r4300_pc_struct(r4300)), (unsigned int)(r4300->recomp.dst+1)); // 10
     /* if non RDRAM read,
@@ -397,10 +397,8 @@ void genlh(struct r4300_core* r4300)
     shl_reg32_imm8(ECX, 3); // 3
     mov_m32_reg32((unsigned int *)&r4300->recomp.shift, ECX); // 6
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
-    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_reg32_m32(EBX, (unsigned int *)(r4300_address(r4300))); // 6
     and_reg32_reg32(EBX, EBX); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -4237,17 +4237,16 @@ void gensdc1(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
-        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writememd);
-        cmp_reg32_imm32(EAX, (unsigned int)write_rdramd);
+        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
+        cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(47);
+    je_rj(42);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_reg32((unsigned int *)(r4300_wdword(r4300)), ECX); // 6
     mov_m32_reg32((unsigned int *)(r4300_wdword(r4300))+1, EDX); // 6
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writememd); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_write_aligned_dword); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300_address(r4300))); // 5
     jmp_imm_short(20); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -4083,14 +4083,13 @@ void genlwc1(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(42);
+    je_rj(37);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_reg32_m32(EDX, (unsigned int*)(&(r4300_cp1_regs_simple(&r4300->cp1))[r4300->recomp.dst->f.lf.ft])); // 6
     mov_m32_reg32((unsigned int *)(&r4300->rdword), EDX); // 6
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_word); // 5
     call_reg32(EBX); // 2
     jmp_imm_short(20); // 2
 

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -599,16 +599,15 @@ void genld(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
-        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmemd);
-        cmp_reg32_imm32(EAX, (unsigned int)read_rdramd);
+        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
+        cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(51);
+    je_rj(46);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmemd); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_dword); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300->recomp.dst->f.i.rt)); // 5
     mov_reg32_m32(ECX, (unsigned int *)(r4300->recomp.dst->f.i.rt)+1); // 6

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -329,7 +329,7 @@ void genlbu(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(93);
+    je_rj(82);
 
     mov_m32_imm32((unsigned int *)&(*r4300_pc_struct(r4300)), (unsigned int)(r4300->recomp.dst+1)); // 10
     /* if non RDRAM read,
@@ -341,10 +341,8 @@ void genlbu(struct r4300_core* r4300)
     shl_reg32_imm8(ECX, 3); // 3
     mov_m32_reg32((unsigned int *)&r4300->recomp.shift, ECX); // 6
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
-    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_reg32_m32(EBX, (unsigned int *)(r4300_address(r4300))); // 6
     and_reg32_reg32(EBX, EBX); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -793,14 +793,13 @@ void gensw(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(51);
+    je_rj(46);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_reg32((unsigned int *)(r4300_wword(r4300)), ECX); // 6
     mov_m32_imm32((unsigned int *)(r4300_wmask(r4300)), ~UINT32_C(0)); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writemem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_write_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300_address(r4300))); // 5
     jmp_imm_short(14); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -4134,17 +4134,16 @@ void genldc1(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
-        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmemd);
-        cmp_reg32_imm32(EAX, (unsigned int)read_rdramd);
+        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
+        cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(42);
+    je_rj(37);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_reg32_m32(EDX, (unsigned int*)(&(r4300_cp1_regs_double(&r4300->cp1))[r4300->recomp.dst->f.lf.ft])); // 6
     mov_m32_reg32((unsigned int *)(&r4300->rdword), EDX); // 6
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmemd); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_dword); // 5
     call_reg32(EBX); // 2
     jmp_imm_short(32); // 2
 

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -504,13 +504,12 @@ void genlw(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(45);
+    je_rj(40);
 
     mov_m32_imm32((unsigned int *)&(*r4300_pc_struct(r4300)), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300->recomp.dst->f.i.rt)); // 5
     jmp_imm_short(12); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -4163,14 +4163,13 @@ void genswc1(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(51);
+    je_rj(46);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_reg32((unsigned int *)(r4300_wword(r4300)), ECX); // 6
     mov_m32_imm32((unsigned int *)(r4300_wmask(r4300)), ~UINT32_C(0)); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writemem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_write_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300_address(r4300))); // 5
     jmp_imm_short(14); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -271,7 +271,7 @@ void genlb(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(112);
+    je_rj(101);
 
     mov_m32_imm32((unsigned int *)&(*r4300_pc_struct(r4300)), (unsigned int)(r4300->recomp.dst+1)); // 10
     /* if non RDRAM read,
@@ -283,10 +283,8 @@ void genlb(struct r4300_core* r4300)
     shl_reg32_imm8(ECX, 3); // 3
     mov_m32_reg32((unsigned int *)&r4300->recomp.shift, ECX); // 6
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
-    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_reg32_m32(EBX, (unsigned int *)(r4300_address(r4300))); // 6
     and_reg32_reg32(EBX, EBX); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -649,7 +649,7 @@ void gensb(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(79);
+    je_rj(68);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     /* if non RDRAM write,
@@ -659,14 +659,12 @@ void gensb(struct r4300_core* r4300)
     xor_reg32_imm32(ECX, 3); // 6
     shl_reg32_imm8(ECX, 3); // 3
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
-    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     shl_reg32_cl(EDX); // 2
     mov_m32_reg32((unsigned int *)(r4300_wword(r4300)), EDX); // 6
     mov_reg32_imm32(EDX, 0xff); // 5
     shl_reg32_cl(EDX); // 2
     mov_m32_reg32((unsigned int *)(r4300_wmask(r4300)), EDX); // 6
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writemem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_write_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300_address(r4300))); // 5
     jmp_imm_short(17); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -542,13 +542,12 @@ void genlwu(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(45);
+    je_rj(40);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300->recomp.dst->f.i.rt)); // 5
     jmp_imm_short(12); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -443,7 +443,7 @@ void genlhu(struct r4300_core* r4300)
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->readmem);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram);
     }
-    je_rj(93);
+    je_rj(82);
 
     mov_m32_imm32((unsigned int *)&(*r4300_pc_struct(r4300)), (unsigned int)(r4300->recomp.dst+1)); // 10
     /* if non RDRAM read,
@@ -455,10 +455,8 @@ void genlhu(struct r4300_core* r4300)
     shl_reg32_imm8(ECX, 3); // 3
     mov_m32_reg32((unsigned int *)&r4300->recomp.shift, ECX); // 6
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
-    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     mov_m32_imm32((unsigned int *)(&r4300->rdword), (unsigned int)r4300->recomp.dst->f.i.rt); // 10
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->readmem); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_read_aligned_word); // 5
     call_reg32(EBX); // 2
     mov_reg32_m32(EBX, (unsigned int *)(r4300_address(r4300))); // 6
     and_reg32_reg32(EBX, EBX); // 2

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -874,17 +874,16 @@ void gensd(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
-        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writememd);
-        cmp_reg32_imm32(EAX, (unsigned int)write_rdramd);
+        mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->writemem);
+        cmp_reg32_imm32(EAX, (unsigned int)write_rdram);
     }
-    je_rj(47);
+    je_rj(42);
 
     mov_m32_imm32((unsigned int *)(&(*r4300_pc_struct(r4300))), (unsigned int)(r4300->recomp.dst+1)); // 10
     mov_m32_reg32((unsigned int *)(r4300_address(r4300)), EBX); // 6
     mov_m32_reg32((unsigned int *)(r4300_wdword(r4300)), ECX); // 6
     mov_m32_reg32((unsigned int *)(r4300_wdword(r4300))+1, EDX); // 6
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg32_preg32x4pimm32(EBX, EBX, (unsigned int)r4300->mem->writememd); // 7
+    mov_reg32_imm32(EBX, (unsigned int)dynarec_write_aligned_dword); // 5
     call_reg32(EBX); // 2
     mov_eax_memoffs32((unsigned int *)(r4300_address(r4300))); // 5
     jmp_imm_short(20); // 2

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -413,11 +413,9 @@ void genlb(struct r4300_core* r4300)
     shl_reg64_imm8(base2, 3);
     mov_m64rel_xreg64(&r4300->recomp.shift, base2);
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), gpr2);
-    and_reg64_imm32(gpr2, ~UINT32_C(3));
     mov_reg64_imm64(gpr1, (unsigned long long) r4300->recomp.dst->f.i.rt);
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), gpr1);
-    shr_reg32_imm8(gpr2, 16);
-    mov_reg64_preg64x8preg64(gpr2, gpr2, base1);
+    mov_reg64_imm64(gpr2, (unsigned long long)dynarec_read_aligned_word);
     call_reg64(gpr2);
     mov_xreg32_m32rel(gpr2, (unsigned int *)(r4300_address(r4300)));
     and_reg64_reg64(gpr2, gpr2);

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -545,11 +545,9 @@ void genlh(struct r4300_core* r4300)
     shl_reg64_imm8(base2, 3);
     mov_m64rel_xreg64(&r4300->recomp.shift, base2);
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), gpr2);
-    and_reg64_imm32(gpr2, ~UINT32_C(3));
     mov_reg64_imm64(gpr1, (unsigned long long) r4300->recomp.dst->f.i.rt);
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), gpr1);
-    shr_reg32_imm8(gpr2, 16);
-    mov_reg64_preg64x8preg64(gpr2, gpr2, base1);
+    mov_reg64_imm64(gpr2, (unsigned long long)dynarec_read_aligned_word);
     call_reg64(gpr2);
     mov_xreg32_m32rel(gpr2, (unsigned int *)(r4300_address(r4300)));
     and_reg64_reg64(gpr2, gpr2);

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -4283,15 +4283,14 @@ void genlwc1(struct r4300_core* r4300)
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(49);
+    je_rj(52);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_xreg64_m64rel(RDX, (unsigned long long *)(&(r4300_cp1_regs_simple(&r4300->cp1))[r4300->recomp.dst->f.lf.ft])); // 7
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), RDX); // 7
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_read_aligned_word); // 10
     call_reg64(RBX); // 2
     jmp_imm_short(28); // 2
 

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -854,7 +854,7 @@ void gensb(struct r4300_core* r4300)
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(91);
+    je_rj(88);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
@@ -865,14 +865,12 @@ void gensb(struct r4300_core* r4300)
     xor_reg8_imm8(CL, 3); // 4
     shl_reg32_imm8(ECX, 3); // 3
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
-    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     shl_reg32_cl(EDX); // 2
     mov_m32rel_xreg32((unsigned int *)(r4300_wword(r4300)), EDX); // 7
     mov_reg64_imm64(RDX, 0xff); // 10
     shl_reg32_cl(EDX); // 2
     mov_m32rel_xreg32((unsigned int *)(r4300_wmask(r4300)), EDX); // 7
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_write_aligned_word); // 10
     call_reg64(RBX); // 2
     mov_xreg32_m32rel(EAX, (unsigned int *)(r4300_address(r4300))); // 7
     jmp_imm_short(25); // 2

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -1105,7 +1105,7 @@ void gensd(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->writememd);
+    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->writemem);
     if (r4300->recomp.fast_memory)
     {
         and_eax_imm32(0xDF800000);
@@ -1113,20 +1113,19 @@ void gensd(struct r4300_core* r4300)
     }
     else
     {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdramd);
+        mov_reg64_imm64(RDI, (unsigned long long) write_rdram);
         shr_reg32_imm8(EAX, 16);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(56);
+    je_rj(59);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_wdword(r4300)), ECX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_wdword(r4300))+1, EDX); // 7
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_write_aligned_dword); // 10
     call_reg64(RBX); // 2
     mov_xreg32_m32rel(EAX, (unsigned int *)(r4300_address(r4300))); // 7
     jmp_imm_short(28); // 2

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -479,11 +479,9 @@ void genlbu(struct r4300_core* r4300)
     shl_reg64_imm8(base2, 3);
     mov_m64rel_xreg64(&r4300->recomp.shift, base2);
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), gpr2);
-    and_reg64_imm32(gpr2, ~UINT32_C(3));
     mov_reg64_imm64(gpr1, (unsigned long long) r4300->recomp.dst->f.i.rt);
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), gpr1);
-    shr_reg32_imm8(gpr2, 16);
-    mov_reg64_preg64x8preg64(gpr2, gpr2, base1);
+    mov_reg64_imm64(gpr2, (unsigned long long)dynarec_read_aligned_word);
     call_reg64(gpr2);
     mov_xreg32_m32rel(gpr2, (unsigned int *)(r4300_address(r4300)));
     and_reg64_reg64(gpr2, gpr2);

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -610,11 +610,9 @@ void genlhu(struct r4300_core* r4300)
     shl_reg64_imm8(base2, 3);
     mov_m64rel_xreg64(&r4300->recomp.shift, base2);
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), gpr2);
-    and_reg64_imm32(gpr2, ~UINT32_C(3));
     mov_reg64_imm64(gpr1, (unsigned long long) r4300->recomp.dst->f.i.rt);
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), gpr1);
-    shr_reg32_imm8(gpr2, 16);
-    mov_reg64_preg64x8preg64(gpr2, gpr2, base1);
+    mov_reg64_imm64(gpr2, (unsigned long long)dynarec_read_aligned_word);
     call_reg64(gpr2);
     mov_xreg32_m32rel(gpr2, (unsigned int *)(r4300_address(r4300)));
     and_reg64_reg64(gpr2, gpr2);

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -4451,7 +4451,7 @@ void gensdc1(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)(&r4300_regs(r4300)[r4300->recomp.dst->f.lf.base]));
     add_eax_imm32((int)r4300->recomp.dst->f.lf.offset);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->writememd);
+    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->writemem);
     if (r4300->recomp.fast_memory)
     {
         and_eax_imm32(0xDF800000);
@@ -4459,20 +4459,19 @@ void gensdc1(struct r4300_core* r4300)
     }
     else
     {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdramd);
+        mov_reg64_imm64(RDI, (unsigned long long) write_rdram);
         shr_reg32_imm8(EAX, 16);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(56);
+    je_rj(59);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_wdword(r4300)), ECX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_wdword(r4300))+1, EDX); // 7
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_write_aligned_dword); // 10
     call_reg64(RBX); // 2
     mov_xreg32_m32rel(EAX, (unsigned int *)(r4300_address(r4300))); // 7
     jmp_imm_short(28); // 2

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -682,8 +682,7 @@ void genlw(struct r4300_core* r4300)
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), gpr2);
     mov_reg64_imm64(gpr1, (unsigned long long) r4300->recomp.dst->f.i.rt);
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), gpr1);
-    shr_reg32_imm8(gpr2, 16);
-    mov_reg64_preg64x8preg64(gpr1, gpr2, base1);
+    mov_reg64_imm64(gpr1, (unsigned long long)dynarec_read_aligned_word);
     call_reg64(gpr1);
     mov_xreg32_m32rel(gpr1, (unsigned int *)(r4300->recomp.dst->f.i.rt));
 

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -726,8 +726,7 @@ void genlwu(struct r4300_core* r4300)
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), gpr2);
     mov_reg64_imm64(gpr1, (unsigned long long) r4300->recomp.dst->f.i.rt);
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), gpr1);
-    shr_reg32_imm8(gpr2, 16);
-    mov_reg64_preg64x8preg64(gpr2, gpr2, base1);
+    mov_reg64_imm64(gpr2, (unsigned long long)dynarec_read_aligned_word);
     call_reg64(gpr2);
     mov_xreg32_m32rel(gpr1, (unsigned int *)r4300->recomp.dst->f.i.rt);
     jmp_imm_short(19);

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -934,7 +934,7 @@ void gensh(struct r4300_core* r4300)
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(91);
+    je_rj(88);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
@@ -945,14 +945,12 @@ void gensh(struct r4300_core* r4300)
     xor_reg8_imm8(CL, 2); // 4
     shl_reg32_imm8(ECX, 3); // 3
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
-    and_reg32_imm32(EBX, ~UINT32_C(3)); // 6
     shl_reg32_cl(EDX); // 2
     mov_m32rel_xreg32((unsigned int *)(r4300_wword(r4300)), EDX); // 7
     mov_reg64_imm64(RDX, 0xffff); // 10
     shl_reg32_cl(EDX); // 2
     mov_m32rel_xreg32((unsigned int *)(r4300_wmask(r4300)), EDX); // 7
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_write_aligned_word); // 10
     call_reg64(RBX); // 2
     mov_xreg32_m32rel(EAX, (unsigned int *)(r4300_address(r4300))); // 7
     jmp_imm_short(26); // 2

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -4377,15 +4377,14 @@ void genswc1(struct r4300_core* r4300)
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(60);
+    je_rj(63);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_wword(r4300)), ECX); // 7
     mov_m32rel_imm32((unsigned int *)(r4300_wmask(r4300)), ~UINT32_C(0)); // 11
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_write_aligned_word); // 10
     call_reg64(RBX); // 2
     mov_xreg32_m32rel(EAX, (unsigned int *)(r4300_address(r4300))); // 7
     jmp_imm_short(21); // 2

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -4331,7 +4331,7 @@ void genldc1(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)(&r4300_regs(r4300)[r4300->recomp.dst->f.lf.base]));
     add_eax_imm32((int)r4300->recomp.dst->f.lf.offset);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->readmemd);
+    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->readmem);
     if (r4300->recomp.fast_memory)
     {
         and_eax_imm32(0xDF800000);
@@ -4339,20 +4339,19 @@ void genldc1(struct r4300_core* r4300)
     }
     else
     {
-        mov_reg64_imm64(RDI, (unsigned long long) read_rdramd);
+        mov_reg64_imm64(RDI, (unsigned long long) read_rdram);
         shr_reg32_imm8(EAX, 16);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(49);
+    je_rj(52);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_xreg64_m64rel(RDX, (unsigned long long *)(&(r4300_cp1_regs_double(&r4300->cp1))[r4300->recomp.dst->f.lf.ft])); // 7
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), RDX); // 7
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_read_aligned_dword); // 10
     call_reg64(RBX); // 2
     jmp_imm_short(39); // 2
 

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -779,7 +779,7 @@ void genld(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->readmemd);
+    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->readmem);
     if (r4300->recomp.fast_memory)
     {
         and_eax_imm32(0xDF800000);
@@ -787,20 +787,19 @@ void genld(struct r4300_core* r4300)
     }
     else
     {
-        mov_reg64_imm64(RDI, (unsigned long long) read_rdramd);
+        mov_reg64_imm64(RDI, (unsigned long long) read_rdram);
         shr_reg32_imm8(EAX, 16);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(59);
+    je_rj(62);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_reg64_imm64(RAX, (unsigned long long) r4300->recomp.dst->f.i.rt); // 10
     mov_m64rel_xreg64((unsigned long long *)(&r4300->rdword), RAX); // 7
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_read_aligned_dword); // 10
     call_reg64(RBX); // 2
     mov_xreg64_m64rel(RAX, (unsigned long long *)(r4300->recomp.dst->f.i.rt)); // 7
     jmp_imm_short(33); // 2

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -1019,15 +1019,14 @@ void gensw(struct r4300_core* r4300)
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
         cmp_reg64_reg64(RAX, RDI);
     }
-    je_rj(60);
+    je_rj(63);
 
     mov_reg64_imm64(RAX, (unsigned long long) (r4300->recomp.dst+1)); // 10
     mov_m64rel_xreg64((unsigned long long *)(&(*r4300_pc_struct(r4300))), RAX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_address(r4300)), EBX); // 7
     mov_m32rel_xreg32((unsigned int *)(r4300_wword(r4300)), ECX); // 7
     mov_m32rel_imm32((unsigned int *)(r4300_wmask(r4300)), ~UINT32_C(0)); // 11
-    shr_reg32_imm8(EBX, 16); // 3
-    mov_reg64_preg64x8preg64(RBX, RBX, RSI);  // 4
+    mov_reg64_imm64(RBX, (unsigned long long)dynarec_write_aligned_word); // 10
     call_reg64(RBX); // 2
     mov_xreg32_m32rel(EAX, (unsigned int *)(r4300_address(r4300))); // 7
     jmp_imm_short(21); // 2

--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -121,8 +121,8 @@ void protect_framebuffers(struct rdp_core* dp)
                 end >>= 16;
                 for (j=start; j<=end; j++)
                 {
-                    map_region(dp->r4300->mem, 0x8000+j, M64P_MEM_RDRAM, RW(rdramFB));
-                    map_region(dp->r4300->mem, 0xa000+j, M64P_MEM_RDRAM, RW(rdramFB));
+                    map_region(dp->r4300->mem, 0x8000+j, M64P_MEM_RDRAM, dp, RW(rdramFB));
+                    map_region(dp->r4300->mem, 0xa000+j, M64P_MEM_RDRAM, dp, RW(rdramFB));
                 }
                 start <<= 4;
                 end <<= 4;
@@ -166,8 +166,8 @@ void unprotect_framebuffers(struct rdp_core* dp)
 
                 for (j=start; j<=end; j++)
                 {
-                    map_region(dp->r4300->mem, 0x8000+j, M64P_MEM_RDRAM, RW(rdram));
-                    map_region(dp->r4300->mem, 0xa000+j, M64P_MEM_RDRAM, RW(rdram));
+                    map_region(dp->r4300->mem, 0x8000+j, M64P_MEM_RDRAM, dp->ri, RW(rdram));
+                    map_region(dp->r4300->mem, 0xa000+j, M64P_MEM_RDRAM, dp->ri, RW(rdram));
                 }
             }
         }

--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -92,8 +92,8 @@ int write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 }
 
 
-#define R(x) read_ ## x, read_ ## x ## d
-#define W(x) write_ ## x, write_ ## x ## d
+#define R(x) read_ ## x
+#define W(x) write_ ## x
 #define RW(x) R(x), W(x)
 
 void protect_framebuffers(struct rdp_core* dp)

--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -77,18 +77,18 @@ static void pre_framebuffer_write(struct fb* fb, uint32_t address)
     }
 }
 
-int read_rdram_fb(void* opaque, uint32_t address, uint32_t* value)
+void read_rdram_fb(void* opaque, uint32_t address, uint32_t* value)
 {
     struct rdp_core* dp = (struct rdp_core*)opaque;
     pre_framebuffer_read(&dp->fb, address);
-    return read_rdram_dram(dp->ri, address, value);
+    read_rdram_dram(dp->ri, address, value);
 }
 
-int write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct rdp_core* dp = (struct rdp_core*)opaque;
     pre_framebuffer_write(&dp->fb, address);
-    return write_rdram_dram(dp->ri, address, value, mask);
+    write_rdram_dram(dp->ri, address, value, mask);
 }
 
 

--- a/src/device/rdp/fb.h
+++ b/src/device/rdp/fb.h
@@ -40,8 +40,8 @@ struct fb
 
 void poweron_fb(struct fb* fb);
 
-int read_rdram_fb(void* opaque, uint32_t address, uint32_t* value);
-int write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_rdram_fb(void* opaque, uint32_t address, uint32_t* value);
+void write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void protect_framebuffers(struct rdp_core* dp);
 void unprotect_framebuffers(struct rdp_core* dp);

--- a/src/device/rdp/rdp_core.c
+++ b/src/device/rdp/rdp_core.c
@@ -77,17 +77,15 @@ void poweron_rdp(struct rdp_core* dp)
 }
 
 
-int read_dpc_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_dpc_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct rdp_core* dp = (struct rdp_core*)opaque;
     uint32_t reg = dpc_reg(address);
 
     *value = dp->dpc_regs[reg];
-
-    return 0;
 }
 
-int write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct rdp_core* dp = (struct rdp_core*)opaque;
     uint32_t reg = dpc_reg(address);
@@ -102,7 +100,7 @@ int write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
     case DPC_BUFBUSY_REG:
     case DPC_PIPEBUSY_REG:
     case DPC_TMEM_REG:
-        return 0;
+        return;
     }
 
     masked_write(&dp->dpc_regs[reg], value, mask);
@@ -117,29 +115,23 @@ int write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         signal_rcp_interrupt(dp->r4300, MI_INTR_DP);
         break;
     }
-
-    return 0;
 }
 
 
-int read_dps_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_dps_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct rdp_core* dp = (struct rdp_core*)opaque;
     uint32_t reg = dps_reg(address);
 
     *value = dp->dps_regs[reg];
-
-    return 0;
 }
 
-int write_dps_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_dps_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct rdp_core* dp = (struct rdp_core*)opaque;
     uint32_t reg = dps_reg(address);
 
     masked_write(&dp->dps_regs[reg], value, mask);
-
-    return 0;
 }
 
 void rdp_interrupt_event(void* opaque)

--- a/src/device/rdp/rdp_core.h
+++ b/src/device/rdp/rdp_core.h
@@ -98,11 +98,11 @@ void init_rdp(struct rdp_core* dp,
 
 void poweron_rdp(struct rdp_core* dp);
 
-int read_dpc_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_dpc_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-int read_dps_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_dps_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_dps_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_dps_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void rdp_interrupt_event(void* opaque);
 

--- a/src/device/ri/rdram.c
+++ b/src/device/ri/rdram.c
@@ -41,44 +41,36 @@ void poweron_rdram(struct rdram* rdram)
 }
 
 
-int read_rdram_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_rdram_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t reg = rdram_reg(address);
 
     *value = ri->rdram.regs[reg];
-
-    return 0;
 }
 
-int write_rdram_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_rdram_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t reg = rdram_reg(address);
 
     masked_write(&ri->rdram.regs[reg], value, mask);
-
-    return 0;
 }
 
 
-int read_rdram_dram(void* opaque, uint32_t address, uint32_t* value)
+void read_rdram_dram(void* opaque, uint32_t address, uint32_t* value)
 {
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t addr = rdram_dram_address(address);
 
     *value = ri->rdram.dram[addr];
-
-    return 0;
 }
 
-int write_rdram_dram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_rdram_dram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t addr = rdram_dram_address(address);
 
     masked_write(&ri->rdram.dram[addr], value, mask);
-
-    return 0;
 }
 

--- a/src/device/ri/rdram.h
+++ b/src/device/ri/rdram.h
@@ -63,10 +63,10 @@ void init_rdram(struct rdram* rdram,
 
 void poweron_rdram(struct rdram* rdram);
 
-int read_rdram_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_rdram_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_rdram_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_rdram_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-int read_rdram_dram(void* opaque, uint32_t address, uint32_t* value);
-int write_rdram_dram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_rdram_dram(void* opaque, uint32_t address, uint32_t* value);
+void write_rdram_dram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 #endif

--- a/src/device/ri/ri_controller.c
+++ b/src/device/ri/ri_controller.c
@@ -40,23 +40,19 @@ void poweron_ri(struct ri_controller* ri)
 }
 
 
-int read_ri_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_ri_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t reg = ri_reg(address);
 
     *value = ri->regs[reg];
-
-    return 0;
 }
 
-int write_ri_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_ri_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct ri_controller* ri = (struct ri_controller*)opaque;
     uint32_t reg = ri_reg(address);
 
     masked_write(&ri->regs[reg], value, mask);
-
-    return 0;
 }
 

--- a/src/device/ri/ri_controller.h
+++ b/src/device/ri/ri_controller.h
@@ -58,7 +58,7 @@ void init_ri(struct ri_controller* ri,
 
 void poweron_ri(struct ri_controller* ri);
 
-int read_ri_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_ri_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_ri_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_ri_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 #endif

--- a/src/device/rsp/rsp_core.c
+++ b/src/device/rsp/rsp_core.c
@@ -172,28 +172,24 @@ void poweron_rsp(struct rsp_core* sp)
 }
 
 
-int read_rsp_mem(void* opaque, uint32_t address, uint32_t* value)
+void read_rsp_mem(void* opaque, uint32_t address, uint32_t* value)
 {
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t addr = rsp_mem_address(address);
 
     *value = sp->mem[addr];
-
-    return 0;
 }
 
-int write_rsp_mem(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_rsp_mem(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t addr = rsp_mem_address(address);
 
     masked_write(&sp->mem[addr], value, mask);
-
-    return 0;
 }
 
 
-int read_rsp_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_rsp_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t reg = rsp_reg(address);
@@ -204,11 +200,9 @@ int read_rsp_regs(void* opaque, uint32_t address, uint32_t* value)
     {
         sp->regs[SP_SEMAPHORE_REG] = 1;
     }
-
-    return 0;
 }
 
-int write_rsp_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_rsp_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t reg = rsp_reg(address);
@@ -219,7 +213,7 @@ int write_rsp_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         update_sp_status(sp, value & mask);
     case SP_DMA_FULL_REG:
     case SP_DMA_BUSY_REG:
-        return 0;
+        return;
     }
 
     masked_write(&sp->regs[reg], value, mask);
@@ -236,29 +230,23 @@ int write_rsp_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         sp->regs[SP_SEMAPHORE_REG] = 0;
         break;
     }
-
-    return 0;
 }
 
 
-int read_rsp_regs2(void* opaque, uint32_t address, uint32_t* value)
+void read_rsp_regs2(void* opaque, uint32_t address, uint32_t* value)
 {
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t reg = rsp_reg2(address);
 
     *value = sp->regs2[reg];
-
-    return 0;
 }
 
-int write_rsp_regs2(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_rsp_regs2(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct rsp_core* sp = (struct rsp_core*)opaque;
     uint32_t reg = rsp_reg2(address);
 
     masked_write(&sp->regs2[reg], value, mask);
-
-    return 0;
 }
 
 void do_SP_Task(struct rsp_core* sp)

--- a/src/device/rsp/rsp_core.h
+++ b/src/device/rsp/rsp_core.h
@@ -108,14 +108,14 @@ void init_rsp(struct rsp_core* sp,
 
 void poweron_rsp(struct rsp_core* sp);
 
-int read_rsp_mem(void* opaque, uint32_t address, uint32_t* value);
-int write_rsp_mem(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_rsp_mem(void* opaque, uint32_t address, uint32_t* value);
+void write_rsp_mem(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-int read_rsp_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_rsp_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_rsp_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_rsp_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
-int read_rsp_regs2(void* opaque, uint32_t address, uint32_t* value);
-int write_rsp_regs2(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_rsp_regs2(void* opaque, uint32_t address, uint32_t* value);
+void write_rsp_regs2(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void do_SP_Task(struct rsp_core* sp);
 

--- a/src/device/si/pif.c
+++ b/src/device/si/pif.c
@@ -315,7 +315,7 @@ void poweron_pif(struct pif* pif)
     }
 }
 
-int read_pif_ram(void* opaque, uint32_t address, uint32_t* value)
+void read_pif_ram(void* opaque, uint32_t address, uint32_t* value)
 {
     struct si_controller* si = (struct si_controller*)opaque;
     uint32_t addr = pif_ram_address(address);
@@ -324,16 +324,14 @@ int read_pif_ram(void* opaque, uint32_t address, uint32_t* value)
     {
         DebugMessage(M64MSG_ERROR, "Invalid PIF address: %08" PRIX32, address);
         *value = 0;
-        return -1;
+        return;
     }
 
     memcpy(value, si->pif.ram + addr, sizeof(*value));
     *value = sl(*value);
-
-    return 0;
 }
 
-int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct si_controller* si = (struct si_controller*)opaque;
     uint32_t addr = pif_ram_address(address);
@@ -341,14 +339,12 @@ int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     if (addr >= PIF_RAM_SIZE)
     {
         DebugMessage(M64MSG_ERROR, "Invalid PIF address: %08" PRIX32, address);
-        return -1;
+        return;
     }
 
     masked_write((uint32_t*)(&si->pif.ram[addr]), sl(value), sl(mask));
 
     process_pif_ram(si);
-
-    return 0;
 }
 
 

--- a/src/device/si/pif.h
+++ b/src/device/si/pif.h
@@ -129,8 +129,8 @@ void poweron_pif(struct pif* pif);
 
 void setup_channels_format(struct pif* pif);
 
-int read_pif_ram(void* opaque, uint32_t address, uint32_t* value);
-int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_pif_ram(void* opaque, uint32_t address, uint32_t* value);
+void write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void process_pif_ram(struct si_controller* si);
 void update_pif_ram(struct si_controller* si);

--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -109,17 +109,15 @@ void poweron_si(struct si_controller* si)
 }
 
 
-int read_si_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_si_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct si_controller* si = (struct si_controller*)opaque;
     uint32_t reg = si_reg(address);
 
     *value = si->regs[reg];
-
-    return 0;
 }
 
-int write_si_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_si_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct si_controller* si = (struct si_controller*)opaque;
     uint32_t reg = si_reg(address);
@@ -145,8 +143,6 @@ int write_si_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
         clear_rcp_interrupt(si->r4300, MI_INTR_SI);
         break;
     }
-
-    return 0;
 }
 
 void si_end_of_dma_event(void* opaque)

--- a/src/device/si/si_controller.h
+++ b/src/device/si/si_controller.h
@@ -75,8 +75,8 @@ void init_si(struct si_controller* si,
 
 void poweron_si(struct si_controller* si);
 
-int read_si_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_si_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_si_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_si_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void si_end_of_dma_event(void* opaque);
 

--- a/src/device/vi/vi_controller.c
+++ b/src/device/vi/vi_controller.c
@@ -73,7 +73,7 @@ void poweron_vi(struct vi_controller* vi)
     vi->count_per_scanline = 1500;
 }
 
-int read_vi_regs(void* opaque, uint32_t address, uint32_t* value)
+void read_vi_regs(void* opaque, uint32_t address, uint32_t* value)
 {
     struct vi_controller* vi = (struct vi_controller*)opaque;
     uint32_t reg = vi_reg(address);
@@ -95,11 +95,9 @@ int read_vi_regs(void* opaque, uint32_t address, uint32_t* value)
     }
 
     *value = vi->regs[reg];
-
-    return 0;
 }
 
-int write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct vi_controller* vi = (struct vi_controller*)opaque;
     uint32_t reg = vi_reg(address);
@@ -112,7 +110,7 @@ int write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
             masked_write(&vi->regs[VI_STATUS_REG], value, mask);
             gfx.viStatusChanged();
         }
-        return 0;
+        return;
 
     case VI_WIDTH_REG:
         if ((vi->regs[VI_WIDTH_REG] & mask) != (value & mask))
@@ -120,16 +118,14 @@ int write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
             masked_write(&vi->regs[VI_WIDTH_REG], value, mask);
             gfx.viWidthChanged();
         }
-        return 0;
+        return;
 
     case VI_CURRENT_REG:
         clear_rcp_interrupt(vi->r4300, MI_INTR_VI);
-        return 0;
+        return;
     }
 
     masked_write(&vi->regs[reg], value, mask);
-
-    return 0;
 }
 
 void vi_vertical_interrupt_event(void* opaque)

--- a/src/device/vi/vi_controller.h
+++ b/src/device/vi/vi_controller.h
@@ -74,8 +74,8 @@ void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected
 
 void poweron_vi(struct vi_controller* vi);
 
-int read_vi_regs(void* opaque, uint32_t address, uint32_t* value);
-int write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_vi_regs(void* opaque, uint32_t address, uint32_t* value);
+void write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 void vi_vertical_interrupt_event(void* opaque);
 


### PR DESCRIPTION
Some more refactorings which allows to get rid of dword memory accessors. Some more will come in this PR or later PR depending on feedback. Please test and report regressions.