### PR TITLE
Remove CountPerOp=1 for Ep I Racer

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -14298,7 +14298,6 @@ CRC=53ED2DC4 06258002
 Players=2
 SaveType=Eeprom 16KB
 Rumble=Yes
-CountPerOp=1
 
 [8CC7E31925FBFA13A584F529E8912207]
 GoodName=Star Wars Episode I - Racer (E) (M3) [f1] (Save)
@@ -14311,7 +14310,6 @@ CRC=61F5B152 046122AB
 Players=2
 SaveType=Eeprom 16KB
 Rumble=Yes
-CountPerOp=1
 
 [CFA21E43DAC50DFF3122ABF3AF3511F8]
 GoodName=Star Wars Episode I - Racer (J) [b1]
@@ -14324,7 +14322,6 @@ CRC=72F70398 6556A98B
 Players=2
 SaveType=Eeprom 16KB
 Rumble=Yes
-CountPerOp=1
 
 [E4353B43CB4302B7A308A42D6BB04435]
 GoodName=Star Wars Episode I - Racer (U) [f1] (Save)


### PR DESCRIPTION
Some PR over the summer has fixed the audio in this game with CountPerOp=2, it used to not work (https://github.com/mupen64plus/mupen64plus-core/pull/272)

The CPU usage in this game is a lot higher with CountPerOp=1, so since there are no more issues with CountPerOp=2, it should be the default again. Hopefully this means I can finally play it on my tablet at full speed!