### PR TITLE
Bump savestate format to 1.2

### DIFF
--- a/src/device/ai/ai_controller.h
+++ b/src/device/ai/ai_controller.h
@@ -55,13 +55,13 @@ struct ai_controller
     uint32_t regs[AI_REGS_COUNT];
     struct ai_dma fifo[AI_DMA_FIFO_SIZE];
     unsigned int samples_format_changed;
+    uint32_t last_read;
+    uint32_t delayed_carry;
 
     struct r4300_core* r4300;
     struct ri_controller* ri;
     struct vi_controller* vi;
     struct audio_out_backend* aout;
-    uint32_t last_read;
-    uint32_t delayed_carry;
 };
 
 static uint32_t ai_reg(uint32_t address)

--- a/src/device/si/game_controller.c
+++ b/src/device/si/game_controller.c
@@ -59,7 +59,7 @@ static int is_pak_present(struct controller_input_backend* cin)
     return 0;
 }
 
-static void standard_controller_reset(struct game_controller* cont)
+void standard_controller_reset(struct game_controller* cont)
 {
     /* reset controller status */
     cont->status = 0x00;
@@ -112,6 +112,7 @@ void poweron_game_controller(struct game_controller* cont)
 {
     standard_controller_reset(cont);
 
+    poweron_rumblepak(&cont->rumblepak);
     poweron_transferpak(&cont->transferpak);
 }
 

--- a/src/device/si/game_controller.h
+++ b/src/device/si/game_controller.h
@@ -62,4 +62,6 @@ void process_controller_command(void* opaque,
     const uint8_t* tx, const uint8_t* tx_buf,
     uint8_t* rx, uint8_t* rx_buf);
 
+void standard_controller_reset(struct game_controller* cont);
+
 #endif

--- a/src/device/si/pif.c
+++ b/src/device/si/pif.c
@@ -147,7 +147,7 @@ static void post_setup_channel(struct pif_channel* channel)
         channel->rx, channel->rx_buf);
 }
 
-static void disable_pif_channel(struct pif_channel* channel)
+void disable_pif_channel(struct pif_channel* channel)
 {
     channel->tx = NULL;
     channel->rx = NULL;
@@ -155,7 +155,7 @@ static void disable_pif_channel(struct pif_channel* channel)
     channel->rx_buf = NULL;
 }
 
-static size_t setup_pif_channel(struct pif_channel* channel, uint8_t* buf)
+size_t setup_pif_channel(struct pif_channel* channel, uint8_t* buf)
 {
     uint8_t tx = buf[0] & 0x3f;
     uint8_t rx = buf[1] & 0x3f;
@@ -204,7 +204,7 @@ void init_pif(struct pif* pif,
     init_cic_using_ipl3(&pif->cic, ipl3);
 }
 
-static void setup_channels_format(struct pif* pif)
+void setup_channels_format(struct pif* pif)
 {
     size_t i = 0;
     size_t k = 0;

--- a/src/device/si/pif.h
+++ b/src/device/si/pif.h
@@ -92,6 +92,9 @@ struct pif_channel
     uint8_t* rx_buf;
 };
 
+void disable_pif_channel(struct pif_channel* channel);
+size_t setup_pif_channel(struct pif_channel* channel, uint8_t* buf);
+
 struct pif
 {
     uint8_t ram[PIF_RAM_SIZE];
@@ -123,6 +126,8 @@ void init_pif(struct pif* pif,
     const uint8_t* ipl3);
 
 void poweron_pif(struct pif* pif);
+
+void setup_channels_format(struct pif* pif);
 
 int read_pif_ram(void* opaque, uint32_t address, uint32_t* value);
 int write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);

--- a/src/device/si/rumblepak.c
+++ b/src/device/si/rumblepak.c
@@ -25,10 +25,20 @@
 
 #include <string.h>
 
+void set_rumble_reg(struct rumblepak* rpk, uint8_t value)
+{
+    rpk->state = value;
+    rumble_exec(rpk->rumble, (rpk->state == 0) ? RUMBLE_STOP : RUMBLE_START);
+}
 
 void init_rumblepak(struct rumblepak* rpk, struct rumble_backend* rumble)
 {
     rpk->rumble = rumble;
+}
+
+void poweron_rumblepak(struct rumblepak* rpk)
+{
+    set_rumble_reg(rpk, 0x00);
 }
 
 void rumblepak_read_command(struct rumblepak* rpk, uint16_t address, uint8_t* data, size_t size)
@@ -49,15 +59,9 @@ void rumblepak_read_command(struct rumblepak* rpk, uint16_t address, uint8_t* da
 
 void rumblepak_write_command(struct rumblepak* rpk, uint16_t address, const uint8_t* data, size_t size)
 {
-    enum rumble_action action;
-
     if (address == 0xc000)
     {
-        action = (*data == 0)
-                ? RUMBLE_STOP
-                : RUMBLE_START;
-
-        rumble_exec(rpk->rumble, action);
+        set_rumble_reg(rpk, data[size - 1]);
     }
 }
 

--- a/src/device/si/rumblepak.h
+++ b/src/device/si/rumblepak.h
@@ -29,10 +29,14 @@ struct rumble_backend;
 
 struct rumblepak
 {
+    uint8_t state;
     struct rumble_backend* rumble;
 };
 
 void init_rumblepak(struct rumblepak* rpk, struct rumble_backend* rumble);
+void poweron_rumblepak(struct rumblepak* rpk);
+
+void set_rumble_reg(struct rumblepak* rpk, uint8_t value);
 
 void rumblepak_read_command(struct rumblepak* rpk, uint16_t address, uint8_t* data, size_t size);
 void rumblepak_write_command(struct rumblepak* rpk, uint16_t address, const uint8_t* data, size_t size);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -458,14 +458,6 @@ void main_state_inc_slot(void)
 
 void main_state_load(const char *filename)
 {
-    if (g_EmulatorRunning)
-    {
-        rumble_exec(g_dev.si.pif.controllers[0].rumblepak.rumble, RUMBLE_STOP);
-        rumble_exec(g_dev.si.pif.controllers[1].rumblepak.rumble, RUMBLE_STOP);
-        rumble_exec(g_dev.si.pif.controllers[2].rumblepak.rumble, RUMBLE_STOP);
-        rumble_exec(g_dev.si.pif.controllers[3].rumblepak.rumble, RUMBLE_STOP);
-    }
-
     if (filename == NULL) // Save to slot
         savestates_set_job(savestates_job_load, savestates_type_m64p, NULL);
     else


### PR DESCRIPTION
Recent development omitted to save several emulated device state
variables. We remedy this by appending them at the end of the savestate
file. When loading older savestate files (<1.2 or pj64) we adopt a best-effort
approach to set the missing state to a reasonnable state. But it may
cause some instability.