### PR TITLE
Base count_per_scanline on N64 clockrate

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -1552,7 +1552,7 @@ GoodName=Biohazard 2 (J) [!]
 CRC=7EAE2488 9D40A35A
 SaveType=SRAM
 Players=1
-CountPerScanline=2200
+CountPerOp=1
 
 [13D7834291A311077B84B9A2816AF6FC]
 GoodName=Birthday Demo for Steve by Nep (PD) [b1]
@@ -2854,14 +2854,12 @@ GoodName=Conker's Bad Fur Day (E) [!]
 CRC=373F5889 9A6CA80A
 SaveType=Eeprom 16KB
 Players=4
-CountPerOp=3
 
 [00E2920665F2329B95797A7EAABC2390]
 GoodName=Conker's Bad Fur Day (U) [!]
 CRC=30C7AC50 7704072D
 SaveType=Eeprom 16KB
 Players=4
-CountPerOp=3
 
 [DB7A03B77D44DB81B8A3FCDFC4B72D8C]
 GoodName=Cruis'n Exotica (U) [!]
@@ -5969,16 +5967,12 @@ GoodName=Indiana Jones and the Infernal Machine (U) [!]
 CRC=AF9DCC15 1A723D88
 Players=1
 SaveType=Eeprom 4KB
-CountPerOp=1
-CountPerScanline=2200
 
 [6F417D30D772F4420C9384E9BBB7BC01]
 GoodName=Indiana Jones and the Infernal Machine (E)
 CRC=3A6F8C6B 2897BAEB
 SaveType=Eeprom 4KB
 Players=1
-CountPerOp=1
-CountPerScanline=2200
 
 [A7781D441AF55C4FF8AFC68AB3A59313]
 GoodName=Indy Racing 2000 (U) [!]
@@ -6650,7 +6644,6 @@ GoodName=King Hill 64 - Extreme Snowboarding (J) [!]
 CRC=519EA4E1 EB7584E8
 Players=4
 SaveType=Controller Pack
-CountPerScanline=1600
 
 [CE9AE0AA6DBBF965B1F72BC3AA6A7CEF]
 GoodName=King Hill 64 - Extreme Snowboarding (J) [b1]
@@ -11695,7 +11688,6 @@ CRC=20FD0BF1 F5CF1D87
 Players=4
 Rumble=Yes
 SaveType=Controller Pack
-CountPerOp=1
 
 [E0BB65C30C1185FD9997020A1994B07E]
 GoodName=Rat Attack (E) (M6) [f1] (NTSC)
@@ -11827,7 +11819,7 @@ CRC=9B500E8E E90550B3
 Players=1
 Rumble=Yes
 SaveType=SRAM
-CountPerScanline=2200
+CountPerOp=1
 
 [1ADD2C0217662B307CDFD876B35FBF7A]
 GoodName=Resident Evil 2 (U) (V1.1) [!]
@@ -11835,7 +11827,7 @@ CRC=AA18B1A5 07DB6AEB
 Players=1
 Rumble=Yes
 SaveType=SRAM
-CountPerScanline=2200
+CountPerOp=1
 
 [AD922DAE446A301E1AAFE1DFBAD75A2E]
 GoodName=Road Rash 64 (E) [!]
@@ -14687,7 +14679,6 @@ CRC=E688A5B8 B14B3F18
 SaveType=Controller Pack
 Players=2
 Rumble=Yes
-CountPerScanline=1600
 
 [4F0E2AF205BEEB49270154810660FF37]
 GoodName=Twisted Edge Extreme Snowboarding (E) [b1]
@@ -14705,7 +14696,6 @@ CRC=BBC99D32 117DAA80
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
-CountPerScanline=1600
 
 [0B0DF8EC747BF99F3A55A3300CE8BC0D]
 GoodName=U64 (Chrome) Demo by Horizon64 (PD) [a1]
@@ -15788,6 +15778,7 @@ GoodName=World Driver Championship (E) (M5) [!]
 CRC=AC062778 DFADFCB8
 SaveType=Controller Pack
 Players=4
+CountPerOp=1
 
 [9A2B0F3226FB8D129BEB7509C169476A]
 GoodName=World Driver Championship (E) (M5) [h1C]
@@ -15799,6 +15790,7 @@ GoodName=World Driver Championship (U) [!]
 CRC=308DFEC8 CE2EB5F6
 SaveType=Controller Pack
 Players=4
+CountPerOp=1
 
 [4B86C373533D015860467C5DC1F1C662]
 GoodName=World Driver Championship (U) [b1]

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -57,7 +57,7 @@ void init_device(struct device* dev,
     /* sp */
     unsigned int audio_signal,
     /* vi */
-    unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline)
+    unsigned int vi_clock, unsigned int expected_refresh_rate)
 {
     struct interrupt_handler interrupt_handlers[] = {
         { &dev->vi,        vi_vertical_interrupt_event }, /* VI */
@@ -91,7 +91,7 @@ void init_device(struct device* dev,
         rom + 0x40,
         &dev->r4300, &dev->ri,
         delay_si);
-    init_vi(&dev->vi, vi_clock, expected_refresh_rate, count_per_scanline, &dev->r4300);
+    init_vi(&dev->vi, vi_clock, expected_refresh_rate, &dev->r4300);
 }
 
 void poweron_device(struct device* dev)

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -82,7 +82,7 @@ void init_device(struct device* dev,
     /* sp */
     unsigned int audio_signal,
     /* vi */
-    unsigned int vi_clock, unsigned int expected_refresh_rate, unsigned int count_per_scanline);
+    unsigned int vi_clock, unsigned int expected_refresh_rate);
 
 /* Setup device such that it's state is
  * what it should be after power on.

--- a/src/device/vi/vi_controller.c
+++ b/src/device/vi/vi_controller.c
@@ -58,12 +58,10 @@ unsigned int vi_expected_refresh_rate_from_tv_standard(m64p_system_type tv_stand
 }
 
 void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected_refresh_rate,
-             unsigned int count_per_scanline,
              struct r4300_core* r4300)
 {
     vi->clock = clock;
     vi->expected_refresh_rate = expected_refresh_rate;
-    vi->count_per_scanline = count_per_scanline;
     vi->r4300 = r4300;
 }
 
@@ -72,6 +70,7 @@ void poweron_vi(struct vi_controller* vi)
     memset(vi->regs, 0, VI_REGS_COUNT*sizeof(uint32_t));
     vi->field = 0;
     vi->delay = vi->next_vi = 5000;
+    vi->count_per_scanline = 1500;
 }
 
 int read_vi_regs(void* opaque, uint32_t address, uint32_t* value)
@@ -143,6 +142,8 @@ void vi_vertical_interrupt_event(void* opaque)
 
     /* toggle vi field if in interlaced mode */
     vi->field ^= (vi->regs[VI_STATUS_REG] >> 6) & 0x1;
+
+    vi->count_per_scanline = ((vi->clock / vi->expected_refresh_rate) / (vi->regs[VI_V_SYNC_REG] + 1));
 
     /* schedule next vertical interrupt */
     vi->delay = (vi->regs[VI_V_SYNC_REG] == 0)

--- a/src/device/vi/vi_controller.h
+++ b/src/device/vi/vi_controller.h
@@ -70,7 +70,6 @@ unsigned int vi_clock_from_tv_standard(m64p_system_type tv_standard);
 unsigned int vi_expected_refresh_rate_from_tv_standard(m64p_system_type tv_standard);
 
 void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected_refresh_rate,
-             unsigned int count_per_scanline,
              struct r4300_core* r4300);
 
 void poweron_vi(struct vi_controller* vi);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -273,7 +273,6 @@ int main_set_core_defaults(void)
     ConfigSetDefaultString(g_CoreConfig, "SharedDataPath", "", "Path to a directory to search when looking for shared data files");
     ConfigSetDefaultBool(g_CoreConfig, "DelaySI", 1, "Delay interrupt after DMA SI read/write");
     ConfigSetDefaultInt(g_CoreConfig, "CountPerOp", 0, "Force number of cycles per emulated instruction");
-    ConfigSetDefaultInt(g_CoreConfig, "CountPerScanline", -1, "Modify the default count per scanline(-1 or 0=Game default)");
     ConfigSetDefaultBool(g_CoreConfig, "DisableSpecRecomp", 1, "Disable speculative precompilation in new dynarec");
 
     /* handle upgrades */
@@ -966,7 +965,6 @@ m64p_error main_run(void)
     unsigned int count_per_op;
     unsigned int emumode;
     unsigned int disable_extra_mem;
-    int count_per_scanline;
     int no_compiled_jump;
     struct file_storage eep;
     struct file_storage fla;
@@ -1001,7 +999,6 @@ m64p_error main_run(void)
         delay_si = ConfigGetParamBool(g_CoreConfig, "DelaySI");
 
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
-    count_per_scanline  = ConfigGetParamInt(g_CoreConfig, "CountPerScanline");
 
     if (ROM_PARAMS.disableextramem)
         disable_extra_mem = ROM_PARAMS.disableextramem;
@@ -1012,9 +1009,6 @@ m64p_error main_run(void)
 
     if (count_per_op <= 0)
         count_per_op = ROM_PARAMS.countperop;
-
-    if (count_per_scanline  <= 0)
-        count_per_scanline = ROM_PARAMS.countperscanline;
 
     cheat_add_hacks();
 
@@ -1096,7 +1090,7 @@ m64p_error main_run(void)
                 &clock,
                 delay_si,
                 ROM_PARAMS.audiosignal,
-                vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype), count_per_scanline);
+                vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype));
 
     // Attach rom to plugins
     if (!gfx.romOpen())

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -45,8 +45,6 @@
 
 #define CHUNKSIZE 1024*128 /* Read files 128KB at a time. */
 
-/* Amount of cpu cycles per vi scanline - empirically determined */
-enum { DEFAULT_COUNT_PER_SCANLINE = 1500 };
 /* Number of cpu cycles per instruction */
 enum { DEFAULT_COUNT_PER_OP = 2 };
 /* by default, extra mem is enabled */
@@ -180,7 +178,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.systemtype = rom_country_code_to_system_type(ROM_HEADER.Country_code);
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
     ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
-    ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
     ROM_PARAMS.delaysi = DEFAULT_DELAY_SI;
     ROM_PARAMS.cheats = NULL;
@@ -201,7 +198,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = entry->rumble;
         ROM_PARAMS.countperop = entry->countperop;
         ROM_PARAMS.audiosignal = entry->audio_signal;
-        ROM_PARAMS.countperscanline = entry->count_per_scanline;
         ROM_PARAMS.disableextramem = entry->disableextramem;
         ROM_PARAMS.delaysi = entry->delaysi;
         ROM_PARAMS.cheats = entry->cheats;
@@ -216,7 +212,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = 0;
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
         ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
-        ROM_PARAMS.countperscanline = DEFAULT_COUNT_PER_SCANLINE;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
         ROM_PARAMS.delaysi = DEFAULT_DELAY_SI;
         ROM_PARAMS.cheats = NULL;
@@ -461,7 +456,6 @@ void romdatabase_open(void)
             search->entry.rumble = 0;
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
             search->entry.audio_signal = DEFAULT_AUDIO_SIGNAL;
-            search->entry.count_per_scanline = DEFAULT_COUNT_PER_SCANLINE;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
             search->entry.delaysi = DEFAULT_DELAY_SI;
             search->entry.cheats = NULL;
@@ -510,10 +504,6 @@ void romdatabase_open(void)
             else if (!strcmp(l.name, "AudioSignal"))
             {
                 search->entry.audio_signal = atoi(l.value);
-            }
-            else if(!strcmp(l.name, "CountPerScanline"))
-            {
-                search->entry.count_per_scanline = atoi(l.value);
             }
             else if(!strcmp(l.name, "RefMD5"))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -51,7 +51,6 @@ typedef struct _rom_params
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
    int audiosignal;
-   int countperscanline;
    int disableextramem;
    int delaysi;
    int special_rom;
@@ -134,7 +133,6 @@ typedef struct
    unsigned char players; /* Local players 0-4, 2/3/4 way Netplay indicated by 5/6/7. */
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
    unsigned char audio_signal;
-   int count_per_scanline;
    unsigned char countperop;
    unsigned char disableextramem;
    unsigned char delaysi;


### PR DESCRIPTION
Right now we default to 1500, which is a pretty close guess.

It's still not great though, for instance, the European version of Pokemon Puzzle League still has audio stuttering, but the USA version is fine. Increasing the count_per_scanline to 1600 fixes the European version of the game.

This change moves away from this "guesswork" system, and calculates the count_per_scanline based on the vi clockrate.

It works pretty well, the audio now works in both the USA and European version of Pokemon Puzzle League. In Resident Evil 2, the audio and video now stay in sync (with CountPerOp=1), without any changes to the scanline setting.

More testing is welcome. I've been testing quite a few games and see no regressions so far.

EDIT: For the curious, in NTSC games, this generally increases the count_per_scanline setting to ~1545, for PAL games it's ~1590