### PR TITLE
Add note about SP_STATUS_REG

### DIFF
--- a/src/api/m64p_plugin.h
+++ b/src/api/m64p_plugin.h
@@ -110,6 +110,10 @@ typedef struct {
     unsigned int version;
     /* SP_STATUS_REG and RDRAM_SIZE were added in version 2 of GFX_INFO.version.
        Plugins should only attempt to read these values if GFX_INFO.version is at least 2. */
+
+    /* The RSP plugin should set (HALT | BROKE | TASKDONE) *before* calling ProcessDList.
+       It should not modify SP_STATUS_REG after ProcessDList has returned.
+       This will allow the GFX plugin to unset these bits if it needs. */
     unsigned int * SP_STATUS_REG;
     const unsigned int * RDRAM_SIZE;
 } GFX_INFO;


### PR DESCRIPTION
I just wanted to add a short note about the expected usage of the SP_STATUS_REG register by the RSP and GFX plugins.

Right now, after the RSP plugin calls ProcessDList(), it sets HALT | BROKE | TASKDONE. I am proposing that the RSP plugin sets those bits before calling ProcessDList(), and then the GFX plugin can unset them if it needs.

This will maintain backwards compatibility with current GFX plugins, while still allowing future GFX plugins to modify SP_STATUS_REG if needed