### PR TITLE
CountPerScanline=2200 for WDC

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -15788,6 +15788,7 @@ GoodName=World Driver Championship (E) (M5) [!]
 CRC=AC062778 DFADFCB8
 SaveType=Controller Pack
 Players=4
+CountPerScanline=2200
 
 [9A2B0F3226FB8D129BEB7509C169476A]
 GoodName=World Driver Championship (E) (M5) [h1C]
@@ -15799,6 +15800,7 @@ GoodName=World Driver Championship (U) [!]
 CRC=308DFEC8 CE2EB5F6
 SaveType=Controller Pack
 Players=4
+CountPerScanline=2200
 
 [4B86C373533D015860467C5DC1F1C662]
 GoodName=World Driver Championship (U) [b1]


### PR DESCRIPTION
During a race in World Driver Championship, you hear "garbage" sometimes, like a random sound you shouldn't hear. Setting CountPerScanline=2200 eliminates this for me, although it would be nice is someone else could test.

The in-race clock still seems to be pretty accurate with CountPerScanline=2200, it doesn't run too fast, but again, if someone could verify that'd be nice