### PR TITLE
Fix timing in DK64

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -3658,7 +3658,8 @@ CRC=11936D8C 6F2C4B43
 SaveType=Eeprom 16KB
 Players=4
 Rumble=Yes
-CountPerOp=1
+CountPerOp=3
+CountPerScanline=1750
 ; Bone displacement fix
 Cheat0=806128E2 0000
 
@@ -3682,7 +3683,8 @@ GoodName=Donkey Kong 64 (J) [!]
 CRC=053C89A7 A5064302
 SaveType=Eeprom 16KB
 Players=4
-CountPerOp=1
+CountPerOp=3
+CountPerScanline=1750
 ; Bone displacement fix
 Cheat0=806170A2 0000
 
@@ -3712,7 +3714,8 @@ GoodName=Donkey Kong 64 (U) [!]
 CRC=EC58EABF AD7C7169
 SaveType=Eeprom 16KB
 Players=4
-CountPerOp=1
+CountPerOp=3
+CountPerScanline=1750
 ; Bone displacement fix
 Cheat0=80619632 0000
 


### PR DESCRIPTION
I'm hoping a couple people can test this out before it gets merged.

I believe this improves the timing in DK64 because:

During the intro, right after the rap sequence, there is a "Press Start" screen. In Project64, and currently in mupen64plus, Donkey Kong jumps into the water, climbs up a hill, and then jumps into the water again, missing the vines.

With this change, he correctly climbs up the hill, then jumps across the vines and into the cannon. This is the correct sequence for the intro of the game.

I've never really played this game much, so I'm hoping some people can test this out in various stages of the game. The settings are CountPerOp=3 and CountPerScanline=1750. You should be able to just modify mupen64plus.cfg to test this, no need to recompile anything