### PR TITLE
[WIP] Fix FBInfo

### DIFF
--- a/src/device/rdp/fb.c
+++ b/src/device/rdp/fb.c
@@ -34,45 +34,56 @@ void poweron_fb(struct fb* fb)
 {
     memset(fb, 0, sizeof(*fb));
     fb->once = 1;
+    fb->dirty_page_counter = 0;
 }
 
 
 static void pre_framebuffer_read(struct fb* fb, uint32_t address)
 {
-    size_t i;
+    if (!fb->infos[0].addr) return;
+
+    size_t i, j;
 
     for(i = 0; i < FB_INFOS_COUNT; ++i)
     {
         if (fb->infos[i].addr)
         {
-            unsigned int start = fb->infos[i].addr & 0x7FFFFF;
+            unsigned int start = fb->infos[i].addr;
             unsigned int end = start + fb->infos[i].width*
                                fb->infos[i].height*
                                fb->infos[i].size - 1;
-            if ((address & 0x7FFFFF) >= start && (address & 0x7FFFFF) <= end &&
-                    fb->dirty_page[(address & 0x7FFFFF)>>12])
+            if (address >= start && address <= end)
             {
+                for (j = 0; j < fb->dirty_page_counter; ++j)
+                {
+                    if (address >= fb->dirty_page[j] && address < fb->dirty_page[j] + 0x1000)
+                        return;
+                }
                 gfx.fBRead(address);
-                fb->dirty_page[(address & 0x7FFFFF)>>12] = 0;
+                if (fb->dirty_page_counter == FB_DIRTY_PAGES_COUNT)
+                    fb->dirty_page_counter = 0;
+                fb->dirty_page[fb->dirty_page_counter++] = address;
             }
         }
     }
 }
 
-static void pre_framebuffer_write(struct fb* fb, uint32_t address)
+static void pre_framebuffer_write(struct fb* fb, uint32_t address, uint32_t length)
 {
+    if (!fb->infos[0].addr) return;
+
     size_t i;
 
     for(i = 0; i < FB_INFOS_COUNT; ++i)
     {
         if (fb->infos[i].addr)
         {
-            unsigned int start = fb->infos[i].addr & 0x7FFFFF;
+            unsigned int start = fb->infos[i].addr;
             unsigned int end = start + fb->infos[i].width*
                                fb->infos[i].height*
                                fb->infos[i].size - 1;
-            if ((address & 0x7FFFFF) >= start && (address & 0x7FFFFF) <= end)
-                gfx.fBWrite(address, 4);
+            if (address >= start && address <= end)
+                gfx.fBWrite(address, length);
         }
     }
 }
@@ -87,7 +98,7 @@ void read_rdram_fb(void* opaque, uint32_t address, uint32_t* value)
 void write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct rdp_core* dp = (struct rdp_core*)opaque;
-    pre_framebuffer_write(&dp->fb, address);
+    pre_framebuffer_write(&dp->fb, address, 4);
     write_rdram_dram(dp->ri, address, value, mask);
 }
 
@@ -103,42 +114,34 @@ void protect_framebuffers(struct rdp_core* dp)
 
     if (gfx.fBGetFrameBufferInfo && gfx.fBRead && gfx.fBWrite)
         gfx.fBGetFrameBufferInfo(fb->infos);
-    if (gfx.fBGetFrameBufferInfo && gfx.fBRead && gfx.fBWrite
-            && fb->infos[0].addr)
-    {
-        size_t i;
-        for(i = 0; i < FB_INFOS_COUNT; ++i)
-        {
-            if (fb->infos[i].addr)
-            {
-                int j;
-                int start = fb->infos[i].addr & 0x7FFFFF;
-                int end = start + fb->infos[i].width*
-                          fb->infos[i].height*
-                          fb->infos[i].size - 1;
-                int start1 = start;
-                int end1 = end;
-                start >>= 16;
-                end >>= 16;
-                for (j=start; j<=end; j++)
-                {
-                    map_region(dp->r4300->mem, 0x0000+j, M64P_MEM_RDRAM, &fb_handler);
-                }
-                start <<= 4;
-                end <<= 4;
-                for (j=start; j<=end; j++)
-                {
-                    if (j>=start1 && j<=end1) fb->dirty_page[j]=1;
-                    else fb->dirty_page[j] = 0;
-                }
 
-                /* disable "fast memory" if framebuffer handlers are used */
-                if (fb->once != 0)
-                {
-                    fb->once = 0;
-                    dp->r4300->recomp.fast_memory = 0;
-                    invalidate_r4300_cached_code(dp->r4300, 0, 0);
-                }
+    if (!fb->infos[0].addr) return;
+
+    size_t i;
+    fb->dirty_page_counter = 0;
+
+    for(i = 0; i < FB_INFOS_COUNT; ++i)
+    {
+        if (fb->infos[i].addr)
+        {
+            int j;
+            int start = fb->infos[i].addr;
+            int end = start + fb->infos[i].width*
+                      fb->infos[i].height*
+                      fb->infos[i].size - 1;
+            start >>= 16;
+            end >>= 16;
+            for (j=start; j<=end; j++)
+            {
+                map_region(dp->r4300->mem, 0x0000+j, M64P_MEM_RDRAM, &fb_handler);
+            }
+
+            /* disable "fast memory" if framebuffer handlers are used */
+            if (fb->once != 0)
+            {
+                fb->once = 0;
+                dp->r4300->recomp.fast_memory = 0;
+                invalidate_r4300_cached_code(dp->r4300, 0, 0);
             }
         }
     }
@@ -149,26 +152,25 @@ void unprotect_framebuffers(struct rdp_core* dp)
     struct fb* fb = &dp->fb;
     struct mem_handler ram_handler = { dp->ri, RW(rdram_dram) };
 
-    if (gfx.fBGetFrameBufferInfo && gfx.fBRead && gfx.fBWrite &&
-            fb->infos[0].addr)
-    {
-        size_t i;
-        for(i = 0; i < FB_INFOS_COUNT; ++i)
-        {
-            if (fb->infos[i].addr)
-            {
-                int j;
-                int start = fb->infos[i].addr & 0x7FFFFF;
-                int end = start + fb->infos[i].width*
-                          fb->infos[i].height*
-                          fb->infos[i].size - 1;
-                start = start >> 16;
-                end = end >> 16;
+    if (!fb->infos[0].addr) return;
 
-                for (j=start; j<=end; j++)
-                {
-                    map_region(dp->r4300->mem, 0x0000+j, M64P_MEM_RDRAM, &ram_handler);
-                }
+    size_t i;
+
+    for(i = 0; i < FB_INFOS_COUNT; ++i)
+    {
+        if (fb->infos[i].addr)
+        {
+            int j;
+            int start = fb->infos[i].addr;
+            int end = start + fb->infos[i].width*
+                      fb->infos[i].height*
+                      fb->infos[i].size - 1;
+            start = start >> 16;
+            end = end >> 16;
+
+            for (j=start; j<=end; j++)
+            {
+                map_region(dp->r4300->mem, 0x0000+j, M64P_MEM_RDRAM, &ram_handler);
             }
         }
     }

--- a/src/device/rdp/fb.h
+++ b/src/device/rdp/fb.h
@@ -33,7 +33,8 @@ enum { FB_DIRTY_PAGES_COUNT = 0x800 };
 
 struct fb
 {
-    unsigned char dirty_page[FB_DIRTY_PAGES_COUNT];
+    uint32_t dirty_page[FB_DIRTY_PAGES_COUNT];
+    uint32_t dirty_page_counter;
     FrameBufferInfo infos[FB_INFOS_COUNT];
     unsigned int once;
 };


### PR DESCRIPTION
This makes the FBInfo API work as well as it does with Mupen64. It's still not perfect (doesn't work with Banjo-Kazooie or Pokemon Snap, but neither does Mupen64).

I believe there are some writes (maybe reads) in the PI controller that need to be tracked using ```pre_framebuffer_write/read```, but I can't get it working quite right. It seems to work in 1964 using GLideN64, at least the puzzle transition in Banjo does. The camera in Pokemon Snap doesn't seem to work in 1964 so I can't see if the red dot is there.

I'll keep working on this to see if I can get Pokemon Snap and Banjo working

***TODO***:

- Get it working with new dynarec
- Waiting for GLideN64 to fix FBInfo on it's side, so this can be properly tested
- Potentially need to add some ```pre_framebuffer_write/read``` to PI DMA
- Would like to have a way to communicate to the graphics plugin that FBInfo has been fixed. My idea is to write a 1 to ```fb->infos[0].addr``` before the first call to ```gfx.fBGetFrameBufferInfo``` this can be a signal to the GFX plugin, a sort of "version number", telling it that the FBInfo implementation has changed/is working.