### PR TITLE
Fix order of operations for AI interrupt timing

### DIFF
--- a/src/device/ai/ai_controller.c
+++ b/src/device/ai/ai_controller.c
@@ -66,7 +66,7 @@ static unsigned int get_dma_duration(struct ai_controller* ai)
     unsigned int bytes_per_sample = 4; /* XXX: assume 16bit stereo - should depends on bitrate instead */
     unsigned int cpu_counts_per_sec = ai->vi->delay * ai->vi->expected_refresh_rate; /* estimate cpu counts/sec using VI */
 
-    return ((uint64_t)ai->regs[AI_LEN_REG] * cpu_counts_per_sec) / (bytes_per_sample * samples_per_sec);
+    return ai->regs[AI_LEN_REG] * (cpu_counts_per_sec / (bytes_per_sample * samples_per_sec));
 }
 
 


### PR DESCRIPTION
You'll notice this the most if you listen to the intro for Pokemon Puzzle League.

In the current master it is very choppy (I'm talking about the very first thing you hear, before you press start). You'll also notice there are some breaks in the audio while you watch the FMV intro after you push "start".

I listened to other games and they still sound good to me. This may fix other audio issues in games if they exist, but I'm not aware of any specific examples.