### PR TITLE
Round PI_WR_LEN_REG up to nearest even number

### DIFF
--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -129,7 +129,7 @@ static void dma_pi_write(struct pi_controller* pi)
         return;
     }
 
-    longueur = (pi->regs[PI_WR_LEN_REG] & 0xFFFFFF)+1;
+    longueur = (pi->regs[PI_WR_LEN_REG] & 0xFFFFFE)+2;
     i = (pi->regs[PI_CART_ADDR_REG]-0x10000000)&0x3FFFFFF;
     longueur = (i + longueur) > pi->cart_rom.rom_size ?
                (pi->cart_rom.rom_size - i) : longueur;


### PR DESCRIPTION
This fixes AI Shogi 3 and other games.

Before:
![before](https://user-images.githubusercontent.com/848146/29297664-bebae210-811f-11e7-9a08-41e037acca65.png)

After:
![after](https://user-images.githubusercontent.com/848146/29297672-c403e168-811f-11e7-96e8-39aa6d83c468.png)

See:
https://github.com/project64/project64/blob/master/Source/Project64-core/N64System/Mips/Dma.cpp#L202-L203