### PR TITLE
Add SI_STATUS_DMA_BUSY

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -8706,6 +8706,7 @@ GoodName=Mischief Makers (E) [!]
 CRC=418BDA98 248A0F58
 Players=1
 SaveType=Eeprom 4KB
+DelaySI=0
 
 [5690D74157C6623E2928A6F0353EF4AF]
 GoodName=Mischief Makers (E) [b1]
@@ -8717,6 +8718,7 @@ GoodName=Mischief Makers (U) [!]
 CRC=0B93051B 603D81F9
 Players=1
 SaveType=Eeprom 4KB
+DelaySI=0
 
 [CCF012DF82022D4797CE4CC5405E084F]
 GoodName=Mischief Makers (U) [b1]

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -996,7 +996,11 @@ m64p_error main_run(void)
 #ifdef NEW_DYNAREC
     stop_after_jal = ConfigGetParamBool(g_CoreConfig, "DisableSpecRecomp");
 #endif
-    delay_si = ConfigGetParamBool(g_CoreConfig, "DelaySI");
+    if (!ROM_PARAMS.delaysi)
+        delay_si = ROM_PARAMS.delaysi;
+    else
+        delay_si = ConfigGetParamBool(g_CoreConfig, "DelaySI");
+
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
     alternate_vi_timing = ConfigGetParamInt(g_CoreConfig, "ViTiming");
     count_per_scanline  = ConfigGetParamInt(g_CoreConfig, "CountPerScanline");

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -55,6 +55,8 @@ enum { DEFAULT_ALTERNATE_VI_TIMING = 0 };
 enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
 /* by default, Audio Signal is disabled */
 enum { DEFAULT_AUDIO_SIGNAL = 0 };
+/* by default, Delay SI is enabled */
+enum { DEFAULT_DELAY_SI = 1 };
 
 static romdatabase_entry* ini_search_by_md5(md5_byte_t* md5);
 
@@ -184,6 +186,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
     ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
+    ROM_PARAMS.delaysi = DEFAULT_DELAY_SI;
     ROM_PARAMS.cheats = NULL;
 
     memcpy(ROM_PARAMS.headername, ROM_HEADER.Name, 20);
@@ -205,6 +208,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.audiosignal = entry->audio_signal;
         ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.disableextramem = entry->disableextramem;
+        ROM_PARAMS.delaysi = entry->delaysi;
         ROM_PARAMS.cheats = entry->cheats;
     }
     else
@@ -220,6 +224,7 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
         ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
+        ROM_PARAMS.delaysi = DEFAULT_DELAY_SI;
         ROM_PARAMS.cheats = NULL;
     }
 
@@ -463,6 +468,7 @@ void romdatabase_open(void)
             search->entry.audio_signal = DEFAULT_AUDIO_SIGNAL;
             search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
+            search->entry.delaysi = DEFAULT_DELAY_SI;
             search->entry.cheats = NULL;
             search->entry.set_flags = ROMDATABASE_ENTRY_NONE;
 
@@ -597,6 +603,10 @@ void romdatabase_open(void)
             else if (!strcmp(l.name, "DisableExtraMem"))
             {
                 search->entry.disableextramem = atoi(l.value);
+            }
+            else if (!strcmp(l.name, "DelaySI"))
+            {
+                search->entry.delaysi = atoi(l.value);
             }
             else if(!strncmp(l.name, "Cheat", 5))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -56,6 +56,7 @@ typedef struct _rom_params
    int audiosignal;
    int countperscanline;
    int disableextramem;
+   int delaysi;
 } rom_params;
 
 extern m64p_rom_header   ROM_HEADER;
@@ -131,6 +132,7 @@ typedef struct
    int count_per_scanline;
    unsigned char countperop;
    unsigned char disableextramem;
+   unsigned char delaysi;
    uint32_t set_flags;
 } romdatabase_entry;
 


### PR DESCRIPTION
This fixes the error:
```
Core Warning: two events of type 0x8 in interrupt queue
```
in some games. I've noticed it in Diddy Kong Racing and Mischief Makers (it really spams this message in Mischief Makers).

Anyway they are doing this because they don't know the SI DMA is busy. I added the busy bit, now these errors don't show up anymore.