### PR TITLE
Implement "Audio Signal"

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -3348,6 +3348,7 @@ CRC=D614E5BF A76DBCC1
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+AudioSignal=1
 
 [AF740B224E5DD0BD09F7254811559ADF]
 GoodName=Disney's Tarzan (E) [h1C]
@@ -3360,6 +3361,7 @@ CRC=001A3BD0 AFB3DE1A
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+AudioSignal=1
 
 [DF3CDD959E8C63B45F557FC197CE0E63]
 GoodName=Disney's Tarzan (G) [!]
@@ -3367,6 +3369,7 @@ CRC=4C261323 4F295E1A
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+AudioSignal=1
 
 [A29E203DDB6293B7D105BF4A2EEEDD1E]
 GoodName=Disney's Tarzan (G) [h1C]
@@ -3379,6 +3382,7 @@ CRC=CBFE69C7 F2C0AB2A
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
+AudioSignal=1
 
 [C56AD8ABD0FB5EFEF1FA0229F9A2EFF0]
 GoodName=Disney's Tarzan (U) [f1] (PAL)
@@ -5828,6 +5832,7 @@ CRC=B58988E9 B1FC4BE8
 Players=4
 SaveType=Controller Pack
 CountPerOp=1
+AudioSignal=1
 
 [1F57194EA272CF5DB500D228E9C94D75]
 GoodName=Hydro Thunder (E) [f1] (NTSC)
@@ -5840,6 +5845,7 @@ CRC=29A045CE ABA9060E
 Players=4
 SaveType=Controller Pack
 CountPerOp=1
+AudioSignal=1
 
 [54F43E6B68782E98CAABEA5E7976B2BE]
 GoodName=Hydro Thunder (U) [!]
@@ -5847,6 +5853,7 @@ CRC=C8DC65EB 3D8C8904
 SaveType=Controller Pack
 Players=4
 CountPerOp=1
+AudioSignal=1
 
 [22AAD544C062FB8A2DC6B2DEB32DE188]
 GoodName=Hydro Thunder (U) [b1]
@@ -9609,12 +9616,12 @@ RefMD5=C5EBBDD41EAEA8BD02CF520640CCCCDF
 
 [881E98B47F32093C330A8B0DAD6BB65D]
 GoodName=NBA Showtime - NBA on NBC (U) [!]
-; This game requires rsp-cxd4 with SupportCPUSemaphoreLock enabled
 CRC=3FFE80F4 A7C15F7E
 Players=4
 Rumble=Yes
 SaveType=Controller Pack
 CountPerOp=1
+AudioSignal=1
 
 [76DB89759121710C416ECFB1736B5E39]
 GoodName=NBA Showtime - NBA on NBC (U) [f1] (Country Check)
@@ -12032,6 +12039,7 @@ CRC=0AC61D39 ABFA03A6
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
+AudioSignal=1
 
 [207EFE58C7C221DBDFFF285AB80126C1]
 GoodName=Rugrats in Paris - The Movie (U) [!]
@@ -12039,6 +12047,7 @@ CRC=1FC21532 0B6466D4
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
+AudioSignal=1
 
 [F3515A45EC01D2C9FEAFBAB2B85D72C4]
 GoodName=Rugrats in Paris - The Movie (U) [T+Spa0.10]

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -53,6 +53,8 @@ void init_device(struct device* dev,
     uint16_t eeprom_id, struct storage_backend* eeprom_storage,
     struct clock_backend* clock,
     unsigned int delay_si,
+    /* sp */
+    unsigned int audio_signal,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline, unsigned int alternate_timing)
 {
@@ -74,7 +76,7 @@ void init_device(struct device* dev,
     init_r4300(&dev->r4300, &dev->mem, &dev->ri, interrupt_handlers,
             emumode, count_per_op, no_compiled_jump);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
-    init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri);
+    init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri, audio_signal);
     init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, fixed_audio_pos);
     init_pi(&dev->pi, rom, rom_size, flashram_storage, sram_storage, &dev->r4300, &dev->ri, &dev->si.pif.cic);
     init_ri(&dev->ri, dram, dram_size);

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -78,6 +78,8 @@ void init_device(struct device* dev,
     uint16_t eeprom_id, struct storage_backend* eeprom_storage,
     struct clock_backend* clock,
     unsigned int delay_si,
+    /* sp */
+    unsigned int audio_signal,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline, unsigned int alternate_timing);
 

--- a/src/device/rsp/rsp_core.c
+++ b/src/device/rsp/rsp_core.c
@@ -113,7 +113,11 @@ static void update_sp_status(struct rsp_core* sp, uint32_t w)
 
     /* clear / set signal 0 */
     if (w & 0x200) sp->regs[SP_STATUS_REG] &= ~SP_STATUS_SIG0;
-    if (w & 0x400) sp->regs[SP_STATUS_REG] |= SP_STATUS_SIG0;
+    if (w & 0x400) {
+        sp->regs[SP_STATUS_REG] |= SP_STATUS_SIG0;
+        if (sp->audio_signal)
+            signal_rcp_interrupt(sp->r4300, MI_INTR_SP);
+    }
 
     /* clear / set signal 1 */
     if (w & 0x800) sp->regs[SP_STATUS_REG] &= ~SP_STATUS_SIG1;
@@ -154,11 +158,13 @@ static void update_sp_status(struct rsp_core* sp, uint32_t w)
 void init_rsp(struct rsp_core* sp,
               struct r4300_core* r4300,
               struct rdp_core* dp,
-              struct ri_controller* ri)
+              struct ri_controller* ri,
+              uint32_t audio_signal)
 {
     sp->r4300 = r4300;
     sp->dp = dp;
     sp->ri = ri;
+    sp->audio_signal = audio_signal;
 }
 
 void poweron_rsp(struct rsp_core* sp)

--- a/src/device/rsp/rsp_core.h
+++ b/src/device/rsp/rsp_core.h
@@ -80,6 +80,7 @@ struct rsp_core
     uint32_t regs[SP_REGS_COUNT];
     uint32_t regs2[SP_REGS2_COUNT];
     uint32_t rsp_task_locked;
+    uint32_t audio_signal;
 
     struct r4300_core* r4300;
     struct rdp_core* dp;
@@ -104,7 +105,8 @@ static uint32_t rsp_reg2(uint32_t address)
 void init_rsp(struct rsp_core* sp,
               struct r4300_core* r4300,
               struct rdp_core* dp,
-              struct ri_controller* ri);
+              struct ri_controller* ri,
+              uint32_t audio_signal);
 
 void poweron_rsp(struct rsp_core* sp);
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1095,6 +1095,7 @@ m64p_error main_run(void)
                 (ROM_SETTINGS.savetype != EEPROM_16KB) ? 0x8000 : 0xc000, &eep_storage,
                 &clock,
                 delay_si,
+                ROM_PARAMS.audiosignal,
                 vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype), count_per_scanline, alternate_vi_timing);
 
     // Attach rom to plugins

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -55,6 +55,8 @@ enum { DEFAULT_ALTERNATE_VI_TIMING = 0 };
 enum { DEFAULT_FIXED_AUDIO_POS = 0 };
 /* by default, extra mem is enabled */
 enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
+/* by default, Audio Signal is disabled */
+enum { DEFAULT_AUDIO_SIGNAL = 0 };
 
 static romdatabase_entry* ini_search_by_md5(md5_byte_t* md5);
 
@@ -182,6 +184,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
     ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
     ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
+    ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
     ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
     ROM_PARAMS.cheats = NULL;
@@ -203,6 +206,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.countperop = entry->countperop;
         ROM_PARAMS.vitiming = entry->alternate_vi_timing;
         ROM_PARAMS.fixedaudiopos = entry->fixed_audio_pos;
+        ROM_PARAMS.audiosignal = entry->audio_signal;
         ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.disableextramem = entry->disableextramem;
         ROM_PARAMS.cheats = entry->cheats;
@@ -218,6 +222,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
         ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
         ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
+        ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
         ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
         ROM_PARAMS.cheats = NULL;
@@ -461,6 +466,7 @@ void romdatabase_open(void)
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
             search->entry.alternate_vi_timing = DEFAULT_ALTERNATE_VI_TIMING;
             search->entry.fixed_audio_pos = DEFAULT_FIXED_AUDIO_POS;
+            search->entry.audio_signal = DEFAULT_AUDIO_SIGNAL;
             search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
             search->entry.cheats = NULL;
@@ -515,6 +521,10 @@ void romdatabase_open(void)
             else if(!strcmp(l.name, "FixedAudioPos"))
             {
                 search->entry.fixed_audio_pos = atoi(l.value);
+            }
+            else if (!strcmp(l.name, "AudioSignal"))
+            {
+                search->entry.audio_signal = atoi(l.value);
             }
             else if(!strcmp(l.name, "CountPerScanline"))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -54,6 +54,7 @@ typedef struct _rom_params
    unsigned char countperop;
    int vitiming;
    int fixedaudiopos;
+   int audiosignal;
    int countperscanline;
    int disableextramem;
 } rom_params;
@@ -128,6 +129,7 @@ typedef struct
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
    unsigned char alternate_vi_timing;
    unsigned char fixed_audio_pos;
+   unsigned char audio_signal;
    int count_per_scanline;
    unsigned char countperop;
    unsigned char disableextramem;


### PR DESCRIPTION
PR https://github.com/mupen64plus/mupen64plus-core/pull/307 actually broke a few games (NBA on NBC, Hydro Thunder).

Project64 has a setting/hack called "RSP Audio Signal" https://github.com/project64/project64/blob/master/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp#L1148-L1152

This fixes games like Hydro Thunder and NBA on NBC. I tested it and it works here as well. It is enabled for: NBA on NBC, Hydro Thunder, Tarzan, and Rugrats in Paris (these games were taken from the Project64 RDB)

Of course we could also revert #307, but I think that was a positive change, it simplified the code and allowed us to remove the strange Perfect Dark hack that was in place, it also fixed freezing in Top Gear Rally 2.