### PR TITLE
[WIP] Transfer pak connection to frontend

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus-Plugin-Parameters.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-Plugin-Parameters.mediawiki
@@ -263,7 +263,7 @@ The Mupen64Plus-Input-SDL plugin uses a separate config section for each simulat
 |-
 |plugin
 |M64TYPE_INT
-|Specifies which type of expansion pak is in the controller: 1=None, 2=Mem pak, 5=Rumble pak
+|Specifies which type of expansion pak is in the controller: 1=None, 2=Mem pak, 4=Transfer pak, 5=Rumble pak
 |-
 |mouse
 |M64TYPE_BOOL
@@ -280,6 +280,14 @@ The Mupen64Plus-Input-SDL plugin uses a separate config section for each simulat
 |AnalogPeak
 |M64TYPE_STRING
 |An absolute value of the SDL joystick axis >= AnalogPeak will saturate the N64 controller axis value (at 80).  For X, Y axes. For each axis, this must be greater than the corresponding AnalogDeadzone value
+|-
+|GBRomFile
+|M64TYPE_STRING
+|Filepath pointing to a GB Cart ROM file. Used if plugin = 4 (Transfer Pak).
+|-
+|GBSaveFile
+|M64TYPE_STRING
+|Filepath pointing to a GB Cart RAM (Save) file. Used if plugin = 4 (Transfer Pak).
 |-
 |}
 

--- a/doc/emuwiki-api-doc/Mupen64Plus-v2.0-API-Versioning.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-v2.0-API-Versioning.mediawiki
@@ -112,3 +112,5 @@ This is the most complicated interface, because it involves 3 components: the vi
 ** add (optional) RenderCallback function to input plugin. This function is called by the core after rendering on screen text (OSD) and before the graphics plugin swaps the buffers. The purpose of this function is to enable the input plugin to draw on screen content, for example buttons in a touch input plugin. If this function is not present the core will ignore it and on screen rendering by the input plugin will be disabled.
 * '''CONFIG_API_VERSION''' version 2.3.1:
 ** add new functions "ConfigExternalOpen()" "ConfigExternalClose()" "ConfigExternalGetParameter()" that allows plugins to leverage the core INI parser to read config files.
+* '''INPUT_API_VERSION''' version 2.0.2:
+** add new function "GetGBCartInfo". This function is called by the core to obtain the filepath to GB ROM and RAM (save) files.

--- a/doc/emuwiki-api-doc/Mupen64Plus-v2.0-Plugin-API.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-v2.0-Plugin-API.mediawiki
@@ -224,6 +224,9 @@ These functions are present in all of the plugins.
 |-
 |<tt>void SDL_KeyUp(int keymod, int keysym);</tt>
 |Pass a SDL_KEYUP-style message to the input plugin
+|-
+|<tt>void GetGBCartInfo(int Controller, const char **RomFile, const char **SaveFile);</tt>
+|Pass GB Cart filepaths to emulator core.
 |}
 
 === Remove From Older Input API ===

--- a/src/api/m64p_plugin.h
+++ b/src/api/m64p_plugin.h
@@ -245,6 +245,7 @@ typedef void (*ptr_InitiateControllers)(CONTROL_INFO ControlInfo);
 typedef void (*ptr_ReadController)(int Control, unsigned char *Command);
 typedef void (*ptr_SDL_KeyDown)(int keymod, int keysym);
 typedef void (*ptr_SDL_KeyUp)(int keymod, int keysym);
+typedef void (*ptr_GetGBCartInfo)(int Controller, const char **RomFile, const char **SaveFile);
 typedef void (*ptr_RenderCallback)(void);
 #if defined(M64P_PLUGIN_PROTOTYPES)
 EXPORT void CALL ControllerCommand(int Control, unsigned char *Command);
@@ -253,6 +254,7 @@ EXPORT void CALL InitiateControllers(CONTROL_INFO ControlInfo);
 EXPORT void CALL ReadController(int Control, unsigned char *Command);
 EXPORT void CALL SDL_KeyDown(int keymod, int keysym);
 EXPORT void CALL SDL_KeyUp(int keymod, int keysym);
+EXPORT void CALL GetGBCartInfo(int Controller, const char **RomFile, const char **SaveFile);
 EXPORT void CALL RenderCallback(void);
 #endif
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -100,22 +100,6 @@ void* g_rdram = NULL;
 
 struct device g_dev;
 
-/* Gameboy roms to load in transfer pak */
-/* TODO: allow ui to pass the gb rom file to the core */
-char* g_gb_rom_files[GAME_CONTROLLERS_COUNT] = {
-#if 0
-    "./pkmb.gb",
-    "./mtennis.gbc",
-    "./pd.gbc",
-    "./pkmc.gbc",
-#else
-    NULL,
-    NULL,
-    NULL,
-    NULL
-#endif
-};
-
 int g_gs_vi_counter = 0;
 
 /** static (local) variables **/
@@ -170,16 +154,6 @@ static char *get_flashram_path(void)
 {
     return formatstr("%s%s.fla", get_savesrampath(), ROM_SETTINGS.goodname);
 }
-
-static char *get_gbsav_path(unsigned int controller)
-{
-    /* gb save files names are suffixed with the controller number
-     * to avoid multiple controllers to write to the same save file.
-     */
-    const char* name = namefrompath(g_gb_rom_files[controller]);
-    return formatstr("%s%s.%u.sav", get_savesrampath(), name, controller);
-}
-
 
 /*********************************************************************************************************
 * helper functions
@@ -1032,6 +1006,7 @@ m64p_error main_run(void)
     sra_storage = (struct storage_backend){ sra.data, sra.size, &sra, save_file_storage };
     eep_storage = (struct storage_backend){ eep.data, (ROM_SETTINGS.savetype != EEPROM_16KB) ? PIF_PDT_EEPROM_4K : PIF_PDT_EEPROM_16K, &eep, save_file_storage };
 
+    int gb_init[GAME_CONTROLLERS_COUNT];
     /* setup game controllers data */
     for(i = 0; i < GAME_CONTROLLERS_COUNT; ++i)
     {
@@ -1040,18 +1015,19 @@ m64p_error main_run(void)
         mpk_storages[i] = (struct storage_backend){ mpk.data + i * MEMPAK_SIZE, MEMPAK_SIZE, &mpk, save_file_storage };
         rumbles[i] = (struct rumble_backend){ &channels[i], rvip_exec };
 
-        if (g_gb_rom_files[i] != NULL)
+        const char* gbsav_path = NULL;
+        const char* gbrom_path = NULL;
+        if (input.getGBCartInfo)
+            input.getGBCartInfo(i, &gbrom_path, &gbsav_path);
+        if (gbrom_path != NULL && gbsav_path != NULL && strcmp(gbrom_path, "") != 0)
         {
-            char* gbsav_path = get_gbsav_path(i);
-            char* gbrom_path = strdup(g_gb_rom_files[i]);
-
             gb_carts_rom[i].data = NULL;
             gb_carts_rom[i].size = 0;
-            gb_carts_rom[i].filename = gbrom_path;
+            gb_carts_rom[i].filename = strdup(gbrom_path);
 
             gb_carts_ram[i].data = NULL;
             gb_carts_ram[i].size = 0;
-            gb_carts_ram[i].filename = gbsav_path;
+            gb_carts_ram[i].filename = strdup(gbsav_path);
 
             if (init_gb_cart(&gb_carts[i],
                              &gb_carts_rom[i], init_gb_rom,
@@ -1061,7 +1037,14 @@ m64p_error main_run(void)
                 /* could not load gb rom file so invalidate it and release other resources */
                 close_file_storage(&gb_carts_rom[i]);
                 close_file_storage(&gb_carts_ram[i]);
-                g_gb_rom_files[i] = NULL;
+                memset(&gb_carts[i], 0, sizeof(struct gb_cart));
+                memset(&gb_carts_rom[i], 0, sizeof(struct file_storage));
+                memset(&gb_carts_ram[i], 0, sizeof(struct file_storage));
+                gb_init[i] = 0;
+            }
+            else
+            {
+                gb_init[i] = 1;
             }
         }
         else
@@ -1069,6 +1052,7 @@ m64p_error main_run(void)
             memset(&gb_carts[i], 0, sizeof(struct gb_cart));
             memset(&gb_carts_rom[i], 0, sizeof(struct file_storage));
             memset(&gb_carts_ram[i], 0, sizeof(struct file_storage));
+            gb_init[i] = 0;
         }
     }
 
@@ -1151,7 +1135,7 @@ m64p_error main_run(void)
 #endif
     /* release gb_carts */
     for(i = 0; i < GAME_CONTROLLERS_COUNT; ++i) {
-        if (g_gb_rom_files[i] != NULL) {
+        if (gb_init[i]) {
             close_file_storage(&gb_carts_rom[i]);
             close_file_storage(&gb_carts_ram[i]);
         }
@@ -1185,7 +1169,7 @@ on_audio_open_failure:
 on_gfx_open_failure:
     /* release gb_carts */
     for(i = 0; i < GAME_CONTROLLERS_COUNT; ++i) {
-        if (g_gb_rom_files[i] != NULL) {
+        if (gb_init[i]) {
             close_file_storage(&gb_carts_rom[i]);
             close_file_storage(&gb_carts_ram[i]);
         }

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -43,8 +43,6 @@ extern void* g_rdram;
 
 extern struct device g_dev;
 
-extern char* g_gb_rom_files[GAME_CONTROLLERS_COUNT];
-
 extern m64p_frame_callback g_FrameCallback;
 
 extern int g_gs_vi_counter;

--- a/src/plugin/dummy_input.c
+++ b/src/plugin/dummy_input.c
@@ -82,4 +82,6 @@ void dummyinput_SDL_KeyUp(int keymod, int keysym)
 {
 }
 
-
+void dummyinput_GetGBCartInfo(int Controller, const char **RomFile, const char **SaveFile)
+{
+}

--- a/src/plugin/dummy_input.h
+++ b/src/plugin/dummy_input.h
@@ -37,6 +37,7 @@ extern int  dummyinput_RomOpen(void);
 extern void dummyinput_RomClosed(void);
 extern void dummyinput_SDL_KeyDown(int keymod, int keysym);
 extern void dummyinput_SDL_KeyUp(int keymod, int keysym);
+extern void dummyinput_GetGBCartInfo(int Controller, const char **RomFile, const char **SaveFile);
 
 #endif /* DUMMY_INPUT_H */
 

--- a/src/plugin/emulate_game_controller_via_input_plugin.c
+++ b/src/plugin/emulate_game_controller_via_input_plugin.c
@@ -45,11 +45,6 @@ int egcvip_is_connected(void* opaque, enum pak_type* pak)
         *pak = PAK_RUMBLE; break;
     }
 
-    /* Force transfer pak if core has loaded a gb cart for this controller */
-    if (g_dev.si.pif.controllers[channel].transferpak.gb_cart != NULL) {
-        *pak = PAK_TRANSFER;
-    }
-
     return c->Present;
 }
 

--- a/src/plugin/plugin.c
+++ b/src/plugin/plugin.c
@@ -99,7 +99,8 @@ static const input_plugin_functions dummy_input = {
     dummyinput_RomClosed,
     dummyinput_RomOpen,
     dummyinput_SDL_KeyDown,
-    dummyinput_SDL_KeyUp
+    dummyinput_SDL_KeyUp,
+    dummyinput_GetGBCartInfo
 };
 
 static const rsp_plugin_functions dummy_rsp = {
@@ -370,6 +371,9 @@ static m64p_error plugin_connect_input(m64p_dynlib_handle plugin_handle)
             plugin_disconnect_input();
             return M64ERR_INPUT_INVALID;
         }
+
+        if (!GET_FUNC(ptr_GetGBCartInfo, input.getGBCartInfo, "GetGBCartInfo"))
+            DebugMessage(M64MSG_WARNING, "No Transfer Pak support in input plugin.");
 
         /* check the version info */
         (*input.getVersion)(&PluginType, &PluginVersion, &APIVersion, NULL, NULL);

--- a/src/plugin/plugin.h
+++ b/src/plugin/plugin.h
@@ -37,7 +37,7 @@ extern CONTROL Controls[4];
 #define RSP_API_VERSION   0x20000
 #define GFX_API_VERSION   0x20200
 #define AUDIO_API_VERSION 0x20000
-#define INPUT_API_VERSION 0x20001
+#define INPUT_API_VERSION 0x20002
 
 /* video plugin function pointers */
 typedef struct _gfx_plugin_functions
@@ -99,6 +99,7 @@ typedef struct _input_plugin_functions
 	ptr_RomOpen             romOpen;
 	ptr_SDL_KeyDown         keyDown;
 	ptr_SDL_KeyUp           keyUp;
+	ptr_GetGBCartInfo       getGBCartInfo;
 	ptr_RenderCallback      renderCallback;
 } input_plugin_functions;
 


### PR DESCRIPTION
This was my attempt to connect the transfer pak code to the end users.

It introduces a new input plugin API function (GetGBCartInfo). So basically the core can query the input plugin to determine what files the user has chosen for the GB ROM/RAM files.

I also changed some of the log output that is generated to "verbose".

Thoughts? I know that I would also have to update the API docs and version numbers. I'll do that if this gets a "thumbs up"

@bsmiles32 one thing I noticed, it doesn't seem to matter what "plugin" I have chosen in the input plugin, the transfer pak always works if I have a valid path to a ROM/RAM chosen

See also https://github.com/mupen64plus/mupen64plus-input-sdl/pull/45