### PR TITLE
Add AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+
+configuration:
+  - New_Dynarec_Release
+  - Release
+platform:
+  - x86
+  - x64
+
+matrix:
+  exclude:
+    - platform: x64
+      configuration: New_Dynarec_Release
+
+before_build:
+- cmd: git clone --depth 1 https://github.com/mupen64plus/mupen64plus-win32-deps.git ../mupen64plus-win32-deps
+build:
+  project: projects/VisualStudio2013/mupen64plus-core.vcxproj
+  verbosity: minimal


### PR DESCRIPTION
AppVeyor is like Travis for Windows.

This will do 2 things for us: it will automatically test the Windows/MSVC builds, just like Travis does for the Unix builds.

It will also test the x86 new dynarec for us, hopefully this will allow us to catch any compile-time errors to the new dynarec.

Someone is going to need to configure the GitHub repo to integrate with AppVeyor, I assume @Narann might know how to do this.