### PR TITLE
[WIP] Add support for streaming audio buffer

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -6641,6 +6641,7 @@ Players=4
 SaveType=Controller Pack
 FixedAudioPos=1
 CountPerScanline=1600
+StreamAudio=1
 
 [CE9AE0AA6DBBF965B1F72BC3AA6A7CEF]
 GoodName=King Hill 64 - Extreme Snowboarding (J) [b1]
@@ -13383,6 +13384,7 @@ CRC=9510D8D7 35100DD2
 SaveType=Controller Pack
 Players=4
 Rumble=Yes
+StreamAudio=1
 
 [14DDF19382385774F253049ABEAF01D2]
 GoodName=Summer64 Demo by Lem (PD) [b1]
@@ -14260,6 +14262,7 @@ CRC=7F43E701 536328D1
 Players=4
 Rumble=Yes
 SaveType=Controller Pack
+StreamAudio=1
 
 [48D6C194AE106018DDFC3486A8B347F7]
 GoodName=Top Gear Rally (E) [b1]
@@ -14277,6 +14280,7 @@ CRC=0E596247 753D4B8B
 Players=4
 SaveType=Controller Pack
 Rumble=Yes
+StreamAudio=1
 
 [6F7030284B6BC84A49E07DA864526B52]
 GoodName=Top Gear Rally (U) [!]
@@ -14284,6 +14288,7 @@ CRC=62269B3D FE11B1E8
 Players=4
 SaveType=Controller Pack
 Rumble=Yes
+StreamAudio=1
 
 [FA88969ECFA72358EF1C045035442F5C]
 GoodName=Top Gear Rally (U) [b1]
@@ -14665,6 +14670,7 @@ Players=2
 Rumble=Yes
 FixedAudioPos=1
 CountPerScanline=1600
+StreamAudio=1
 
 [4F0E2AF205BEEB49270154810660FF37]
 GoodName=Twisted Edge Extreme Snowboarding (E) [b1]
@@ -14684,6 +14690,7 @@ Rumble=Yes
 SaveType=Controller Pack
 FixedAudioPos=1
 CountPerScanline=1600
+StreamAudio=1
 
 [0B0DF8EC747BF99F3A55A3300CE8BC0D]
 GoodName=U64 (Chrome) Demo by Horizon64 (PD) [a1]
@@ -15766,6 +15773,7 @@ GoodName=World Driver Championship (E) (M5) [!]
 CRC=AC062778 DFADFCB8
 SaveType=Controller Pack
 Players=4
+StreamAudio=1
 
 [9A2B0F3226FB8D129BEB7509C169476A]
 GoodName=World Driver Championship (E) (M5) [h1C]
@@ -15777,6 +15785,7 @@ GoodName=World Driver Championship (U) [!]
 CRC=308DFEC8 CE2EB5F6
 SaveType=Controller Pack
 Players=4
+StreamAudio=1
 
 [4B86C373533D015860467C5DC1F1C662]
 GoodName=World Driver Championship (U) [b1]

--- a/src/api/m64p_plugin.h
+++ b/src/api/m64p_plugin.h
@@ -224,6 +224,7 @@ typedef int  (*ptr_VolumeGetLevel)(void);
 typedef void (*ptr_VolumeSetLevel)(int level);
 typedef void (*ptr_VolumeMute)(void);
 typedef const char * (*ptr_VolumeGetString)(void);
+typedef void (*ptr_PlayAudio)(unsigned char *buffer, unsigned int size);
 #if defined(M64P_PLUGIN_PROTOTYPES)
 EXPORT void CALL AiDacrateChanged(int SystemType);
 EXPORT void CALL AiLenChanged(void);
@@ -236,6 +237,7 @@ EXPORT int  CALL VolumeGetLevel(void);
 EXPORT void CALL VolumeSetLevel(int level);
 EXPORT void CALL VolumeMute(void);
 EXPORT const char * CALL VolumeGetString(void);
+EXPORT void CALL PlayAudio(unsigned char *buffer, unsigned int size);
 #endif
 
 /* input plugin function pointers */

--- a/src/device/ai/ai_controller.h
+++ b/src/device/ai/ai_controller.h
@@ -62,6 +62,8 @@ struct ai_controller
     struct audio_out_backend* aout;
     uint32_t fixed_audio_pos;
     uint32_t audio_pos;
+    unsigned char audio_buffer[0x40000];
+    uint32_t stream_audio;
 };
 
 static uint32_t ai_reg(uint32_t address)
@@ -73,7 +75,7 @@ void init_ai(struct ai_controller* ai,
              struct r4300_core* r4300,
              struct ri_controller* ri,
              struct vi_controller* vi,
-             struct audio_out_backend* aout, unsigned int fixed_audio_pos);
+             struct audio_out_backend* aout, unsigned int fixed_audio_pos, unsigned int stream_audio);
 
 void poweron_ai(struct ai_controller* ai);
 

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -38,7 +38,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     /* ai */
-    struct audio_out_backend* aout, unsigned int fixed_audio_pos,
+    struct audio_out_backend* aout, unsigned int fixed_audio_pos, unsigned int stream_audio,
     /* pi */
     uint8_t* rom, size_t rom_size,
     struct storage_backend* flashram_storage,
@@ -75,7 +75,7 @@ void init_device(struct device* dev,
             emumode, count_per_op, no_compiled_jump);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
     init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri);
-    init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, fixed_audio_pos);
+    init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, fixed_audio_pos, stream_audio);
     init_pi(&dev->pi, rom, rom_size, flashram_storage, sram_storage, &dev->r4300, &dev->ri, &dev->si.pif.cic);
     init_ri(&dev->ri, dram, dram_size);
     init_si(&dev->si,

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -63,7 +63,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     /* ai */
-    struct audio_out_backend* aout, unsigned int fixed_audio_pos,
+    struct audio_out_backend* aout, unsigned int fixed_audio_pos, unsigned int stream_audio,
     /* pi */
     uint8_t* rom, size_t rom_size,
     struct storage_backend* flashram_storage,

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1083,7 +1083,7 @@ m64p_error main_run(void)
                 emumode,
                 count_per_op,
                 no_compiled_jump,
-                &aout, ROM_PARAMS.fixedaudiopos,
+                &aout, ROM_PARAMS.fixedaudiopos, ROM_PARAMS.streamaudio,
                 g_rom, g_rom_size,
                 &fla_storage,
                 &sra_storage,

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -53,6 +53,8 @@ enum { DEFAULT_COUNT_PER_OP = 2 };
 enum { DEFAULT_ALTERNATE_VI_TIMING = 0 };
 /* by default, fixed audio position is disabled */
 enum { DEFAULT_FIXED_AUDIO_POS = 0 };
+/* by default, streaming audio is disabled */
+enum { DEFAULT_STREAM_AUDIO = 0 };
 /* by default, extra mem is enabled */
 enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
 
@@ -182,6 +184,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
     ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
     ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
+    ROM_PARAMS.streamaudio = DEFAULT_STREAM_AUDIO;
     ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
     ROM_PARAMS.cheats = NULL;
@@ -203,6 +206,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.countperop = entry->countperop;
         ROM_PARAMS.vitiming = entry->alternate_vi_timing;
         ROM_PARAMS.fixedaudiopos = entry->fixed_audio_pos;
+        ROM_PARAMS.streamaudio = entry->stream_audio;
         ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.disableextramem = entry->disableextramem;
         ROM_PARAMS.cheats = entry->cheats;
@@ -218,6 +222,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
         ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
         ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
+        ROM_PARAMS.streamaudio = DEFAULT_STREAM_AUDIO;
         ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
         ROM_PARAMS.cheats = NULL;
@@ -461,6 +466,7 @@ void romdatabase_open(void)
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
             search->entry.alternate_vi_timing = DEFAULT_ALTERNATE_VI_TIMING;
             search->entry.fixed_audio_pos = DEFAULT_FIXED_AUDIO_POS;
+            search->entry.stream_audio = DEFAULT_STREAM_AUDIO;
             search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
             search->entry.cheats = NULL;
@@ -515,6 +521,10 @@ void romdatabase_open(void)
             else if(!strcmp(l.name, "FixedAudioPos"))
             {
                 search->entry.fixed_audio_pos = atoi(l.value);
+            }
+            else if (!strcmp(l.name, "StreamAudio"))
+            {
+                search->entry.stream_audio = atoi(l.value);
             }
             else if(!strcmp(l.name, "CountPerScanline"))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -54,6 +54,7 @@ typedef struct _rom_params
    unsigned char countperop;
    int vitiming;
    int fixedaudiopos;
+   int streamaudio;
    int countperscanline;
    int disableextramem;
 } rom_params;
@@ -128,6 +129,7 @@ typedef struct
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
    unsigned char alternate_vi_timing;
    unsigned char fixed_audio_pos;
+   unsigned char stream_audio;
    int count_per_scanline;
    unsigned char countperop;
    unsigned char disableextramem;

--- a/src/plugin/dummy_audio.c
+++ b/src/plugin/dummy_audio.c
@@ -110,3 +110,8 @@ const char *dummyaudio_VolumeGetString(void)
 {
     return "disabled";
 }
+
+void dummyaudio_PlayAudio(unsigned char *buffer, unsigned int size)
+{
+
+}

--- a/src/plugin/dummy_audio.h
+++ b/src/plugin/dummy_audio.h
@@ -40,6 +40,7 @@ extern int dummyaudio_VolumeGetLevel(void);
 extern void dummyaudio_VolumeSetLevel(int level);
 extern void dummyaudio_VolumeMute(void);
 extern const char * dummyaudio_VolumeGetString(void);
+extern void dummyaudio_PlayAudio(unsigned char *buffer, unsigned int size);
 
 #endif /* DUMMY_AUDIO_H */
 

--- a/src/plugin/plugin.c
+++ b/src/plugin/plugin.c
@@ -87,7 +87,8 @@ static const audio_plugin_functions dummy_audio = {
     dummyaudio_VolumeGetLevel,
     dummyaudio_VolumeSetLevel,
     dummyaudio_VolumeMute,
-    dummyaudio_VolumeGetString
+    dummyaudio_VolumeGetString,
+    dummyaudio_PlayAudio
 };
 
 static const input_plugin_functions dummy_input = {
@@ -299,6 +300,9 @@ static m64p_error plugin_connect_audio(m64p_dynlib_handle plugin_handle)
             plugin_disconnect_audio();
             return M64ERR_INPUT_INVALID;
         }
+
+        if (!GET_FUNC(ptr_PlayAudio, audio.playAudio, "PlayAudio"))
+            DebugMessage(M64MSG_WARNING, "Audio plugin does not support streaming audio.");
 
         /* check the version info */
         (*audio.getVersion)(&PluginType, &PluginVersion, &APIVersion, NULL, NULL);

--- a/src/plugin/plugin.h
+++ b/src/plugin/plugin.h
@@ -83,6 +83,7 @@ typedef struct _audio_plugin_functions
 	ptr_VolumeSetLevel    volumeSetLevel;
 	ptr_VolumeMute        volumeMute;
 	ptr_VolumeGetString   volumeGetString;
+	ptr_PlayAudio         playAudio;
 } audio_plugin_functions;
 
 extern audio_plugin_functions audio;


### PR DESCRIPTION
This PR proposes a change to the API, so I haven't updated the docs yet, I'll do that if the API change gets a thumbs up.

This fixes audio in Boss Games (Stunt Racer, World Driver Championship, Top Gear Rally, Twisted Edge Snowboarding).

You can read my explanation of the problem/solution here:
https://github.com/mupen64plus/mupen64plus-core/issues/200#issuecomment-316780301

Basically in this PR, every time AI_LEN_REG is read, we update the contents of the audio buffer. These games update the audio data while the DMA is happening, so we can't just copy the memory at the beginning of the DMA and send it to the audio plugin.

Because of this, I created a new audio API function (PlayAudio), which just takes a buffer and plays the audio in it, instead of having to read from DMEM.

You can see the change I made to the audio plugin here:
https://github.com/m64p/mupen64plus-audio-sdl2/commit/79fef8d055e78664e13f9855e34fc98631dd7ac7

These games don't seem to play nice with audio speed limiters/"sync to audio" settings, so if you're going to test it, you'll probably need to test it with that sort of thing disabled.

I'm hoping some people can test this, I can provide a binary build if needed.

(technically this is actually the more accurate way to emulate the AI, but since it will add some audio latency because the audio plugin won't start playing the audio until the end of the DMA, I've only enabled it for these Boss games)