### PR TITLE
Fix reset

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -121,7 +121,7 @@ void init_device(struct device* dev,
         { &dev->ai,        ai_end_of_dma_event         }, /* AI */
         { &dev->sp,        rsp_interrupt_event         }, /* SP */
         { &dev->dp,        rdp_interrupt_event         }, /* DP */
-        { &dev->r4300,     hw2_int_handler             }, /* HW2 */
+        { &dev->si.pif,    hw2_int_handler             }, /* HW2 */
         { dev,             nmi_int_handler             }, /* NMI */
         { dev,             reset_hard_handler          }  /* reset_hard */
     };
@@ -231,7 +231,5 @@ void hard_reset_device(struct device* dev)
 
 void soft_reset_device(struct device* dev)
 {
-    /* schedule HW2 interrupt now and an NMI after 1/2 seconds */
-    add_interrupt_event(&dev->r4300.cp0, HW2_INT, 0);
-    add_interrupt_event(&dev->r4300.cp0, NMI_INT, 50000000);
+    reset_pif(&dev->si.pif, 1); /* Soft reset */
 }

--- a/src/device/pifbootrom/pifbootrom.c
+++ b/src/device/pifbootrom/pifbootrom.c
@@ -66,7 +66,7 @@ void pifbootrom_hle_execute(struct r4300_core* r4300)
     /* XXX: wait for SP to finish last operation (poll halt) */
 
     /* stop RSP (halt + clear interrupts) */
-    r4300_write_aligned_word(r4300, R4300_KSEG1 + MM_RSP_REGS  + 4*SP_STATUS_REG, 0x0a, ~UINT32_C(0));
+    r4300_write_aligned_word(r4300, R4300_KSEG1 + MM_RSP_REGS + 4*SP_STATUS_REG, 0x0a, ~UINT32_C(0));
 
     /* XXX: wait for SP DMA to finish (poll busy) */
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -449,6 +449,9 @@ void nmi_int_handler(void* opaque)
     g_gs_vi_counter = 0;
     init_interrupt(&r4300->cp0);
 
+    dev->vi.next_vi = cp0_regs[CP0_COUNT_REG] + dev->vi.delay;
+    add_interrupt_event_count(&r4300->cp0, VI_INT, dev->vi.next_vi);
+
     // clear the audio status register so that subsequent write_ai() calls will work properly
     dev->ai.regs[AI_STATUS_REG] = 0;
     // set ErrorEPC with the last instruction address

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -431,17 +431,6 @@ void special_int_handler(void* opaque)
     add_interrupt_event_count(cp0, SPECIAL_INT, 0);
 }
 
-void hw2_int_handler(void* opaque)
-{
-    struct r4300_core* r4300 = (struct r4300_core*)opaque;
-    uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
-
-    cp0_regs[CP0_STATUS_REG] = (cp0_regs[CP0_STATUS_REG] & ~(CP0_STATUS_SR | CP0_STATUS_TS | UINT32_C(0x00080000))) | CP0_STATUS_IM4;
-    cp0_regs[CP0_CAUSE_REG] = (cp0_regs[CP0_CAUSE_REG] | CP0_CAUSE_IP4) & ~CP0_CAUSE_EXCCODE_MASK;
-
-    exception_general(r4300);
-}
-
 /* XXX: this should only require r4300 struct not device ? */
 /* XXX: This is completly WTF ! */
 void nmi_int_handler(void* opaque)

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -51,7 +51,6 @@ void reset_hard_handler(void* opaque);
 void compare_int_handler(void* opaque);
 void check_int_handler(void* opaque);
 void special_int_handler(void* opaque);
-void hw2_int_handler(void* opaque);
 void nmi_int_handler(void* opaque);
 
 #define VI_INT      0x001

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -38,7 +38,6 @@
 #endif
 #include "main/main.h"
 
-#include <assert.h>
 #include <string.h>
 #include <time.h>
 
@@ -355,7 +354,12 @@ int r4300_read_aligned_dword(struct r4300_core* r4300, uint32_t address, uint64_
 {
     uint32_t w[2];
 
-    assert((address & 0x7) == 0);
+    /* XXX: unaligned dword accesses should trigger a address error,
+     * but inaccurate timing of the core can lead to unaligned address on reset
+     * so just emit a warning and keep going */
+    if ((address & 0x7) != 0) {
+        DebugMessage(M64MSG_WARNING, "Unaligned dword read %08x", address);
+    }
 
     if ((address & UINT32_C(0xc0000000)) != UINT32_C(0x80000000)) {
         address = virtual_to_physical_address(r4300, address, 0);
@@ -403,7 +407,12 @@ int r4300_write_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_
 /* Write aligned dword to memory */
 int r4300_write_aligned_dword(struct r4300_core* r4300, uint32_t address, uint64_t value, uint64_t mask)
 {
-    assert((address & 0x7) == 0);
+    /* XXX: unaligned dword accesses should trigger a address error,
+     * but inaccurate timing of the core can lead to unaligned address on reset
+     * so just emit a warning and keep going */
+    if ((address & 0x7) != 0) {
+        DebugMessage(M64MSG_WARNING, "Unaligned dword write %08x", address);
+    }
 
     if ((address & UINT32_C(0xc0000000)) != UINT32_C(0x80000000)) {
 

--- a/src/device/si/pif.h
+++ b/src/device/si/pif.h
@@ -29,6 +29,7 @@
 
 struct joybus_device_interface;
 struct si_controller;
+struct r4300_core;
 
 enum { PIF_RAM_SIZE = 0x40 };
 enum { PIF_CHANNELS_COUNT = 5 };
@@ -53,6 +54,8 @@ struct pif
     struct pif_channel channels[PIF_CHANNELS_COUNT];
 
     struct cic cic;
+
+    struct r4300_core* r4300;
 };
 
 static uint32_t pif_ram_address(uint32_t address)
@@ -65,9 +68,12 @@ void init_pif(struct pif* pif,
     uint8_t* pif_base,
     void* jbds[PIF_CHANNELS_COUNT],
     const struct joybus_device_interface* ijbds[PIF_CHANNELS_COUNT],
-    const uint8_t* ipl3);
+    const uint8_t* ipl3,
+    struct r4300_core* r4300);
 
 void poweron_pif(struct pif* pif);
+
+void reset_pif(struct pif* pif, unsigned int reset_type);
 
 void setup_channels_format(struct pif* pif);
 
@@ -76,6 +82,8 @@ void write_pif_ram(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 
 void process_pif_ram(struct si_controller* si);
 void update_pif_ram(struct si_controller* si);
+
+void hw2_int_handler(void* opaque);
 
 #endif
 

--- a/src/device/si/si_controller.c
+++ b/src/device/si/si_controller.c
@@ -52,7 +52,8 @@ void init_si(struct si_controller* si,
     init_pif(&si->pif,
         pif_base,
         jbds, ijbds,
-        ipl3);
+        ipl3,
+        r4300);
 }
 
 void poweron_si(struct si_controller* si)


### PR DESCRIPTION
@Gillou68310 noticed that reset has been broken since remove_memd PR and bisected it at PIF Boot ROM rewrite. But a deeper analysis revealed several point of regressions (at least 3) and general weakness of the reset implementation. I'm not sure this PR fixes all regressions related to reset as I can still trigger some cascade of warnings at times. But I haven't been able to exactly track down why it is like that and what broke it.