### PR TITLE
Get rid of "alternate VI timing"

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -10907,7 +10907,6 @@ CRC=4A1CD153 D830AEF8
 Players=2
 SaveType=Flash RAM
 Rumble=No
-ViTiming=Alternate
 
 [A3BA044DFC00BB766B4B2BFB9D4B5BE9]
 GoodName=Pokemon Puzzle League (F) [!]
@@ -10915,7 +10914,6 @@ CRC=3EB2E6F3 062F9EFE
 Players=2
 SaveType=Flash RAM
 Rumble=No
-ViTiming=Alternate
 
 [000364BAC80E41D9060A31A5923874B7]
 GoodName=Pokemon Puzzle League (G) [!]
@@ -10923,7 +10921,6 @@ CRC=7A4747AC 44EEEC23
 Players=2
 SaveType=Flash RAM
 Rumble=No
-ViTiming=Alternate
 
 [E722576A15182CFED6782379CE4BC8BE]
 GoodName=Pokemon Puzzle League (U) [!]
@@ -10931,19 +10928,16 @@ CRC=19C553A7 A70F4B52
 Players=2
 SaveType=Flash RAM
 Rumble=No
-ViTiming=Alternate
 
 [DC09E2685EB95471311E57B3605F4894]
 GoodName=Pokemon Puzzle League (U) [t1]
 CRC=E1AAA925 27C9C94B
 RefMD5=E722576A15182CFED6782379CE4BC8BE
-ViTiming=Alternate
 
 [D5EDC7B884DFBA7CF4AC4CDFA8AC64A4]
 GoodName=Pokemon Puzzle League (U) [t2]
 CRC=AAE125A9 C9274BC9
 RefMD5=E722576A15182CFED6782379CE4BC8BE
-ViTiming=Alternate
 
 [E5A0CA3DC54B38EA7FCD927E3CFFAD3B]
 GoodName=Pokemon Snap (A) [!]

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -56,7 +56,7 @@ void init_device(struct device* dev,
     /* sp */
     unsigned int audio_signal,
     /* vi */
-    unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline, unsigned int alternate_timing)
+    unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline)
 {
     struct interrupt_handler interrupt_handlers[] = {
         { &dev->vi,        vi_vertical_interrupt_event }, /* VI */
@@ -90,7 +90,7 @@ void init_device(struct device* dev,
         rom + 0x40,
         &dev->r4300, &dev->ri,
         delay_si);
-    init_vi(&dev->vi, vi_clock, expected_refresh_rate, count_per_scanline, alternate_timing, &dev->r4300);
+    init_vi(&dev->vi, vi_clock, expected_refresh_rate, count_per_scanline, &dev->r4300);
 }
 
 void poweron_device(struct device* dev)

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -81,7 +81,7 @@ void init_device(struct device* dev,
     /* sp */
     unsigned int audio_signal,
     /* vi */
-    unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline, unsigned int alternate_timing);
+    unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline);
 
 /* Setup device such that it's state is
  * what it should be after power on.

--- a/src/device/vi/vi_controller.h
+++ b/src/device/vi/vi_controller.h
@@ -56,7 +56,6 @@ struct vi_controller
     unsigned int clock;
     unsigned int expected_refresh_rate;
     unsigned int count_per_scanline;
-    unsigned int alternate_timing;
 
     struct r4300_core* r4300;
 };
@@ -71,7 +70,7 @@ unsigned int vi_clock_from_tv_standard(m64p_system_type tv_standard);
 unsigned int vi_expected_refresh_rate_from_tv_standard(m64p_system_type tv_standard);
 
 void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected_refresh_rate,
-             unsigned int count_per_scanline, unsigned int alternate_timing,
+             unsigned int count_per_scanline,
              struct r4300_core* r4300);
 
 void poweron_vi(struct vi_controller* vi);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -273,7 +273,6 @@ int main_set_core_defaults(void)
     ConfigSetDefaultString(g_CoreConfig, "SharedDataPath", "", "Path to a directory to search when looking for shared data files");
     ConfigSetDefaultBool(g_CoreConfig, "DelaySI", 1, "Delay interrupt after DMA SI read/write");
     ConfigSetDefaultInt(g_CoreConfig, "CountPerOp", 0, "Force number of cycles per emulated instruction");
-    ConfigSetDefaultInt(g_CoreConfig, "ViTiming", -1, "Use alternate VI timing (-1=Game default, 0=Don't use alternate timing, 1=Use alternate timing)");
     ConfigSetDefaultInt(g_CoreConfig, "CountPerScanline", -1, "Modify the default count per scanline(-1 or 0=Game default)");
     ConfigSetDefaultBool(g_CoreConfig, "DisableSpecRecomp", 1, "Disable speculative precompilation in new dynarec");
 
@@ -967,7 +966,7 @@ m64p_error main_run(void)
     unsigned int count_per_op;
     unsigned int emumode;
     unsigned int disable_extra_mem;
-    int alternate_vi_timing, count_per_scanline;
+    int count_per_scanline;
     int no_compiled_jump;
     struct file_storage eep;
     struct file_storage fla;
@@ -1002,7 +1001,6 @@ m64p_error main_run(void)
         delay_si = ConfigGetParamBool(g_CoreConfig, "DelaySI");
 
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
-    alternate_vi_timing = ConfigGetParamInt(g_CoreConfig, "ViTiming");
     count_per_scanline  = ConfigGetParamInt(g_CoreConfig, "CountPerScanline");
 
     if (ROM_PARAMS.disableextramem)
@@ -1014,9 +1012,6 @@ m64p_error main_run(void)
 
     if (count_per_op <= 0)
         count_per_op = ROM_PARAMS.countperop;
-
-    if (alternate_vi_timing < 0)
-        alternate_vi_timing = ROM_PARAMS.vitiming;
 
     if (count_per_scanline  <= 0)
         count_per_scanline = ROM_PARAMS.countperscanline;
@@ -1100,7 +1095,7 @@ m64p_error main_run(void)
                 &clock,
                 delay_si,
                 ROM_PARAMS.audiosignal,
-                vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype), count_per_scanline, alternate_vi_timing);
+                vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype), count_per_scanline);
 
     // Attach rom to plugins
     if (!gfx.romOpen())

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -49,8 +49,6 @@
 enum { DEFAULT_COUNT_PER_SCANLINE = 1500 };
 /* Number of cpu cycles per instruction */
 enum { DEFAULT_COUNT_PER_OP = 2 };
-/* by default, alternate VI timing is disabled */
-enum { DEFAULT_ALTERNATE_VI_TIMING = 0 };
 /* by default, extra mem is enabled */
 enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
 /* by default, Audio Signal is disabled */
@@ -182,7 +180,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     /* add some useful properties to ROM_PARAMS */
     ROM_PARAMS.systemtype = rom_country_code_to_system_type(ROM_HEADER.Country_code);
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
-    ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
     ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
     ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
@@ -204,7 +201,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.players = entry->players;
         ROM_SETTINGS.rumble = entry->rumble;
         ROM_PARAMS.countperop = entry->countperop;
-        ROM_PARAMS.vitiming = entry->alternate_vi_timing;
         ROM_PARAMS.audiosignal = entry->audio_signal;
         ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.disableextramem = entry->disableextramem;
@@ -220,7 +216,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.players = 0;
         ROM_SETTINGS.rumble = 0;
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
-        ROM_PARAMS.vitiming = DEFAULT_ALTERNATE_VI_TIMING;
         ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
         ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
@@ -464,7 +459,6 @@ void romdatabase_open(void)
             search->entry.players = 0;
             search->entry.rumble = 0;
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
-            search->entry.alternate_vi_timing = DEFAULT_ALTERNATE_VI_TIMING;
             search->entry.audio_signal = DEFAULT_AUDIO_SIGNAL;
             search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
@@ -510,12 +504,6 @@ void romdatabase_open(void)
                 {
                     search->entry.crc1 = search->entry.crc2 = 0;
                     DebugMessage(M64MSG_WARNING, "ROM Database: Invalid CRC on line %i", lineno);
-                }
-            }
-            else if(!strcmp(l.name, "ViTiming"))
-            {
-                if(!strcmp(l.value, "Alternate")) {
-                    search->entry.alternate_vi_timing = 1;
                 }
             }
             else if (!strcmp(l.name, "AudioSignal"))

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -52,7 +52,6 @@ typedef struct _rom_params
    m64p_system_type systemtype;
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
-   int vitiming;
    int audiosignal;
    int countperscanline;
    int disableextramem;
@@ -127,7 +126,6 @@ typedef struct
    unsigned char savetype;
    unsigned char players; /* Local players 0-4, 2/3/4 way Netplay indicated by 5/6/7. */
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
-   unsigned char alternate_vi_timing;
    unsigned char audio_signal;
    int count_per_scanline;
    unsigned char countperop;


### PR DESCRIPTION
I noticed a while ago (https://github.com/mupen64plus/mupen64plus-core/pull/196#issuecomment-298761293) that this "alternate timing" hack only makes a difference when the result of the calculation makes vi->regs[VI_CURRENT_REG] = 0

I got the idea for "< 40" from this comment: https://github.com/tj90241/cen64/blob/master/vi/controller.c#L83-L87

Sometimes ```vi->next_vi - cp0_regs[CP0_COUNT_REG]``` can actually be a negative number in Pokemon Puzzle League, so we've already passed the VI interrupt when this math is being done, which screws up the calculation.

Anyway I've tested this with a number of games and I don't see any regressions, however it is modifying the VI interrupt system, which is already a little "fragile" as it is, so I will probably do some more testing over the next few days.