### PR TITLE
Send audio data to plugin as the DMA drains

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -6646,7 +6646,6 @@ GoodName=King Hill 64 - Extreme Snowboarding (J) [!]
 CRC=519EA4E1 EB7584E8
 Players=4
 SaveType=Controller Pack
-FixedAudioPos=1
 CountPerScanline=1600
 
 [CE9AE0AA6DBBF965B1F72BC3AA6A7CEF]
@@ -14680,7 +14679,6 @@ CRC=E688A5B8 B14B3F18
 SaveType=Controller Pack
 Players=2
 Rumble=Yes
-FixedAudioPos=1
 CountPerScanline=1600
 
 [4F0E2AF205BEEB49270154810660FF37]
@@ -14699,7 +14697,6 @@ CRC=BBC99D32 117DAA80
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
-FixedAudioPos=1
 CountPerScanline=1600
 
 [0B0DF8EC747BF99F3A55A3300CE8BC0D]

--- a/src/device/ai/ai_controller.h
+++ b/src/device/ai/ai_controller.h
@@ -62,6 +62,7 @@ struct ai_controller
     struct audio_out_backend* aout;
     uint32_t fixed_audio_pos;
     uint32_t audio_pos;
+    uint32_t last_read;
 };
 
 static uint32_t ai_reg(uint32_t address)

--- a/src/device/ai/ai_controller.h
+++ b/src/device/ai/ai_controller.h
@@ -60,9 +60,8 @@ struct ai_controller
     struct ri_controller* ri;
     struct vi_controller* vi;
     struct audio_out_backend* aout;
-    uint32_t fixed_audio_pos;
-    uint32_t audio_pos;
     uint32_t last_read;
+    uint32_t delayed_carry;
 };
 
 static uint32_t ai_reg(uint32_t address)
@@ -74,7 +73,7 @@ void init_ai(struct ai_controller* ai,
              struct r4300_core* r4300,
              struct ri_controller* ri,
              struct vi_controller* vi,
-             struct audio_out_backend* aout, unsigned int fixed_audio_pos);
+             struct audio_out_backend* aout);
 
 void poweron_ai(struct ai_controller* ai);
 

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -38,7 +38,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     /* ai */
-    struct audio_out_backend* aout, unsigned int fixed_audio_pos,
+    struct audio_out_backend* aout,
     /* pi */
     uint8_t* rom, size_t rom_size,
     struct storage_backend* flashram_storage,
@@ -77,7 +77,7 @@ void init_device(struct device* dev,
             emumode, count_per_op, no_compiled_jump);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
     init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri, audio_signal);
-    init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, fixed_audio_pos);
+    init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout);
     init_pi(&dev->pi, rom, rom_size, flashram_storage, sram_storage, &dev->r4300, &dev->ri, &dev->si.pif.cic);
     init_ri(&dev->ri, dram, dram_size);
     init_si(&dev->si,

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -63,7 +63,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     /* ai */
-    struct audio_out_backend* aout, unsigned int fixed_audio_pos,
+    struct audio_out_backend* aout,
     /* pi */
     uint8_t* rom, size_t rom_size,
     struct storage_backend* flashram_storage,

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1083,7 +1083,7 @@ m64p_error main_run(void)
                 emumode,
                 count_per_op,
                 no_compiled_jump,
-                &aout, ROM_PARAMS.fixedaudiopos,
+                &aout,
                 g_rom, g_rom_size,
                 &fla_storage,
                 &sra_storage,

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -51,8 +51,6 @@ enum { DEFAULT_COUNT_PER_SCANLINE = 1500 };
 enum { DEFAULT_COUNT_PER_OP = 2 };
 /* by default, alternate VI timing is disabled */
 enum { DEFAULT_ALTERNATE_VI_TIMING = 0 };
-/* by default, fixed audio position is disabled */
-enum { DEFAULT_FIXED_AUDIO_POS = 0 };
 /* by default, extra mem is enabled */
 enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
 /* by default, Audio Signal is disabled */
@@ -183,7 +181,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.systemtype = rom_country_code_to_system_type(ROM_HEADER.Country_code);
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
     ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
-    ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
     ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
     ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
@@ -205,7 +202,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = entry->rumble;
         ROM_PARAMS.countperop = entry->countperop;
         ROM_PARAMS.vitiming = entry->alternate_vi_timing;
-        ROM_PARAMS.fixedaudiopos = entry->fixed_audio_pos;
         ROM_PARAMS.audiosignal = entry->audio_signal;
         ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.disableextramem = entry->disableextramem;
@@ -221,7 +217,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = 0;
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
         ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
-        ROM_PARAMS.fixedaudiopos = DEFAULT_FIXED_AUDIO_POS;
         ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
         ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
@@ -465,7 +460,6 @@ void romdatabase_open(void)
             search->entry.rumble = 0;
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
             search->entry.alternate_vi_timing = DEFAULT_ALTERNATE_VI_TIMING;
-            search->entry.fixed_audio_pos = DEFAULT_FIXED_AUDIO_POS;
             search->entry.audio_signal = DEFAULT_AUDIO_SIGNAL;
             search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
@@ -517,10 +511,6 @@ void romdatabase_open(void)
                 if(!strcmp(l.value, "Alternate")) {
                     search->entry.alternate_vi_timing = 1;
                 }
-            }
-            else if(!strcmp(l.name, "FixedAudioPos"))
-            {
-                search->entry.fixed_audio_pos = atoi(l.value);
             }
             else if (!strcmp(l.name, "AudioSignal"))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -53,7 +53,6 @@ typedef struct _rom_params
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
    int vitiming;
-   int fixedaudiopos;
    int audiosignal;
    int countperscanline;
    int disableextramem;
@@ -128,7 +127,6 @@ typedef struct
    unsigned char players; /* Local players 0-4, 2/3/4 way Netplay indicated by 5/6/7. */
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
    unsigned char alternate_vi_timing;
-   unsigned char fixed_audio_pos;
    unsigned char audio_signal;
    int count_per_scanline;
    unsigned char countperop;


### PR DESCRIPTION
This is an improved version of https://github.com/mupen64plus/mupen64plus-core/pull/342. Please read that for details on the problem that this fixes.

This version is much simpler and doesn't require any changes to the API. Instead of sending all the audio data to the plugin at the beginning of the DMA, we send it piece by piece as the DMA happens. Then, at the end of the DMA, we send whatever is leftover.

This should be a "global solution" that doesn't add any noticeable latency, while still fixing the audio in these games.