### PR TITLE
CountPerOp=1 for Gauntlet Legends

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -5581,6 +5581,7 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
+CountPerOp=1
 
 [0806E6DB8B2BF0501BE9F2D78D280DCF]
 GoodName=Gauntlet Legends (E) [b1]
@@ -5594,6 +5595,7 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
+CountPerOp=1
 
 [9CB963E8B71F18568F78EC1AF120362E]
 GoodName=Gauntlet Legends (U) [!]
@@ -5602,6 +5604,7 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
+CountPerOp=1
 
 [50F8E73CA0160EB1A339AC2137A7B559]
 GoodName=Gauntlet Legends (U) [f1] (PAL)


### PR DESCRIPTION
Allows for better performance when using GLideN64. Still needs a fairly quick CPU, but the audio is really bad when using GLideN64 HLE with CountPerOp=2