### PR TITLE
[WIP] Switch FGR to 32bit mode when jumping to an exception handler.

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -3663,8 +3663,6 @@ SaveType=Eeprom 16KB
 Players=4
 Rumble=Yes
 CountPerOp=1
-; Bone displacement fix
-Cheat0=806128E2 0000
 
 [428067DC7DB42DFC977A775F0A6E55B1]
 GoodName=Donkey Kong 64 (E) [b1]
@@ -3687,8 +3685,6 @@ CRC=053C89A7 A5064302
 SaveType=Eeprom 16KB
 Players=4
 CountPerOp=1
-; Bone displacement fix
-Cheat0=806170A2 0000
 
 [98A5836E3A5DA7BD0B5819E7498ACEA2]
 GoodName=Donkey Kong 64 (U) (Kiosk Demo) [!]
@@ -3717,8 +3713,6 @@ CRC=EC58EABF AD7C7169
 SaveType=Eeprom 16KB
 Players=4
 CountPerOp=1
-; Bone displacement fix
-Cheat0=80619632 0000
 
 [6B4772AA1743FEAC1919618B3FC6B3E1]
 GoodName=Donkey Kong 64 (U) [b1]

--- a/src/device/r4300/cp0.c
+++ b/src/device/r4300/cp0.c
@@ -76,6 +76,8 @@ void poweron_cp0(struct cp0* cp0)
     init_interrupt(cp0);
 
     poweron_tlb(&cp0->tlb);
+
+    poweron_exception(cp0);
 }
 
 
@@ -113,6 +115,7 @@ int check_cop1_unusable(struct r4300_core* r4300)
     {
         cp0_regs[CP0_CAUSE_REG] = CP0_CAUSE_EXCCODE_CPU | CP0_CAUSE_CE1;
         exception_general(r4300);
+        add_exception_to_list(r4300);
         return 1;
     }
     return 0;

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -172,6 +172,14 @@ struct interrupt_handler
     void (*callback)(void*);
 };
 
+struct exception_infos
+{
+    uint32_t EPC;
+    uint32_t fgr64;
+    struct exception_infos *previous;
+    struct exception_infos *next;
+};
+
 enum { CP0_INTERRUPT_HANDLERS_COUNT = 12 };
 
 struct cp0
@@ -204,6 +212,10 @@ struct cp0
     unsigned int count_per_op;
 
     struct tlb tlb;
+
+    struct exception_infos *current_exception;
+    struct exception_infos *skipped_exception;
+    int exception_level;
 };
 
 void init_cp0(struct cp0* cp0, unsigned int count_per_op, struct new_dynarec_hot_state* new_dynarec_hot_state, const struct interrupt_handler* interrupt_handlers);

--- a/src/device/r4300/exception.h
+++ b/src/device/r4300/exception.h
@@ -23,9 +23,15 @@
 #define M64P_DEVICE_R4300_EXCEPTION_H
 
 #include <stdint.h>
+#include "device/r4300/r4300_core.h"
 
 struct r4300_core;
 
+void poweron_exception(struct cp0* cp0);
+void add_exception_to_list(struct r4300_core* r4300);
+void remove_exception_from_list(struct r4300_core* r4300);
+void check_exception_list(struct r4300_core* r4300);
+void clear_exception_list(struct r4300_core* r4300);
 void TLB_refill_exception(struct r4300_core* r4300, uint32_t address, int w);
 void exception_general(struct r4300_core* r4300);
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -385,6 +385,7 @@ static void wrapped_exception_general(struct r4300_core* r4300)
     }
 #else
     exception_general(r4300);
+    add_exception_to_list(r4300);
 #endif
 }
 

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1083,6 +1083,7 @@ DECLARE_INSTRUCTION(ERET)
         cp0_regs[CP0_STATUS_REG] &= ~CP0_STATUS_EXL;
         generic_jump_to(r4300, cp0_regs[CP0_EPC_REG]);
     }
+    remove_exception_from_list(r4300);
     r4300->llbit = 0;
     check_interrupt(r4300);
     r4300->cp0.last_addr = PCADDR;
@@ -1453,6 +1454,7 @@ DECLARE_INSTRUCTION(MTC0)
         break;
     case CP0_EPC_REG:
         cp0_regs[CP0_EPC_REG] = rrt32;
+        check_exception_list(r4300);
         break;
     case CP0_PREVID_REG:
         break;

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -28,6 +28,7 @@
 #include "new_dynarec/new_dynarec.h"
 #include "pure_interp.h"
 #include "recomp.h"
+#include "exception.h"
 
 #include "api/callbacks.h"
 #include "api/debugger.h"
@@ -191,6 +192,7 @@ void run_r4300(struct r4300_core* r4300)
         free_blocks(r4300);
     }
 
+    clear_exception_list(r4300);
     DebugMessage(M64MSG_INFO, "R4300 emulator finished.");
 
     /* print instruction counts */
@@ -365,6 +367,8 @@ void savestates_load_set_pc(struct r4300_core* r4300, uint32_t pc)
     else
 #endif
     {
+        clear_exception_list(r4300);
+        add_exception_to_list(r4300);
         generic_jump_to(r4300, pc);
         invalidate_r4300_cached_code(r4300, 0, 0);
     }

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -142,6 +142,7 @@ uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address,
     //printf("tlb exception !!! @ %x, %x, add:%x\n", address, w, r4300->pc->addr);
     //getchar();
     TLB_refill_exception(r4300, address, w);
+    add_exception_to_list(r4300);
     //return 0x80000000;
     return 0x00000000;
 }


### PR DESCRIPTION
First of all, credit for this goes to @Gillou68310, he's the one that actually wrote this code.

You can read the original discussion about this problem here:
https://github.com/mupen64plus/mupen64plus-core/issues/145#issuecomment-249221815

Basically, this is a fix for the "Bone Displacement" issue in DK64, as well as some flickering graphics in Factor5 games, see below:
![29176429-190830d0-7da9-11e7-9bab-1289473d5ca1](https://user-images.githubusercontent.com/848146/29191547-5c7462da-7ddb-11e7-812e-c192b2b32e4b.png)

![indiana_jones-028](https://user-images.githubusercontent.com/848146/29193178-7878c0ce-7de1-11e7-8528-8b276e735db4.png)


I tested this with the save states that @Isotarge provided and it does indeed seem to fix the DK bone displacement issue. I also tested Rogue Squadron and Indiana Jones (with CountPerOp=2) and it fixes the odd graphics in those games.

I tested save states as well and they seem to be functioning normally.

Here is a 64-bit Windows build of mupen64plus+GLideN64 if anyone would like to test this on Windows:
[mupen64plus-GLideN64-FGR-fix.zip](https://github.com/mupen64plus/mupen64plus-core/files/1218190/mupen64plus-GLideN64-FGR-fix.zip)

TODO:
I'm hoping @Gillou68310 can comment on this with his thoughts.
More work needs to be done to integrate this with the new dynarec.