### PR TITLE
Fix Indiana Jones

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -5962,12 +5962,18 @@ GoodName=Indiana Jones and the Infernal Machine (U) [!]
 CRC=AF9DCC15 1A723D88
 Players=1
 SaveType=Eeprom 4KB
+CountPerOp=1
+CountPerScanline=2200
+DisableExtraMem=1
 
 [6F417D30D772F4420C9384E9BBB7BC01]
 GoodName=Indiana Jones and the Infernal Machine (E)
 CRC=3A6F8C6B 2897BAEB
 SaveType=Eeprom 4KB
 Players=1
+CountPerOp=1
+CountPerScanline=2200
+DisableExtraMem=1
 
 [A7781D441AF55C4FF8AFC68AB3A59313]
 GoodName=Indy Racing 2000 (U) [!]


### PR DESCRIPTION
This is my latest attempt to get Indiana Jones working.

CountPerOp=1 fixes graphical and stability issues
CountPerScanline=2200 allows the game to boot with CountPerOp=1

DisableExtraMem=1 disables the expansion pak. This seems to fix the hang at the end of the level, right before the Trading Post. The expansion pak brought the game to 640x480, but I think disabling it is worth it to make the game playable, at least until a better fix is found.

I'm going to test this over the next few days to make sure I got this right. These are all just settings you can set in mupen64plus.cfg, so anyone can test this out. If you're going to test I would suggest deleting any save (eep) files associated with the game.