### PR TITLE
Have emulator signal RSP interrupts again

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -3346,7 +3346,6 @@ CRC=D614E5BF A76DBCC1
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-AudioSignal=1
 
 [AF740B224E5DD0BD09F7254811559ADF]
 GoodName=Disney's Tarzan (E) [h1C]
@@ -3359,7 +3358,6 @@ CRC=001A3BD0 AFB3DE1A
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-AudioSignal=1
 
 [DF3CDD959E8C63B45F557FC197CE0E63]
 GoodName=Disney's Tarzan (G) [!]
@@ -3367,7 +3365,6 @@ CRC=4C261323 4F295E1A
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-AudioSignal=1
 
 [A29E203DDB6293B7D105BF4A2EEEDD1E]
 GoodName=Disney's Tarzan (G) [h1C]
@@ -3380,7 +3377,6 @@ CRC=CBFE69C7 F2C0AB2A
 Players=1
 SaveType=Controller Pack
 CountPerOp=1
-AudioSignal=1
 
 [C56AD8ABD0FB5EFEF1FA0229F9A2EFF0]
 GoodName=Disney's Tarzan (U) [f1] (PAL)
@@ -5830,7 +5826,6 @@ CRC=B58988E9 B1FC4BE8
 Players=4
 SaveType=Controller Pack
 CountPerOp=1
-AudioSignal=1
 
 [1F57194EA272CF5DB500D228E9C94D75]
 GoodName=Hydro Thunder (E) [f1] (NTSC)
@@ -5843,7 +5838,6 @@ CRC=29A045CE ABA9060E
 Players=4
 SaveType=Controller Pack
 CountPerOp=1
-AudioSignal=1
 
 [54F43E6B68782E98CAABEA5E7976B2BE]
 GoodName=Hydro Thunder (U) [!]
@@ -5851,7 +5845,6 @@ CRC=C8DC65EB 3D8C8904
 SaveType=Controller Pack
 Players=4
 CountPerOp=1
-AudioSignal=1
 
 [22AAD544C062FB8A2DC6B2DEB32DE188]
 GoodName=Hydro Thunder (U) [b1]
@@ -9627,7 +9620,6 @@ Players=4
 Rumble=Yes
 SaveType=Controller Pack
 CountPerOp=1
-AudioSignal=1
 
 [76DB89759121710C416ECFB1736B5E39]
 GoodName=NBA Showtime - NBA on NBC (U) [f1] (Country Check)
@@ -12039,7 +12031,6 @@ CRC=0AC61D39 ABFA03A6
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
-AudioSignal=1
 
 [207EFE58C7C221DBDFFF285AB80126C1]
 GoodName=Rugrats in Paris - The Movie (U) [!]
@@ -12047,7 +12038,6 @@ CRC=1FC21532 0B6466D4
 Players=2
 Rumble=Yes
 SaveType=Controller Pack
-AudioSignal=1
 
 [F3515A45EC01D2C9FEAFBAB2B85D72C4]
 GoodName=Rugrats in Paris - The Movie (U) [T+Spa0.10]

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -54,8 +54,6 @@ void init_device(struct device* dev,
     uint16_t eeprom_id, struct storage_backend* eeprom_storage,
     struct clock_backend* clock,
     unsigned int delay_si,
-    /* sp */
-    unsigned int audio_signal,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate)
 {
@@ -77,7 +75,7 @@ void init_device(struct device* dev,
     init_r4300(&dev->r4300, &dev->mem, &dev->ri, interrupt_handlers,
             emumode, count_per_op, no_compiled_jump, special_rom);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
-    init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri, audio_signal);
+    init_rsp(&dev->sp, &dev->r4300, &dev->dp, &dev->ri);
     init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout);
     init_pi(&dev->pi, rom, rom_size, flashram_storage, sram_storage, &dev->r4300, &dev->ri, &dev->si.pif.cic);
     init_ri(&dev->ri, dram, dram_size);

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -79,8 +79,6 @@ void init_device(struct device* dev,
     uint16_t eeprom_id, struct storage_backend* eeprom_storage,
     struct clock_backend* clock,
     unsigned int delay_si,
-    /* sp */
-    unsigned int audio_signal,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate);
 

--- a/src/device/rdp/rdp_core.c
+++ b/src/device/rdp/rdp_core.c
@@ -42,8 +42,11 @@ static int update_dpc_status(struct rdp_core* dp, uint32_t w)
     {
         dp->dpc_regs[DPC_STATUS_REG] &= ~DPC_STATUS_FREEZE;
 
-        if (!(dp->sp->regs[SP_STATUS_REG] & (SP_STATUS_HALT | SP_STATUS_BROKE)))
+        if (!(dp->sp->regs[SP_STATUS_REG] & (SP_STATUS_HALT | SP_STATUS_BROKE)) && !get_event(&dp->r4300->cp0.q, SP_INT))
+        {
             do_sp_task_on_unfreeze = 1;
+            dp->sp->regs[SP_STATUS_REG] &= ~SP_STATUS_YIELD;
+        }
     }
     if (w & DPC_STATUS_SET_FREEZE) dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_FREEZE;
 

--- a/src/device/rsp/rsp_core.h
+++ b/src/device/rsp/rsp_core.h
@@ -80,7 +80,6 @@ struct rsp_core
     uint32_t regs[SP_REGS_COUNT];
     uint32_t regs2[SP_REGS2_COUNT];
     uint32_t rsp_task_locked;
-    uint32_t audio_signal;
 
     struct r4300_core* r4300;
     struct rdp_core* dp;
@@ -105,8 +104,7 @@ static uint32_t rsp_reg2(uint32_t address)
 void init_rsp(struct rsp_core* sp,
               struct r4300_core* r4300,
               struct rdp_core* dp,
-              struct ri_controller* ri,
-              uint32_t audio_signal);
+              struct ri_controller* ri);
 
 void poweron_rsp(struct rsp_core* sp);
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1089,7 +1089,6 @@ m64p_error main_run(void)
                 (ROM_SETTINGS.savetype != EEPROM_16KB) ? 0x8000 : 0xc000, &eep_storage,
                 &clock,
                 delay_si,
-                ROM_PARAMS.audiosignal,
                 vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype));
 
     // Attach rom to plugins

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -49,8 +49,6 @@
 enum { DEFAULT_COUNT_PER_OP = 2 };
 /* by default, extra mem is enabled */
 enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
-/* by default, Audio Signal is disabled */
-enum { DEFAULT_AUDIO_SIGNAL = 0 };
 /* by default, Delay SI is enabled */
 enum { DEFAULT_DELAY_SI = 1 };
 
@@ -177,7 +175,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     /* add some useful properties to ROM_PARAMS */
     ROM_PARAMS.systemtype = rom_country_code_to_system_type(ROM_HEADER.Country_code);
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
-    ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
     ROM_PARAMS.delaysi = DEFAULT_DELAY_SI;
     ROM_PARAMS.cheats = NULL;
@@ -197,7 +194,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.players = entry->players;
         ROM_SETTINGS.rumble = entry->rumble;
         ROM_PARAMS.countperop = entry->countperop;
-        ROM_PARAMS.audiosignal = entry->audio_signal;
         ROM_PARAMS.disableextramem = entry->disableextramem;
         ROM_PARAMS.delaysi = entry->delaysi;
         ROM_PARAMS.cheats = entry->cheats;
@@ -211,7 +207,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.players = 0;
         ROM_SETTINGS.rumble = 0;
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
-        ROM_PARAMS.audiosignal = DEFAULT_AUDIO_SIGNAL;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
         ROM_PARAMS.delaysi = DEFAULT_DELAY_SI;
         ROM_PARAMS.cheats = NULL;
@@ -453,7 +448,6 @@ void romdatabase_open(void)
             search->entry.players = 0;
             search->entry.rumble = 0;
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
-            search->entry.audio_signal = DEFAULT_AUDIO_SIGNAL;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
             search->entry.delaysi = DEFAULT_DELAY_SI;
             search->entry.cheats = NULL;
@@ -498,10 +492,6 @@ void romdatabase_open(void)
                     search->entry.crc1 = search->entry.crc2 = 0;
                     DebugMessage(M64MSG_WARNING, "ROM Database: Invalid CRC on line %i", lineno);
                 }
-            }
-            else if (!strcmp(l.name, "AudioSignal"))
-            {
-                search->entry.audio_signal = atoi(l.value);
             }
             else if(!strcmp(l.name, "RefMD5"))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -50,7 +50,6 @@ typedef struct _rom_params
    m64p_system_type systemtype;
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
-   int audiosignal;
    int disableextramem;
    int delaysi;
    int special_rom;
@@ -131,7 +130,6 @@ typedef struct
    unsigned char savetype;
    unsigned char players; /* Local players 0-4, 2/3/4 way Netplay indicated by 5/6/7. */
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
-   unsigned char audio_signal;
    unsigned char countperop;
    unsigned char disableextramem;
    unsigned char delaysi;


### PR DESCRIPTION
This partially reverts https://github.com/mupen64plus/mupen64plus-core/pull/307

@Gillou68310 brought to my attention that those changes might not be quite right. The main difference here is that we unset TASKDONE/HALT/BROKE at the end of the RSP task, and set them when the interrupt is triggered. This should prevent the "doubling up" of RSP tasks that caused us issues before.

I tested Top Gear Rally 2, which used to freeze when an overlapping SP interrupt was called, it still seems fine. I also tested other "troublesome" games like Pokemon Snap, Kirby, World Driver Championship, they all seem to work well, but I'm hoping for some testing on this.

This also allows us to remove the "audio signal" hack that was added.