### PR TITLE
Let travis handle the package installation directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,20 @@ language: cpp
 compiler:
   - gcc
   - clang
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libsdl1.2-dev libsdl2-dev libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev pkg-config zlib1g-dev liblircclient-dev binutils-dev nasm
+addons:
+  apt:
+    packages:
+    - libsdl1.2-dev
+    - libsdl2-dev
+    - libfreetype6-dev
+    - libgl1-mesa-dev
+    - libglu1-mesa-dev
+    - libpng-dev
+    - pkg-config
+    - zlib1g-dev
+    - liblircclient-dev
+    - binutils-dev
+    - nasm
 env:
  - OSD=0
  - OSD=1


### PR DESCRIPTION
The before_install  currently fails on Travis CI with:

    The following packages have unmet dependencies:
     libsdl2-dev : Depends: libegl1-mesa-dev
                   Depends: libgles2-mesa-dev
    E: Unable to correct problems, you have held broken packages.

This can currently only be solved by using the apt addon to install packages.