### PR TITLE
Updates to DisableExtraMem

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -5914,6 +5914,7 @@ GoodName=Iggy's Reckin' Balls (E) [!]
 CRC=D692CC5E EC58D072
 Players=2
 SaveType=Controller Pack
+DisableExtraMem=1
 
 [26CEC7A56ABB81F3468CFA26D8F16B67]
 GoodName=Iggy's Reckin' Balls (E) [o1]
@@ -5925,6 +5926,7 @@ GoodName=Iggy's Reckin' Balls (U) [!]
 CRC=E616B5BC C9658B88
 Players=2
 SaveType=Controller Pack
+DisableExtraMem=1
 
 [8BF0EAFB7014B7B5CE8E7D778B6B4B99]
 GoodName=Iggy's Reckin' Balls (U) [o1]
@@ -5936,6 +5938,7 @@ GoodName=Iggy-kun no Bura Bura Poyon (J) [!]
 CRC=69458B9E FC95F936
 Players=2
 SaveType=Controller Pack
+DisableExtraMem=1
 
 [827106236756DC5B585C4226184835FA]
 GoodName=Iggy-kun no Bura Bura Poyon (J) [o1]

--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -58,8 +58,6 @@ EXPORT m64p_error CALL CoreStartup(int APIVersion, const char *ConfigPath, const
                                    void (*DebugCallback)(void *, int, const char *), void *Context2,
                                    void (*StateCallback)(void *, m64p_core_param, int))
 {
-    unsigned int disable_extra_mem;
-
     if (l_CoreInit)
         return M64ERR_ALREADY_INIT;
 
@@ -95,11 +93,8 @@ EXPORT m64p_error CALL CoreStartup(int APIVersion, const char *ConfigPath, const
         return M64ERR_INTERNAL;
 
     /* allocate memory for rdram */
-    disable_extra_mem = ConfigGetParamInt(g_CoreConfig, "DisableExtraMem");
-    g_rdram_size = (disable_extra_mem == 0) ? 0x800000 : 0x400000;
     g_rdram = malloc(RDRAM_MAX_SIZE);
     if (g_rdram == NULL) {
-        g_rdram_size = 0;
         return M64ERR_NO_MEMORY;
     }
 
@@ -129,7 +124,6 @@ EXPORT m64p_error CALL CoreShutdown(void)
     /* deallocate RDRAM */
     free(g_rdram);
     g_rdram = NULL;
-    g_rdram_size = 0;
 
     l_CoreInit = 0;
     return M64ERR_SUCCESS;

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -40,7 +40,6 @@ extern int g_EmulatorRunning;
 extern int g_rom_pause;
 
 extern void* g_rdram;
-extern size_t g_rdram_size;
 
 extern struct device g_dev;
 

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -53,6 +53,8 @@ enum { DEFAULT_COUNT_PER_OP = 2 };
 enum { DEFAULT_ALTERNATE_VI_TIMING = 0 };
 /* by default, fixed audio position is disabled */
 enum { DEFAULT_FIXED_AUDIO_POS = 0 };
+/* by default, extra mem is enabled */
+enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
 
 static romdatabase_entry* ini_search_by_md5(md5_byte_t* md5);
 
@@ -181,6 +183,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
     ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
     ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
+    ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
     ROM_PARAMS.cheats = NULL;
 
     memcpy(ROM_PARAMS.headername, ROM_HEADER.Name, 20);
@@ -201,6 +204,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.vitiming = entry->alternate_vi_timing;
         ROM_PARAMS.fixedaudiopos = entry->fixed_audio_pos;
         ROM_PARAMS.countperscanline = entry->count_per_scanline;
+        ROM_PARAMS.disableextramem = entry->disableextramem;
         ROM_PARAMS.cheats = entry->cheats;
     }
     else
@@ -215,6 +219,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
         ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
         ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
+        ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
         ROM_PARAMS.cheats = NULL;
     }
 
@@ -457,6 +462,7 @@ void romdatabase_open(void)
             search->entry.alternate_vi_timing = DEFAULT_ALTERNATE_VI_TIMING;
             search->entry.fixed_audio_pos = DEFAULT_FIXED_AUDIO_POS;
             search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
+            search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
             search->entry.cheats = NULL;
             search->entry.set_flags = ROMDATABASE_ENTRY_NONE;
 
@@ -587,6 +593,10 @@ void romdatabase_open(void)
                 } else {
                     DebugMessage(M64MSG_WARNING, "ROM Database: Invalid CountPerOp on line %i", lineno);
                 }
+            }
+            else if (!strcmp(l.name, "DisableExtraMem"))
+            {
+                search->entry.disableextramem = atoi(l.value);
             }
             else if(!strncmp(l.name, "Cheat", 5))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -55,6 +55,7 @@ typedef struct _rom_params
    int vitiming;
    int fixedaudiopos;
    int countperscanline;
+   int disableextramem;
 } rom_params;
 
 extern m64p_rom_header   ROM_HEADER;
@@ -129,6 +130,7 @@ typedef struct
    unsigned char fixed_audio_pos;
    int count_per_scanline;
    unsigned char countperop;
+   unsigned char disableextramem;
    uint32_t set_flags;
 } romdatabase_entry;
 


### PR DESCRIPTION
This PR does a number of things:

It moves the initialization of (g_)rdram_size from CoreStartup to main_run, with the rest of the config variables. @bsmiles32 I didn't see any need for this to be a global, am I correct in my understanding?

It allows DisableExtraMem to be set in mupen64plus.ini, and enables it for Iggy's Reckin' Balls, where it is required.