### PR TITLE
Add support for SRAM cpu read/write

### DIFF
--- a/src/device/cart/cart.h
+++ b/src/device/cart/cart.h
@@ -69,8 +69,6 @@ void poweron_cart(struct cart* cart);
 
 void read_cart_dom2(void* opaque, uint32_t address, uint32_t* value);
 void write_cart_dom2(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
-void read_cart_dom2_dummy(void* opaque, uint32_t address, uint32_t* value);
-void write_cart_dom2_dummy(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 unsigned int cart_dom2_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
 unsigned int cart_dom2_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);

--- a/src/device/cart/flashram.c
+++ b/src/device/cart/flashram.c
@@ -93,6 +93,8 @@ static void flashram_command(struct flashram* flashram, uint32_t command)
         flashram->mode = FLASHRAM_MODE_READ;
         flashram->status = 0x11118004f0000000LL;
         break;
+    case 0x00000000:
+        break;
     default:
         DebugMessage(M64MSG_WARNING, "unknown flashram command: %" PRIX32, command);
         break;

--- a/src/device/cart/sram.c
+++ b/src/device/cart/sram.c
@@ -74,3 +74,24 @@ unsigned int sram_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uin
     return /* length / 8 */0x1000;
 }
 
+void read_sram(void* opaque, uint32_t address, uint32_t* value)
+{
+    struct sram* sram = (struct sram*)opaque;
+    const uint8_t* mem = sram->istorage->data(sram->storage);
+
+    address &= SRAM_ADDR_MASK;
+
+    *value = *(uint32_t*)(mem + address);
+}
+
+void write_sram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+{
+    struct sram* sram = (struct sram*)opaque;
+    uint8_t* mem = sram->istorage->data(sram->storage);
+
+    address &= SRAM_ADDR_MASK;
+
+    *(uint32_t*)(mem + address) = value & mask;
+
+    sram->istorage->save(sram->storage);
+}

--- a/src/device/cart/sram.c
+++ b/src/device/cart/sram.c
@@ -32,7 +32,7 @@
 
 void format_sram(uint8_t* mem)
 {
-    memset(mem, 0, SRAM_SIZE);
+    memset(mem, 0xff, SRAM_SIZE);
 }
 
 void init_sram(struct sram* sram,

--- a/src/device/cart/sram.c
+++ b/src/device/cart/sram.c
@@ -91,7 +91,7 @@ void write_sram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 
     address &= SRAM_ADDR_MASK;
 
-    *(uint32_t*)(mem + address) = value & mask;
+    masked_write((uint32_t*)(mem + address), value, mask);
 
     sram->istorage->save(sram->storage);
 }

--- a/src/device/cart/sram.h
+++ b/src/device/cart/sram.h
@@ -41,5 +41,7 @@ void init_sram(struct sram* sram,
 
 unsigned int sram_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
 unsigned int sram_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
+void read_sram(void* opaque, uint32_t address, uint32_t* value);
+void write_sram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 #endif

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -147,8 +147,7 @@ void init_device(struct device* dev,
         { A(MM_PI_REGS, 0xffff), M64P_MEM_PI, { &dev->pi, RW(pi_regs) } },
         { A(MM_RI_REGS, 0xffff), M64P_MEM_RI, { &dev->ri, RW(ri_regs) } },
         { A(MM_SI_REGS, 0xffff), M64P_MEM_SI, { &dev->si, RW(si_regs) } },
-        { A(MM_CART_DOM2, 0xffff), M64P_MEM_FLASHRAMSTAT, { &dev->cart, R(cart_dom2), W(cart_dom2_dummy)  } },
-        { A(MM_CART_DOM2 + 0x10000, 0xffff), M64P_MEM_NOTHING, { &dev->cart, R(cart_dom2_dummy), W(cart_dom2) } },
+        { A(MM_CART_DOM2, 0x1ffff), M64P_MEM_FLASHRAMSTAT, { &dev->cart, RW(cart_dom2)  } },
         { A(MM_CART_ROM, rom_size-1), M64P_MEM_ROM, { &dev->cart.cart_rom, RW(cart_rom) } },
         { A(MM_PIF_MEM, 0xffff), M64P_MEM_PIF, { &dev->si, RW(pif_ram) } }
     };


### PR DESCRIPTION
This will fix https://github.com/mupen64plus/mupen64plus-core/issues/456 once https://github.com/mupen64plus/mupen64plus-core/pull/455 is merged.

The auto-detection scheme we use to detect SRAM/flashram doesn't seem to work with Waialae Country Club.

This change will take the value in ROM_SETTINGS if it can, but still try to fallback to the auto-detection scheme if ROM_SETTINGS doesn't specify the type.

This PR adds support for reading/writing to sram via read_cart_dom2/write_cart_dom2, Waialae Country Club does this.

Finally, it gets rid of read_cart_dom2_dummy/write_cart_dom2_dummy, and maps the whole DOM2 address space to read_cart_dom2/write_cart_dom2. I'm not sure why the dummy functions are there, perhaps someone knows the back story?

So far I've tested Paper Mario and Waialae Country Club, I'll do some more testing. I'm hoping @bsmiles32 can comment on this since you seem to be pretty familiar with the memory mapping and just refactored this code