### PR TITLE
Proper fix for Twisted Edge audio

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -6639,7 +6639,6 @@ GoodName=King Hill 64 - Extreme Snowboarding (J) [!]
 CRC=519EA4E1 EB7584E8
 Players=4
 SaveType=Controller Pack
-FixedAudioPos=1
 CountPerScanline=1600
 
 [CE9AE0AA6DBBF965B1F72BC3AA6A7CEF]
@@ -14663,7 +14662,6 @@ CRC=E688A5B8 B14B3F18
 SaveType=Controller Pack
 Players=2
 Rumble=Yes
-FixedAudioPos=1
 CountPerScanline=1600
 
 [4F0E2AF205BEEB49270154810660FF37]
@@ -14682,7 +14680,6 @@ CRC=BBC99D32 117DAA80
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
-FixedAudioPos=1
 CountPerScanline=1600
 
 [0B0DF8EC747BF99F3A55A3300CE8BC0D]

--- a/src/device/ai/ai_controller.c
+++ b/src/device/ai/ai_controller.c
@@ -70,7 +70,7 @@ static unsigned int get_dma_duration(struct ai_controller* ai)
 }
 
 
-static void do_dma(struct ai_controller* ai, const struct ai_dma* dma)
+static void do_dma(struct ai_controller* ai, struct ai_dma* dma)
 {
     /* lazy initialization of sample format */
     if (ai->samples_format_changed)
@@ -88,8 +88,15 @@ static void do_dma(struct ai_controller* ai, const struct ai_dma* dma)
         ai->samples_format_changed = 0;
     }
 
+    if (ai->delayed_carry) dma->address += 0x2000;
+
     /* push audio samples to external sink */
     audio_out_push_samples(ai->aout, &ai->ri->rdram.dram[dma->address/4], dma->length);
+
+    if (((dma->address + dma->length) & 0x1FFF) == 0)
+        ai->delayed_carry = 1;
+    else
+        ai->delayed_carry = 0;
 
     /* schedule end of dma event */
     cp0_update_count(ai->r4300);
@@ -132,6 +139,7 @@ static void fifo_pop(struct ai_controller* ai)
     else
     {
         ai->regs[AI_STATUS_REG] &= ~AI_STATUS_BUSY;
+        ai->delayed_carry = 0;
     }
 }
 
@@ -140,13 +148,12 @@ void init_ai(struct ai_controller* ai,
              struct r4300_core* r4300,
              struct ri_controller* ri,
              struct vi_controller* vi,
-             struct audio_out_backend* aout, unsigned int fixed_audio_pos)
+             struct audio_out_backend* aout)
 {
     ai->r4300 = r4300;
     ai->ri = ri;
     ai->vi = vi;
     ai->aout = aout;
-    ai->fixed_audio_pos = fixed_audio_pos;
 }
 
 void poweron_ai(struct ai_controller* ai)
@@ -154,7 +161,7 @@ void poweron_ai(struct ai_controller* ai)
     memset(ai->regs, 0, AI_REGS_COUNT*sizeof(uint32_t));
     memset(ai->fifo, 0, AI_DMA_FIFO_SIZE*sizeof(struct ai_dma));
     ai->samples_format_changed = 0;
-    ai->audio_pos = 0;
+    ai->delayed_carry = 0;
 }
 
 int read_ai_regs(void* opaque, uint32_t address, uint32_t* value)
@@ -181,15 +188,6 @@ int write_ai_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 
     switch (reg)
     {
-    case AI_DRAM_ADDR_REG:
-        masked_write(&ai->regs[AI_DRAM_ADDR_REG], value, mask);
-        if (ai->fixed_audio_pos) {
-            if (ai->audio_pos == 0)
-                ai->audio_pos = ai->regs[AI_DRAM_ADDR_REG];
-            ai->regs[AI_DRAM_ADDR_REG] = ai->audio_pos;
-        }
-        return 0;
-
     case AI_LEN_REG:
         masked_write(&ai->regs[AI_LEN_REG], value, mask);
         fifo_push(ai);

--- a/src/device/ai/ai_controller.h
+++ b/src/device/ai/ai_controller.h
@@ -60,8 +60,7 @@ struct ai_controller
     struct ri_controller* ri;
     struct vi_controller* vi;
     struct audio_out_backend* aout;
-    uint32_t fixed_audio_pos;
-    uint32_t audio_pos;
+    uint32_t delayed_carry;
 };
 
 static uint32_t ai_reg(uint32_t address)
@@ -73,7 +72,7 @@ void init_ai(struct ai_controller* ai,
              struct r4300_core* r4300,
              struct ri_controller* ri,
              struct vi_controller* vi,
-             struct audio_out_backend* aout, unsigned int fixed_audio_pos);
+             struct audio_out_backend* aout);
 
 void poweron_ai(struct ai_controller* ai);
 

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -38,7 +38,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     /* ai */
-    struct audio_out_backend* aout, unsigned int fixed_audio_pos,
+    struct audio_out_backend* aout,
     /* pi */
     uint8_t* rom, size_t rom_size,
     struct storage_backend* flashram_storage,
@@ -75,7 +75,7 @@ void init_device(struct device* dev,
             emumode, count_per_op, no_compiled_jump);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
     init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri);
-    init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, fixed_audio_pos);
+    init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout);
     init_pi(&dev->pi, rom, rom_size, flashram_storage, sram_storage, &dev->r4300, &dev->ri, &dev->si.pif.cic);
     init_ri(&dev->ri, dram, dram_size);
     init_si(&dev->si,

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -63,7 +63,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     /* ai */
-    struct audio_out_backend* aout, unsigned int fixed_audio_pos,
+    struct audio_out_backend* aout,
     /* pi */
     uint8_t* rom, size_t rom_size,
     struct storage_backend* flashram_storage,

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1083,7 +1083,7 @@ m64p_error main_run(void)
                 emumode,
                 count_per_op,
                 no_compiled_jump,
-                &aout, ROM_PARAMS.fixedaudiopos,
+                &aout,
                 g_rom, g_rom_size,
                 &fla_storage,
                 &sra_storage,

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -51,8 +51,6 @@ enum { DEFAULT_COUNT_PER_SCANLINE = 1500 };
 enum { DEFAULT_COUNT_PER_OP = 2 };
 /* by default, alternate VI timing is disabled */
 enum { DEFAULT_ALTERNATE_VI_TIMING = 0 };
-/* by default, fixed audio position is disabled */
-enum { DEFAULT_FIXED_AUDIO_POS = 0 };
 /* by default, extra mem is enabled */
 enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
 
@@ -181,7 +179,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.systemtype = rom_country_code_to_system_type(ROM_HEADER.Country_code);
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
     ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
-    ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
     ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
     ROM_PARAMS.cheats = NULL;
@@ -202,7 +199,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = entry->rumble;
         ROM_PARAMS.countperop = entry->countperop;
         ROM_PARAMS.vitiming = entry->alternate_vi_timing;
-        ROM_PARAMS.fixedaudiopos = entry->fixed_audio_pos;
         ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.disableextramem = entry->disableextramem;
         ROM_PARAMS.cheats = entry->cheats;
@@ -217,7 +213,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = 0;
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
         ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
-        ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
         ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
         ROM_PARAMS.cheats = NULL;
@@ -460,7 +455,6 @@ void romdatabase_open(void)
             search->entry.rumble = 0;
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
             search->entry.alternate_vi_timing = DEFAULT_ALTERNATE_VI_TIMING;
-            search->entry.fixed_audio_pos = DEFAULT_FIXED_AUDIO_POS;
             search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
             search->entry.cheats = NULL;
@@ -511,10 +505,6 @@ void romdatabase_open(void)
                 if(!strcmp(l.value, "Alternate")) {
                     search->entry.alternate_vi_timing = 1;
                 }
-            }
-            else if(!strcmp(l.name, "FixedAudioPos"))
-            {
-                search->entry.fixed_audio_pos = atoi(l.value);
             }
             else if(!strcmp(l.name, "CountPerScanline"))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -53,7 +53,6 @@ typedef struct _rom_params
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
    int vitiming;
-   int fixedaudiopos;
    int countperscanline;
    int disableextramem;
 } rom_params;
@@ -127,7 +126,6 @@ typedef struct
    unsigned char players; /* Local players 0-4, 2/3/4 way Netplay indicated by 5/6/7. */
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
    unsigned char alternate_vi_timing;
-   unsigned char fixed_audio_pos;
    int count_per_scanline;
    unsigned char countperop;
    unsigned char disableextramem;


### PR DESCRIPTION
This mostly reverts https://github.com/mupen64plus/mupen64plus-core/pull/289

This was taken from https://github.com/mamedev/mame/commit/aee15107876b7ce7f9b298931b4c4710f38a12ee so credits to @Happy-yappH

The author states that this behavior is actually the result of a hardware bug. I'm not aware of any game besides Twisted Edge that runs into this, but at least this is a generic solution instead of being game specific.

In practice is does the same thing, so there is no real difference, other than a more proper solution, and perhaps this also fixes some audio issue is another game, I'm not sure.