### PR TITLE
SDL_Delay is only called just before input polling.

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -857,15 +857,14 @@ static void pause_loop(void)
  * Allow the core to perform various things */
 void new_vi(void)
 {
-    gs_apply_cheats();
-
-    main_check_inputs();
-
     timed_sections_refresh();
 
-    pause_loop();
+    gs_apply_cheats();
 
     apply_speed_limiter();
+    main_check_inputs();
+
+    pause_loop();
 }
 
 static void open_mpk_file(struct file_storage* storage)


### PR DESCRIPTION
This should help reduce the input lag as suggested by wareya in issue https://github.com/mupen64plus/mupen64plus-core/issues/164

Be sure to test with `AUDIO_SYNC = False` in audio plugin so that SDL_Delay is only called right before input_polling.

@wareya can you test if it makes a difference for you ?