### PR TITLE
Get x86 new dynarec compiling again (when using PIC)

### DIFF
--- a/src/device/r4300/new_dynarec/x86/linkage_x86.asm
+++ b/src/device/r4300/new_dynarec/x86/linkage_x86.asm
@@ -488,7 +488,7 @@ read_byte_new:
     mov     ecx,    [find_local_data(g_dev_r4300_address)]
     and     ecx,    3
     xor     ecx,    3
-    movzx   eax,    BYTE [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword) + ecx]
+    movzx   eax,    BYTE [ecx + find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)]
     mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)], eax
     ret
 
@@ -503,7 +503,7 @@ read_hword_new:
     mov     ecx,    [find_local_data(g_dev_r4300_address)]
     and     ecx,    2
     xor     ecx,    2
-    movzx   eax,    WORD [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword) + ecx]
+    movzx   eax,    WORD [ecx + find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)]
     mov     [find_local_data(g_dev_r4300_new_dynarec_hot_state_rdword)], eax
     ret
 


### PR DESCRIPTION
This allows the x86 new dynarec to compile again. I just switched the order of operations that the compiler was complain against and it allows it to build.

My x86 assembly skill is not strong at all, but you would think that the order of additions should not matter. Can anyone double check this and make sure that south park doesn't restart on its own anymore?

This is for this issue: https://github.com/mupen64plus/mupen64plus-core/issues/316