### PR TITLE
Randomize PI/SI interrupt timing

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -53,6 +53,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     int special_rom,
+    int randomize_interrupt,
     /* ai */
     void* aout, const struct audio_out_backend_interface* iaout,
     /* pi */
@@ -117,7 +118,7 @@ void init_device(struct device* dev,
 
     init_memory(&dev->mem, mappings, ARRAY_SIZE(mappings), base, &dbg_handler);
     init_r4300(&dev->r4300, &dev->mem, &dev->ri, interrupt_handlers,
-            emumode, count_per_op, no_compiled_jump, special_rom);
+            emumode, count_per_op, no_compiled_jump, special_rom, randomize_interrupt);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
     init_rsp(&dev->sp, (uint32_t*)((uint8_t*)base + MM_RSP_MEM), &dev->r4300, &dev->dp, &dev->ri);
     init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, iaout);

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -100,6 +100,7 @@ void init_device(struct device* dev,
     unsigned int count_per_op,
     int no_compiled_jump,
     int special_rom,
+    int randomize_interrupt,
     /* ai */
     void* aout, const struct audio_out_backend_interface* iaout,
     /* pi */

--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -161,7 +161,7 @@ static void dma_pi_write(struct pi_controller* pi)
 
     /* schedule end of dma interrupt event */
     cp0_update_count(pi->r4300);
-    add_interrupt_event(&pi->r4300->cp0, PI_INT, longueur/8);
+    add_interrupt_event(&pi->r4300->cp0, PI_INT, (longueur/8) + add_random_interrupt_time(pi->r4300));
 }
 
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -23,6 +23,11 @@
 
 #include "interrupt.h"
 
+#ifdef __MINGW32__
+#define _CRT_RAND_S
+#include <stdlib.h>
+#endif
+
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -128,9 +133,15 @@ static int before_event(const struct cp0* cp0, unsigned int evt1, unsigned int e
 
 unsigned int add_random_interrupt_time(struct r4300_core* r4300)
 {
-    if (r4300->randomize_interrupt)
-        return rand() % 0x1000;
-    else
+    if (r4300->randomize_interrupt) {
+        unsigned int value;
+#ifdef __MINGW32__
+        rand_s(&value);
+#else
+        value = rand();
+#endif
+        return value % 0x40;
+    } else
         return 0;
 }
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -126,6 +126,14 @@ static int before_event(const struct cp0* cp0, unsigned int evt1, unsigned int e
     else return 0;
 }
 
+unsigned int add_random_interrupt_time(struct r4300_core* r4300)
+{
+    if (r4300->randomize_interrupt)
+        return rand() % 0x1000;
+    else
+        return 0;
+}
+
 void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay)
 {
     const uint32_t* cp0_regs = r4300_cp0_regs(cp0);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -41,6 +41,7 @@ void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count);
 void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);
 unsigned int get_event(const struct interrupt_queue* q, int type);
 int get_next_event_type(const struct interrupt_queue* q);
+unsigned int add_random_interrupt_time(struct r4300_core* r4300);
 
 int save_eventqueue_infos(struct cp0* cp0, char *buf);
 void load_eventqueue_infos(struct cp0* cp0, const char *buf);

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -40,9 +40,10 @@
 
 #include <assert.h>
 #include <string.h>
+#include <time.h>
 
-
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom)
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers,
+    unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom, int randomize_interrupt)
 {
     struct new_dynarec_hot_state* new_dynarec_hot_state =
 #if NEW_DYNAREC == NEW_DYNAREC_ARM
@@ -60,6 +61,8 @@ void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controll
     r4300->mem = mem;
     r4300->ri = ri;
     r4300->special_rom = special_rom;
+    r4300->randomize_interrupt = randomize_interrupt;
+    srand(time(NULL));
 }
 
 void poweron_r4300(struct r4300_core* r4300)

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -204,12 +204,13 @@ struct r4300_core
     struct ri_controller* ri;
 
     uint32_t special_rom;
+    uint32_t randomize_interrupt;
 };
 
 #define R4300_KSEG0 UINT32_C(0x80000000)
 #define R4300_KSEG1 UINT32_C(0xa0000000)
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom);
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct ri_controller* ri, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom, int randomize_interrupt);
 void poweron_r4300(struct r4300_core* r4300);
 
 void run_r4300(struct r4300_core* r4300);

--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -55,7 +55,7 @@ static void dma_si_write(struct si_controller* si)
 
     cp0_update_count(si->r4300);
     si->regs[SI_STATUS_REG] |= SI_STATUS_DMA_BUSY;
-    add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
+    add_interrupt_event(&si->r4300->cp0, SI_INT, 0x900 + add_random_interrupt_time(si->r4300));
 }
 
 static void dma_si_read(struct si_controller* si)
@@ -70,7 +70,7 @@ static void dma_si_read(struct si_controller* si)
 
     cp0_update_count(si->r4300);
     si->regs[SI_STATUS_REG] |= SI_STATUS_RD_BUSY;
-    add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
+    add_interrupt_event(&si->r4300->cp0, SI_INT, 0x900 + add_random_interrupt_time(si->r4300));
 }
 
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -262,6 +262,7 @@ int main_set_core_defaults(void)
     ConfigSetDefaultString(g_CoreConfig, "SharedDataPath", "", "Path to a directory to search when looking for shared data files");
     ConfigSetDefaultInt(g_CoreConfig, "CountPerOp", 0, "Force number of cycles per emulated instruction");
     ConfigSetDefaultBool(g_CoreConfig, "DisableSpecRecomp", 1, "Disable speculative precompilation in new dynarec");
+    ConfigSetDefaultBool(g_CoreConfig, "RandomizeInterrupt", 1, "Randomize PI/SI Interrupt Timing");
 
     /* handle upgrades */
     if (bUpgrade)
@@ -1075,6 +1076,7 @@ m64p_error main_run(void)
     unsigned int emumode;
     unsigned int disable_extra_mem;
     int no_compiled_jump;
+    int randomize_interrupt;
     struct file_storage eep;
     struct file_storage fla;
     struct file_storage sra;
@@ -1092,6 +1094,7 @@ m64p_error main_run(void)
     savestates_set_autoinc_slot(ConfigGetParamBool(g_CoreConfig, "AutoStateSlotIncrement"));
     savestates_select_slot(ConfigGetParamInt(g_CoreConfig, "CurrentStateSlot"));
     no_compiled_jump = ConfigGetParamBool(g_CoreConfig, "NoCompiledJump");
+    randomize_interrupt = ConfigGetParamBool(g_CoreConfig, "RandomizeInterrupt");
 #ifdef NEW_DYNAREC
     stop_after_jal = ConfigGetParamBool(g_CoreConfig, "DisableSpecRecomp");
 #endif
@@ -1270,6 +1273,7 @@ m64p_error main_run(void)
                 count_per_op,
                 no_compiled_jump,
                 ROM_PARAMS.special_rom,
+                randomize_interrupt,
                 &g_dev.ai, &g_iaudio_out_backend_plugin_compat,
                 g_rom_size,
                 &fla, &g_ifile_storage,


### PR DESCRIPTION
This is to address https://github.com/mupen64plus/mupen64plus-core/issues/361

This is ready, but I put the WIP tag because it should get some testing. Right now I've only done very limited testing.

2 easy tests for this: The intro to Smash Bros and Star Wars Ep I Racer. The master hand should pull a random character out of the box, right now it always pulls out Mario. The Ep I Racer intro should either be Anakin or Subulba, right now it's always Subulba.

I added a core option to enable/disable randomizing the interrupt timing. Disabling it will be needed for some scenarios like regression testing, netplay, and possibly TAS runs. I think enabling it by default would be good, since it's more similar to how the N64 operated, assuming there aren't any regressions.