### PR TITLE
Remove DelaySI hack/option

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -8692,7 +8692,6 @@ GoodName=Mischief Makers (E) [!]
 CRC=418BDA98 248A0F58
 Players=1
 SaveType=Eeprom 4KB
-DelaySI=0
 
 [5690D74157C6623E2928A6F0353EF4AF]
 GoodName=Mischief Makers (E) [b1]
@@ -8704,7 +8703,6 @@ GoodName=Mischief Makers (U) [!]
 CRC=0B93051B 603D81F9
 Players=1
 SaveType=Eeprom 4KB
-DelaySI=0
 
 [CCF012DF82022D4797CE4CC5405E084F]
 GoodName=Mischief Makers (U) [b1]
@@ -15997,7 +15995,6 @@ GoodName=Yuke Yuke!! Trouble Makers (J) [!]
 CRC=9FE6162D E97E4037
 Players=1
 SaveType=Eeprom 4KB
-DelaySI=0
 
 [6F9E56C8A2B6BA5F6DBE5214E352590D]
 GoodName=Yuke Yuke!! Trouble Makers (J) [a1]

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -53,7 +53,6 @@ void init_device(struct device* dev,
     struct gb_cart* gb_carts,
     uint16_t eeprom_id, struct storage_backend* eeprom_storage,
     struct clock_backend* clock,
-    unsigned int delay_si,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate)
 {
@@ -87,8 +86,7 @@ void init_device(struct device* dev,
         eeprom_id, eeprom_storage,
         clock,
         rom + 0x40,
-        &dev->r4300, &dev->ri,
-        delay_si);
+        &dev->r4300, &dev->ri);
     init_vi(&dev->vi, vi_clock, expected_refresh_rate, &dev->r4300);
 }
 

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -78,7 +78,6 @@ void init_device(struct device* dev,
     struct gb_cart* gb_carts,
     uint16_t eeprom_id, struct storage_backend* eeprom_storage,
     struct clock_backend* clock,
-    unsigned int delay_si,
     /* vi */
     unsigned int vi_clock, unsigned int expected_refresh_rate);
 

--- a/src/device/si/pif.c
+++ b/src/device/si/pif.c
@@ -142,8 +142,6 @@ int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
         if (si->pif.ram[0x3f] == 0x08)
         {
             si->pif.ram[0x3f] = 0;
-            cp0_update_count(si->r4300);
-            add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
         }
         else
         {

--- a/src/device/si/si_controller.h
+++ b/src/device/si/si_controller.h
@@ -52,8 +52,6 @@ struct si_controller
 
     struct r4300_core* r4300;
     struct ri_controller* ri;
-
-    unsigned int delay_si;
 };
 
 static uint32_t si_reg(uint32_t address)
@@ -72,8 +70,7 @@ void init_si(struct si_controller* si,
              struct clock_backend* clock,
              const uint8_t* ipl3,
              struct r4300_core* r4300,
-             struct ri_controller* ri,
-             unsigned int delay_si);
+             struct ri_controller* ri);
 
 void poweron_si(struct si_controller* si);
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -271,7 +271,6 @@ int main_set_core_defaults(void)
     ConfigSetDefaultString(g_CoreConfig, "SaveStatePath", "", "Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserConfigPath}/save will be used");
     ConfigSetDefaultString(g_CoreConfig, "SaveSRAMPath", "", "Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserConfigPath}/save will be used");
     ConfigSetDefaultString(g_CoreConfig, "SharedDataPath", "", "Path to a directory to search when looking for shared data files");
-    ConfigSetDefaultBool(g_CoreConfig, "DelaySI", 1, "Delay interrupt after DMA SI read/write");
     ConfigSetDefaultInt(g_CoreConfig, "CountPerOp", 0, "Force number of cycles per emulated instruction");
     ConfigSetDefaultBool(g_CoreConfig, "DisableSpecRecomp", 1, "Disable speculative precompilation in new dynarec");
 
@@ -961,7 +960,6 @@ m64p_error main_run(void)
 {
     size_t i;
     size_t rdram_size;
-    unsigned int delay_si;
     unsigned int count_per_op;
     unsigned int emumode;
     unsigned int disable_extra_mem;
@@ -993,10 +991,6 @@ m64p_error main_run(void)
 #ifdef NEW_DYNAREC
     stop_after_jal = ConfigGetParamBool(g_CoreConfig, "DisableSpecRecomp");
 #endif
-    if (!ROM_PARAMS.delaysi)
-        delay_si = ROM_PARAMS.delaysi;
-    else
-        delay_si = ConfigGetParamBool(g_CoreConfig, "DelaySI");
 
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
 
@@ -1088,7 +1082,6 @@ m64p_error main_run(void)
                 gb_carts,
                 (ROM_SETTINGS.savetype != EEPROM_16KB) ? 0x8000 : 0xc000, &eep_storage,
                 &clock,
-                delay_si,
                 vi_clock_from_tv_standard(ROM_PARAMS.systemtype), vi_expected_refresh_rate_from_tv_standard(ROM_PARAMS.systemtype));
 
     // Attach rom to plugins

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -49,8 +49,6 @@
 enum { DEFAULT_COUNT_PER_OP = 2 };
 /* by default, extra mem is enabled */
 enum { DEFAULT_DISABLE_EXTRA_MEM = 0 };
-/* by default, Delay SI is enabled */
-enum { DEFAULT_DELAY_SI = 1 };
 
 static romdatabase_entry* ini_search_by_md5(md5_byte_t* md5);
 
@@ -176,7 +174,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     ROM_PARAMS.systemtype = rom_country_code_to_system_type(ROM_HEADER.Country_code);
     ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
     ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
-    ROM_PARAMS.delaysi = DEFAULT_DELAY_SI;
     ROM_PARAMS.cheats = NULL;
 
     memcpy(ROM_PARAMS.headername, ROM_HEADER.Name, 20);
@@ -195,7 +192,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = entry->rumble;
         ROM_PARAMS.countperop = entry->countperop;
         ROM_PARAMS.disableextramem = entry->disableextramem;
-        ROM_PARAMS.delaysi = entry->delaysi;
         ROM_PARAMS.cheats = entry->cheats;
     }
     else
@@ -208,7 +204,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         ROM_SETTINGS.rumble = 0;
         ROM_PARAMS.countperop = DEFAULT_COUNT_PER_OP;
         ROM_PARAMS.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
-        ROM_PARAMS.delaysi = DEFAULT_DELAY_SI;
         ROM_PARAMS.cheats = NULL;
     }
 
@@ -449,7 +444,6 @@ void romdatabase_open(void)
             search->entry.rumble = 0;
             search->entry.countperop = DEFAULT_COUNT_PER_OP;
             search->entry.disableextramem = DEFAULT_DISABLE_EXTRA_MEM;
-            search->entry.delaysi = DEFAULT_DELAY_SI;
             search->entry.cheats = NULL;
             search->entry.set_flags = ROMDATABASE_ENTRY_NONE;
 
@@ -570,10 +564,6 @@ void romdatabase_open(void)
             else if (!strcmp(l.name, "DisableExtraMem"))
             {
                 search->entry.disableextramem = atoi(l.value);
-            }
-            else if (!strcmp(l.name, "DelaySI"))
-            {
-                search->entry.delaysi = atoi(l.value);
             }
             else if(!strncmp(l.name, "Cheat", 5))
             {

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -353,6 +353,12 @@ static size_t romdatabase_resolve_round(void)
             entry->entry.set_flags |= ROMDATABASE_ENTRY_CHEATS;
         }
 
+        if (!isset_bitmask(entry->entry.set_flags, ROMDATABASE_ENTRY_EXTRAMEM) &&
+            isset_bitmask(ref->set_flags, ROMDATABASE_ENTRY_EXTRAMEM)) {
+            entry->entry.disableextramem = ref->disableextramem;
+            entry->entry.set_flags |= ROMDATABASE_ENTRY_EXTRAMEM;
+        }
+
         free(entry->entry.refmd5);
         entry->entry.refmd5 = NULL;
     }
@@ -564,6 +570,7 @@ void romdatabase_open(void)
             else if (!strcmp(l.name, "DisableExtraMem"))
             {
                 search->entry.disableextramem = atoi(l.value);
+                search->entry.set_flags |= ROMDATABASE_ENTRY_EXTRAMEM;
             }
             else if(!strncmp(l.name, "Cheat", 5))
             {

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -143,7 +143,8 @@ enum romdatabase_entry_set_flags {
     ROMDATABASE_ENTRY_PLAYERS = BIT(4),
     ROMDATABASE_ENTRY_RUMBLE = BIT(5),
     ROMDATABASE_ENTRY_COUNTEROP = BIT(6),
-    ROMDATABASE_ENTRY_CHEATS = BIT(7)
+    ROMDATABASE_ENTRY_CHEATS = BIT(7),
+    ROMDATABASE_ENTRY_EXTRAMEM = BIT(8)
 };
 
 typedef struct _romdatabase_search

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -51,7 +51,6 @@ typedef struct _rom_params
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
    int disableextramem;
-   int delaysi;
    int special_rom;
 } rom_params;
 
@@ -132,7 +131,6 @@ typedef struct
    unsigned char rumble; /* 0 - No, 1 - Yes boolean for rumble support. */
    unsigned char countperop;
    unsigned char disableextramem;
-   unsigned char delaysi;
    uint32_t set_flags;
 } romdatabase_entry;
 


### PR DESCRIPTION
Right now we have the SI interrupt delayed in the majority of cases. The only case I know of where DelaySI needs to be off is Mischief Makers (input doesn't work with it enabled). However, I assume if 1 game has issues, others may as well.

The SI DMA has 2 parts: the DMA itself, and the PIF processing. This PR breaks those 2 steps up (right now they both happen at the beginning of the DMA). So for a DMA write, it does the DMA at the beginning of the DMA, and the PIF processing at the end. For a DMA read, it does the PIF processing at the beginning and the DMA at the end. You get the idea.

This removes the need to disable DelaySI for Mischief Makers. Therefore, I assume this is a more accurate way to represent the DMA, and we can remove the DelaySI option altogether.

I've tested a good number of games with this change and I've seen no regressions, however more testing is obviously welcome.