### PR TITLE
Use count_per_op instead of 2

### DIFF
--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1330,7 +1330,7 @@ DECLARE_INSTRUCTION(TLBWR)
     DECLARE_R4300
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
     cp0_update_count(r4300);
-    cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/2 % (32 - cp0_regs[CP0_WIRED_REG]))
+    cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % (32 - cp0_regs[CP0_WIRED_REG]))
         + cp0_regs[CP0_WIRED_REG];
     TLBWrite(r4300, cp0_regs[CP0_RANDOM_REG]);
     ADD_TO_PC(1);
@@ -1356,7 +1356,7 @@ DECLARE_INSTRUCTION(MFC0)
     {
     case CP0_RANDOM_REG:
         cp0_update_count(r4300);
-        cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/2 % (32 - cp0_regs[CP0_WIRED_REG]))
+        cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % (32 - cp0_regs[CP0_WIRED_REG]))
             + cp0_regs[CP0_WIRED_REG];
         break;
     case CP0_COUNT_REG:

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -11068,7 +11068,7 @@ static void TLBWI_new(void)
 static void TLBWR_new(void)
 {
   unsigned int i;
-  r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_RANDOM_REG] = (r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_COUNT_REG]/2 % (32 - r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_WIRED_REG])) + r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_WIRED_REG];
+  r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_RANDOM_REG] = (r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_COUNT_REG]/g_dev.r4300.cp0.count_per_op % (32 - r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_WIRED_REG])) + r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_WIRED_REG];
   /* Remove old entries */
   unsigned int old_start_even=g_dev.r4300.cp0.tlb.entries[r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_RANDOM_REG]&0x3F].start_even;
   unsigned int old_end_even=g_dev.r4300.cp0.tlb.entries[r4300_cp0_regs(&g_dev.r4300.cp0)[CP0_RANDOM_REG]&0x3F].end_even;


### PR DESCRIPTION
Someone can correct me if I'm wrong, but I'm fairly certain that is "2" is supposed to represent the "count_per_op" setting