### PR TITLE
Add CP0_ERROREPC_REG to MTC0

### DIFF
--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1465,6 +1465,9 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_TAGHI_REG:
         cp0_regs[CP0_TAGHI_REG] = 0;
         break;
+    case CP0_ERROREPC_REG:
+        cp0_regs[CP0_ERROREPC_REG] = rrt32;
+        break;
     default:
         DebugMessage(M64MSG_ERROR, "Unknown MTC0 write: %d", rfs);
         *r4300_stop(r4300)=1;


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-core/issues/323

(Allows NHL Breakaway 98 and WCW Backstage Assault to boot)