### PR TITLE
Fix Indiana Jones

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -5962,12 +5962,16 @@ GoodName=Indiana Jones and the Infernal Machine (U) [!]
 CRC=AF9DCC15 1A723D88
 Players=1
 SaveType=Eeprom 4KB
+CountPerOp=1
+CountPerScanline=2200
 
 [6F417D30D772F4420C9384E9BBB7BC01]
 GoodName=Indiana Jones and the Infernal Machine (E)
 CRC=3A6F8C6B 2897BAEB
 SaveType=Eeprom 4KB
 Players=1
+CountPerOp=1
+CountPerScanline=2200
 
 [A7781D441AF55C4FF8AFC68AB3A59313]
 GoodName=Indy Racing 2000 (U) [!]

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -37,6 +37,7 @@ void init_device(struct device* dev,
     unsigned int emumode,
     unsigned int count_per_op,
     int no_compiled_jump,
+    int special_rom,
     /* ai */
     struct audio_out_backend* aout, unsigned int fixed_audio_pos,
     /* pi */
@@ -72,7 +73,7 @@ void init_device(struct device* dev,
     };
 
     init_r4300(&dev->r4300, &dev->mem, &dev->ri, interrupt_handlers,
-            emumode, count_per_op, no_compiled_jump);
+            emumode, count_per_op, no_compiled_jump, special_rom);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
     init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri);
     init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, fixed_audio_pos);

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -62,6 +62,7 @@ void init_device(struct device* dev,
     unsigned int emumode,
     unsigned int count_per_op,
     int no_compiled_jump,
+    int special_rom,
     /* ai */
     struct audio_out_backend* aout, unsigned int fixed_audio_pos,
     /* pi */

--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -31,6 +31,7 @@
 #include "device/r4300/r4300_core.h"
 #include "device/ri/rdram_detection_hack.h"
 #include "device/ri/ri_controller.h"
+#include "main/rom.h"
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -72,7 +73,7 @@ static void dma_pi_read(struct pi_controller* pi)
 
     /* schedule end of dma interrupt event */
     cp0_update_count(pi->r4300);
-    add_interrupt_event(&pi->r4300->cp0, PI_INT, 0x1000/*pi->regs[PI_RD_LEN_REG]*/); /* XXX: 0x1000 ??? */
+    add_interrupt_event(&pi->r4300->cp0, PI_INT, 0x1000 / pi->interrupt_mod /*pi->regs[PI_RD_LEN_REG]*/); /* XXX: 0x1000 ??? */
 }
 
 static void dma_pi_write(struct pi_controller* pi)
@@ -111,7 +112,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count(pi->r4300);
-        add_interrupt_event(&pi->r4300->cp0, PI_INT, /*pi->regs[PI_WR_LEN_REG]*/0x1000); /* XXX: 0x1000 ??? */
+        add_interrupt_event(&pi->r4300->cp0, PI_INT, /*pi->regs[PI_WR_LEN_REG]*/0x1000 / pi->interrupt_mod); /* XXX: 0x1000 ??? */
 
         return;
     }
@@ -124,7 +125,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count(pi->r4300);
-        add_interrupt_event(&pi->r4300->cp0, PI_INT, 0x1000); /* XXX: 0x1000 ??? */
+        add_interrupt_event(&pi->r4300->cp0, PI_INT, 0x1000 / pi->interrupt_mod); /* XXX: 0x1000 ??? */
 
         return;
     }
@@ -144,7 +145,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
         /* schedule end of dma interrupt event */
         cp0_update_count(pi->r4300);
-        add_interrupt_event(&pi->r4300->cp0, PI_INT, longueur/8);
+        add_interrupt_event(&pi->r4300->cp0, PI_INT, longueur/8 / pi->interrupt_mod);
 
         return;
     }
@@ -175,7 +176,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
     /* schedule end of dma interrupt event */
     cp0_update_count(pi->r4300);
-    add_interrupt_event(&pi->r4300->cp0, PI_INT, longueur/8);
+    add_interrupt_event(&pi->r4300->cp0, PI_INT, longueur/8 / pi->interrupt_mod);
 }
 
 
@@ -197,6 +198,8 @@ void init_pi(struct pi_controller* pi,
     pi->ri = ri;
 
     pi->cic = cic;
+
+    pi->interrupt_mod = r4300->special_rom == INDIANA_JONES ? 2 : 1;
 }
 
 void poweron_pi(struct pi_controller* pi)

--- a/src/device/pi/pi_controller.h
+++ b/src/device/pi/pi_controller.h
@@ -62,6 +62,8 @@ struct pi_controller
 
     int use_flashram;
 
+    int interrupt_mod;
+
     struct r4300_core* r4300;
     struct ri_controller* ri;
 

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -2097,6 +2097,8 @@ void *get_addr_32(u_int vaddr,u_int flags)
 
 void *TLB_refill_exception_new(u_int inst_addr,u_int mem_addr,int w)
 {
+  if (g_dev.r4300.special_rom == RAT_ATTACK)
+    return get_addr_ht(0x80000000);
   int i;
   uint32_t* cp0_regs = r4300_cp0_regs(&g_dev.r4300.cp0);
 

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -41,7 +41,7 @@
 #include <string.h>
 
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump)
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom)
 {
     struct new_dynarec_hot_state* new_dynarec_hot_state =
 #if NEW_DYNAREC == NEW_DYNAREC_ARM
@@ -58,6 +58,7 @@ void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controll
 
     r4300->mem = mem;
     r4300->ri = ri;
+    r4300->special_rom = special_rom;
 }
 
 void poweron_r4300(struct r4300_core* r4300)

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -202,9 +202,11 @@ struct r4300_core
 
     struct memory* mem;
     struct ri_controller* ri;
+
+    uint32_t special_rom;
 };
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump);
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom);
 void poweron_r4300(struct r4300_core* r4300);
 
 void run_r4300(struct r4300_core* r4300);

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -103,7 +103,7 @@ void tlb_map(struct tlb* tlb, size_t entry)
 
 uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address, int w)
 {
-    if (address >= UINT32_C(0x7f000000) && address < UINT32_C(0x80000000) && isGoldeneyeRom)
+    if (address >= UINT32_C(0x7f000000) && address < UINT32_C(0x80000000) && r4300->special_rom == GOLDEN_EYE)
     {
         /**************************************************
          GoldenEye 007 hack allows for use of TLB.
@@ -141,7 +141,8 @@ uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address,
     }
     //printf("tlb exception !!! @ %x, %x, add:%x\n", address, w, r4300->pc->addr);
     //getchar();
-    TLB_refill_exception(r4300, address, w);
+    if (r4300->special_rom != RAT_ATTACK)
+        TLB_refill_exception(r4300, address, w);
     //return 0x80000000;
     return 0x00000000;
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1083,6 +1083,7 @@ m64p_error main_run(void)
                 emumode,
                 count_per_op,
                 no_compiled_jump,
+                ROM_PARAMS.special_rom,
                 &aout, ROM_PARAMS.fixedaudiopos,
                 g_rom, g_rom_size,
                 &fla_storage,

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -246,6 +246,8 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.special_rom = GOLDEN_EYE;
     else if (strcmp(ROM_PARAMS.headername, "RAT ATTACK") == 0)
         ROM_PARAMS.special_rom = RAT_ATTACK;
+    else if (strcmp(ROM_PARAMS.headername, "Indiana Jones") == 0)
+        ROM_PARAMS.special_rom = INDIANA_JONES;
     else
         ROM_PARAMS.special_rom = NORMAL_ROM;
 

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -64,7 +64,6 @@ static _romdatabase g_romdatabase;
 unsigned char* g_rom = NULL;
 /* Global loaded rom size. */
 int g_rom_size = 0;
-unsigned char isGoldeneyeRom = 0;
 
 m64p_rom_header   ROM_HEADER;
 rom_params        ROM_PARAMS;
@@ -243,10 +242,12 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     DebugMessage(M64MSG_VERBOSE, "PC = %" PRIX32, sl(ROM_HEADER.PC));
     DebugMessage(M64MSG_VERBOSE, "Save type: %d", ROM_SETTINGS.savetype);
 
-    //Prepare Hack for GOLDENEYE
-    isGoldeneyeRom = 0;
     if(strcmp(ROM_PARAMS.headername, "GOLDENEYE") == 0)
-       isGoldeneyeRom = 1;
+        ROM_PARAMS.special_rom = GOLDEN_EYE;
+    else if (strcmp(ROM_PARAMS.headername, "RAT ATTACK") == 0)
+        ROM_PARAMS.special_rom = RAT_ATTACK;
+    else
+        ROM_PARAMS.special_rom = NORMAL_ROM;
 
     return M64ERR_SUCCESS;
 }

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -44,8 +44,6 @@ m64p_error close_rom(void);
 extern unsigned char* g_rom;
 extern int g_rom_size;
 
-extern unsigned char isGoldeneyeRom;
-
 typedef struct _rom_params
 {
    char *cheats;
@@ -56,6 +54,7 @@ typedef struct _rom_params
    int fixedaudiopos;
    int countperscanline;
    int disableextramem;
+   int special_rom;
 } rom_params;
 
 extern m64p_rom_header   ROM_HEADER;
@@ -100,6 +99,14 @@ enum
     FLASH_RAM,
     CONTROLLER_PACK,
     NONE
+};
+
+/*ROM specific hacks */
+enum
+{
+    NORMAL_ROM,
+    GOLDEN_EYE,
+    RAT_ATTACK
 };
 
 /* Rom INI database structures and functions */

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -106,7 +106,8 @@ enum
 {
     NORMAL_ROM,
     GOLDEN_EYE,
-    RAT_ATTACK
+    RAT_ATTACK,
+    INDIANA_JONES
 };
 
 /* Rom INI database structures and functions */


### PR DESCRIPTION
This PR is dependent on https://github.com/mupen64plus/mupen64plus-core/pull/330. Fixes https://github.com/mupen64plus/mupen64plus-core/issues/331

I would like someone to test this and review before it's merged, I don't mind if it sits here for a while.

This does a number of things:
It sets CountPerOp=1 and CountPerScanline=2200. This fixes random freezing and some graphical glitches

It also introduces ```pi->interrupt_mod```, basically, for Indiana Jones, it divides the pi interrupt timers by 2. This fixes the black screen/hanging at the end of the levels. I think this is acceptable, since the current value (0x1000 usually), seems like a guess/approximation.

I played through the first 2 levels using the x64 dynarec without issue. But like I said, I would like someone else to test/comment before it's merged. This was mostly the result of trial/error.

I tested the U rom, I did not test the PAL rom