### PR TITLE
Better flags and timing for PI/SI interrupts

### DIFF
--- a/src/device/pi/pi_controller.c
+++ b/src/device/pi/pi_controller.c
@@ -154,9 +154,8 @@ static void dma_pi_write(struct pi_controller* pi)
         force_detected_rdram_size_hack(&pi->ri->rdram, pi->cic);
     }
 
-    /* mark both DMA and IO as busy */
-    pi->regs[PI_STATUS_REG] |=
-        PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY;
+    /* mark DMA as busy */
+    pi->regs[PI_STATUS_REG] |= PI_STATUS_DMA_BUSY;
 
     /* schedule end of dma interrupt event */
     cp0_update_count(pi->r4300);
@@ -222,6 +221,8 @@ int write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
     case PI_STATUS_REG:
         if (value & mask & 2)
             clear_rcp_interrupt(pi->r4300, MI_INTR_PI);
+        if (value & mask & 1)
+            DebugMessage(M64MSG_WARNING, "Unimplemented PI reset!");
         return 0;
 
     case PI_BSD_DOM1_LAT_REG:

--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -40,18 +40,13 @@ enum
 
 static void dma_si_write(struct si_controller* si)
 {
-    int i;
-
     if (si->regs[SI_PIF_ADDR_WR64B_REG] != 0x1FC007C0)
     {
         DebugMessage(M64MSG_ERROR, "dma_si_write(): unknown SI use");
         return;
     }
 
-    for (i = 0; i < PIF_RAM_SIZE; i += 4)
-    {
-        *((uint32_t*)(&si->pif.ram[i])) = sl(si->ri->rdram.dram[(si->regs[SI_DRAM_ADDR_REG]+i)/4]);
-    }
+    si->si_type = SI_DMA_WRITE;
 
     cp0_update_count(si->r4300);
     si->regs[SI_STATUS_REG] |= SI_STATUS_DMA_BUSY;
@@ -66,10 +61,10 @@ static void dma_si_read(struct si_controller* si)
         return;
     }
 
-    update_pif_ram(si);
+    si->si_type = SI_DMA_READ;
 
     cp0_update_count(si->r4300);
-    si->regs[SI_STATUS_REG] |= SI_STATUS_RD_BUSY;
+    si->regs[SI_STATUS_REG] |= SI_STATUS_DMA_BUSY;
     add_interrupt_event(&si->r4300->cp0, SI_INT, /*0x100*/0x900);
 }
 
@@ -106,6 +101,8 @@ void poweron_si(struct si_controller* si)
     memset(si->regs, 0, SI_REGS_COUNT*sizeof(uint32_t));
 
     poweron_pif(&si->pif);
+
+    si->si_type = SI_NONE;
 }
 
 
@@ -152,22 +149,30 @@ int write_si_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 void si_end_of_dma_event(void* opaque)
 {
     struct si_controller* si = (struct si_controller*)opaque;
+    int i;
 
-    if (si->regs[SI_STATUS_REG] & SI_STATUS_DMA_BUSY)
+    if (si->si_type == SI_DMA_WRITE)
     {
+        for (i = 0; i < PIF_RAM_SIZE; i += 4)
+        {
+            *((uint32_t*)(&si->pif.ram[i])) = sl(si->ri->rdram.dram[(si->regs[SI_DRAM_ADDR_REG]+i)/4]);
+        }
+
         process_pif_ram(si);
     }
-    else if (si->regs[SI_STATUS_REG] & SI_STATUS_RD_BUSY)
+    else if (si->si_type == SI_DMA_READ)
     {
-        int i;
+        update_pif_ram(si);
+
         for (i = 0; i < PIF_RAM_SIZE; i += 4)
         {
             si->ri->rdram.dram[(si->regs[SI_DRAM_ADDR_REG]+i)/4] = sl(*(uint32_t*)(&si->pif.ram[i]));
         }
     }
 
+    si->si_type = SI_NONE;
     /* trigger SI interrupt */
-    si->regs[SI_STATUS_REG] &= ~(SI_STATUS_DMA_BUSY | SI_STATUS_RD_BUSY);
+    si->regs[SI_STATUS_REG] &= ~SI_STATUS_DMA_BUSY;
     si->regs[SI_STATUS_REG] |= SI_STATUS_INTERRUPT;
     raise_rcp_interrupt(si->r4300, MI_INTR_SI);
 }

--- a/src/device/si/si_controller.h
+++ b/src/device/si/si_controller.h
@@ -32,6 +32,13 @@ struct controller_input_backend;
 struct rumble_backend;
 struct storage_backend;
 
+enum
+{
+    SI_NONE,
+    SI_DMA_READ,
+    SI_DMA_WRITE
+};
+
 enum si_registers
 {
     SI_DRAM_ADDR_REG,
@@ -52,6 +59,8 @@ struct si_controller
 
     struct r4300_core* r4300;
     struct ri_controller* ri;
+
+    uint32_t si_type;
 };
 
 static uint32_t si_reg(uint32_t address)

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -614,6 +614,9 @@ int savestates_load_m64p(char *filepath)
 
         /* extra vi state */
         g_dev.vi.count_per_scanline = GETDATA(curr, unsigned int);
+
+        /* extra si state */
+        g_dev.si.si_type = GETDATA(curr, uint32_t);
     }
     else {
         /* extra ai state */
@@ -649,6 +652,9 @@ int savestates_load_m64p(char *filepath)
         g_dev.vi.count_per_scanline = (g_dev.vi.regs[VI_V_SYNC_REG] == 0)
             ? 1500
             : ((g_dev.vi.clock / g_dev.vi.expected_refresh_rate) / (g_dev.vi.regs[VI_V_SYNC_REG] + 1));
+
+        /* extra si state */
+        g_dev.si.si_type = 0;
     }
 
     /* Zilmar-Spec plugin expect a call with control_id = -1 when RAM processing is done */
@@ -836,7 +842,8 @@ static int savestates_load_pj64(char *filepath, void *handle,
         ? 1500
         : ((g_dev.vi.clock / g_dev.vi.expected_refresh_rate) / (g_dev.vi.regs[VI_V_SYNC_REG] + 1));
 
-
+    /* extra si state */
+    g_dev.si.si_type = 0;
 
     // ai_register
     g_dev.ai.regs[AI_DRAM_ADDR_REG] = GETDATA(curr, uint32_t);
@@ -1503,6 +1510,7 @@ int savestates_save_m64p(char *filepath)
 
     PUTDATA(curr, unsigned int, g_dev.vi.count_per_scanline);
 
+    PUTDATA(curr, uint32_t, g_dev.si.si_type);
 
     init_work(&save->work, savestates_save_m64p_work);
     queue_work(&save->work);


### PR DESCRIPTION
I've actually been working on this and researching this for a while now, but I never found a case of it helping until @bsmiles32 comment in my other PR (https://github.com/mupen64plus/mupen64plus-core/pull/415#issuecomment-333855557), where Conker's would freeze if the PI timing was off (adding 0x1000 to the PI interrupt delay causes the game to freeze at the N64 logo)

The PI and SI have 2 kinds of data transfers: IO and DMA. It had always been a little unclear to me what the difference is but now I understand. A DMA is a DMA, initiated by a write to the read/write register of the PI/SI. IO is when there is a write/read to the memory space of the ROM or PIF.

With this PR, the DMA's only set the DMA_BUSY flag, not the IO_BUSY flag. I never actually set the IO_BUSY flag, I just trigger an interrupt immediately after an IO read/write.

The SI processing still needs to be done at the end of the DMA, not the beginning (or else Mischief Makers input won't work). I had to add a "si_type" field to keep track of what kind of processing to do at the end of the DMA. I added it to the end of the current savestate revision. I'm hoping to "sneak it in" there since it's only been a couple days since it was last bumped...

EDIT: I forgot where I was going with all this! This change makes Conker's more tolerant to PI timing changes (adding 0x1000 doesn't freeze the game anymore), and it's hopefully a generally more accurate way of emulating the DMA/IO interrupts