### PR TITLE
Do a proper open bus read

### DIFF
--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -86,12 +86,14 @@ static int writed(writefn write_word, void* opaque, uint32_t address, uint64_t v
 
 static void read_nothing(void)
 {
-    *g_dev.r4300.rdword = 0;
+    *g_dev.r4300.rdword = *r4300_address(&g_dev.r4300) & 0xFFFF;
+    *g_dev.r4300.rdword = (*g_dev.r4300.rdword << 16) | *g_dev.r4300.rdword;
 }
 
 static void read_nothingd(void)
 {
-    *g_dev.r4300.rdword = 0;
+    *g_dev.r4300.rdword = *r4300_address(&g_dev.r4300) & 0xFFFF;
+    *g_dev.r4300.rdword = (*g_dev.r4300.rdword << 16) | *g_dev.r4300.rdword;
 }
 
 static void write_nothing(void)


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-core/issues/418

Castlevania tries to read from "Cartridge Domain 1 Address 3" (http://en64.shoutwiki.com/wiki/N64_Memory#Memory_Map_Overview)

I have no idea with that address space is for. I seem to recall Paper Mario tried to access it as well via PI DMA when I was working on fixing duplicate saving in that game. Nothing I read gives me any hints as to what it might be for.

Anyway, when the N64 tries to read from unmapped memory, it's an "open bus" and it shouldn't just return 0. It returns some strange mash-up of the address.

Interestingly, the intro in the E version is different from the U version in Castlevania (the guy takes a different path and fights different enemies). I guess they were programmed differently, which might explain why this didn't happen in the E version