### PR TITLE
Add hack for Rat Attack!

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -11701,6 +11701,7 @@ CRC=20FD0BF1 F5CF1D87
 Players=4
 Rumble=Yes
 SaveType=Controller Pack
+CountPerOp=1
 
 [E0BB65C30C1185FD9997020A1994B07E]
 GoodName=Rat Attack (E) (M6) [f1] (NTSC)

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -37,6 +37,7 @@ void init_device(struct device* dev,
     unsigned int emumode,
     unsigned int count_per_op,
     int no_compiled_jump,
+    int special_rom,
     /* ai */
     struct audio_out_backend* aout,
     /* pi */
@@ -74,7 +75,7 @@ void init_device(struct device* dev,
     };
 
     init_r4300(&dev->r4300, &dev->mem, &dev->ri, interrupt_handlers,
-            emumode, count_per_op, no_compiled_jump);
+            emumode, count_per_op, no_compiled_jump, special_rom);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
     init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri, audio_signal);
     init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout);

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -62,6 +62,7 @@ void init_device(struct device* dev,
     unsigned int emumode,
     unsigned int count_per_op,
     int no_compiled_jump,
+    int special_rom,
     /* ai */
     struct audio_out_backend* aout,
     /* pi */

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -2097,6 +2097,8 @@ void *get_addr_32(u_int vaddr,u_int flags)
 
 void *TLB_refill_exception_new(u_int inst_addr,u_int mem_addr,int w)
 {
+  if (g_dev.r4300.special_rom == RAT_ATTACK)
+    return get_addr_ht(0x80000000);
   int i;
   uint32_t* cp0_regs = r4300_cp0_regs(&g_dev.r4300.cp0);
 

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -41,7 +41,7 @@
 #include <string.h>
 
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump)
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom)
 {
     struct new_dynarec_hot_state* new_dynarec_hot_state =
 #if NEW_DYNAREC == NEW_DYNAREC_ARM
@@ -58,6 +58,7 @@ void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controll
 
     r4300->mem = mem;
     r4300->ri = ri;
+    r4300->special_rom = special_rom;
 }
 
 void poweron_r4300(struct r4300_core* r4300)

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -202,9 +202,11 @@ struct r4300_core
 
     struct memory* mem;
     struct ri_controller* ri;
+
+    uint32_t special_rom;
 };
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump);
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom);
 void poweron_r4300(struct r4300_core* r4300);
 
 void run_r4300(struct r4300_core* r4300);

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -103,7 +103,7 @@ void tlb_map(struct tlb* tlb, size_t entry)
 
 uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address, int w)
 {
-    if (address >= UINT32_C(0x7f000000) && address < UINT32_C(0x80000000) && isGoldeneyeRom)
+    if (address >= UINT32_C(0x7f000000) && address < UINT32_C(0x80000000) && r4300->special_rom == GOLDEN_EYE)
     {
         /**************************************************
          GoldenEye 007 hack allows for use of TLB.
@@ -141,7 +141,8 @@ uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address,
     }
     //printf("tlb exception !!! @ %x, %x, add:%x\n", address, w, r4300->pc->addr);
     //getchar();
-    TLB_refill_exception(r4300, address, w);
+    if (r4300->special_rom != RAT_ATTACK)
+        TLB_refill_exception(r4300, address, w);
     //return 0x80000000;
     return 0x00000000;
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1087,6 +1087,7 @@ m64p_error main_run(void)
                 emumode,
                 count_per_op,
                 no_compiled_jump,
+                ROM_PARAMS.special_rom,
                 &aout,
                 g_rom, g_rom_size,
                 &fla_storage,

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -66,7 +66,6 @@ static _romdatabase g_romdatabase;
 unsigned char* g_rom = NULL;
 /* Global loaded rom size. */
 int g_rom_size = 0;
-unsigned char isGoldeneyeRom = 0;
 
 m64p_rom_header   ROM_HEADER;
 rom_params        ROM_PARAMS;
@@ -248,10 +247,12 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     DebugMessage(M64MSG_VERBOSE, "PC = %" PRIX32, sl(ROM_HEADER.PC));
     DebugMessage(M64MSG_VERBOSE, "Save type: %d", ROM_SETTINGS.savetype);
 
-    //Prepare Hack for GOLDENEYE
-    isGoldeneyeRom = 0;
     if(strcmp(ROM_PARAMS.headername, "GOLDENEYE") == 0)
-       isGoldeneyeRom = 1;
+        ROM_PARAMS.special_rom = GOLDEN_EYE;
+    else if (strcmp(ROM_PARAMS.headername, "RAT ATTACK") == 0)
+        ROM_PARAMS.special_rom = RAT_ATTACK;
+    else
+        ROM_PARAMS.special_rom = NORMAL_ROM;
 
     return M64ERR_SUCCESS;
 }

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -44,8 +44,6 @@ m64p_error close_rom(void);
 extern unsigned char* g_rom;
 extern int g_rom_size;
 
-extern unsigned char isGoldeneyeRom;
-
 typedef struct _rom_params
 {
    char *cheats;
@@ -57,6 +55,7 @@ typedef struct _rom_params
    int countperscanline;
    int disableextramem;
    int delaysi;
+   int special_rom;
 } rom_params;
 
 extern m64p_rom_header   ROM_HEADER;
@@ -101,6 +100,14 @@ enum
     FLASH_RAM,
     CONTROLLER_PACK,
     NONE
+};
+
+/*ROM specific hacks */
+enum
+{
+    NORMAL_ROM,
+    GOLDEN_EYE,
+    RAT_ATTACK
 };
 
 /* Rom INI database structures and functions */


### PR DESCRIPTION
Yes I know... another game specific hack. Project64 employs a similar hack (they disable TLB for the game).

I also took the opportunity to remove the global variable, and I used the same variable for the GoldenEye, and now Rat Attack, hack.

I'm open to suggestions on variables names, I was never very good at naming things...