### PR TITLE
Add support for different flashram types.

### DIFF
--- a/src/device/cart/cart.c
+++ b/src/device/cart/cart.c
@@ -104,6 +104,7 @@ void init_cart(struct cart* cart,
                uint16_t eeprom_type,
                void* eeprom_storage, const struct storage_backend_interface* ieeprom_storage,
                /* flashram */
+               uint32_t flashram_type,
                void* flashram_storage, const struct storage_backend_interface* iflashram_storage,
                /* sram */
                void* sram_storage, const struct storage_backend_interface* isram_storage)
@@ -120,6 +121,7 @@ void init_cart(struct cart* cart,
         eeprom_type, eeprom_storage, ieeprom_storage);
 
     init_flashram(&cart->flashram,
+        flashram_type,
         flashram_storage, iflashram_storage, (uint8_t*)rdram->dram);
 
     init_sram(&cart->sram,

--- a/src/device/cart/cart.h
+++ b/src/device/cart/cart.h
@@ -61,6 +61,7 @@ void init_cart(struct cart* cart,
                uint16_t eeprom_type,
                void* eeprom_storage, const struct storage_backend_interface* ieeprom_storage,
                /* flashram */
+               uint32_t flashram_type,
                void* flashram_storage, const struct storage_backend_interface* iflashram_storage,
                /* sram */
                void* sram_storage, const struct storage_backend_interface* isram_storage);

--- a/src/device/cart/flashram.h
+++ b/src/device/cart/flashram.h
@@ -29,6 +29,14 @@ struct storage_backend_interface;
 
 enum { FLASHRAM_SIZE = 0x20000 };
 
+/* flashram manufacture and device code */
+enum {
+    MX29L1100_ID = 0x00c2001e,
+    MX29L1101_ID = 0x00c2001d,
+    MN63F8MPN_ID = 0x003200f1,
+};
+
+
 enum flashram_mode
 {
     FLASHRAM_MODE_NOPES = 0,
@@ -41,7 +49,7 @@ enum flashram_mode
 struct flashram
 {
     enum flashram_mode mode;
-    uint64_t status;
+    uint32_t status[2];
     unsigned int erase_offset;
     unsigned int write_pointer;
 
@@ -51,6 +59,7 @@ struct flashram
 };
 
 void init_flashram(struct flashram* flashram,
+                   uint32_t flashram_type,
                    void* storage,
                    const struct storage_backend_interface* istorage,
                    const uint8_t* dram);

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -108,6 +108,7 @@ void init_device(struct device* dev,
     size_t rom_size,
     uint16_t eeprom_type,
     void* eeprom_storage, const struct storage_backend_interface* ieeprom_storage,
+    uint32_t flashram_type,
     void* flashram_storage, const struct storage_backend_interface* iflashram_storage,
     void* sram_storage, const struct storage_backend_interface* isram_storage)
 {
@@ -182,7 +183,7 @@ void init_device(struct device* dev,
             &dev->r4300,
             &dev->ri.rdram, &dev->si.pif.cic,
             eeprom_type, eeprom_storage, ieeprom_storage,
-            flashram_storage, iflashram_storage,
+            flashram_type, flashram_storage, iflashram_storage,
             sram_storage, isram_storage);
 }
 

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -115,6 +115,7 @@ void init_device(struct device* dev,
     size_t rom_size,
     uint16_t eeprom_type,
     void* eeprom_storage, const struct storage_backend_interface* ieeprom_storage,
+    uint32_t flashram_type,
     void* flashram_storage, const struct storage_backend_interface* iflashram_storage,
     void* sram_storage, const struct storage_backend_interface* isram_storage);
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1087,6 +1087,10 @@ m64p_error main_run(void)
     struct file_storage mpk_storages[GAME_CONTROLLERS_COUNT];
     struct file_storage mpk;
 
+    /* XXX: select type of flashram from db */
+    uint32_t flashram_type = MX29L1100_ID;
+
+
     /* take the r4300 emulator mode from the config file at this point and cache it in a global variable */
     emumode = ConfigGetParamInt(g_CoreConfig, "R4300Emulator");
 
@@ -1271,6 +1275,7 @@ m64p_error main_run(void)
                 g_rom_size,
                 (ROM_SETTINGS.savetype != EEPROM_16KB) ? JDT_EEPROM_4K : JDT_EEPROM_16K,
                 &eep, &g_ifile_storage,
+                flashram_type,
                 &fla, &g_ifile_storage,
                 &sra, &g_ifile_storage);
 

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -213,6 +213,7 @@ int savestates_load_m64p(char *filepath)
     char queue[1024];
     unsigned char additionalData[4];
     unsigned char data_0001_0200[4096]; // 4k for extra state from v1.2
+    uint64_t flashram_status;
 
     uint32_t* cp0_regs = r4300_cp0_regs(&g_dev.r4300.cp0);
 
@@ -462,7 +463,9 @@ int savestates_load_m64p(char *filepath)
 
     g_dev.cart.use_flashram = GETDATA(curr, int);
     g_dev.cart.flashram.mode = GETDATA(curr, int);
-    g_dev.cart.flashram.status = GETDATA(curr, unsigned long long);
+    flashram_status = GETDATA(curr, unsigned long long);
+    g_dev.cart.flashram.status[0] = (uint32_t)(flashram_status >> 32);
+    g_dev.cart.flashram.status[1] = (uint32_t)(flashram_status);
     g_dev.cart.flashram.erase_offset = GETDATA(curr, unsigned int);
     g_dev.cart.flashram.write_pointer = GETDATA(curr, unsigned int);
 
@@ -1229,6 +1232,7 @@ int savestates_save_m64p(char *filepath)
 {
     unsigned char outbuf[4];
     int i;
+    uint64_t flashram_status;
 
     char queue[1024];
 
@@ -1420,7 +1424,8 @@ int savestates_save_m64p(char *filepath)
 
     PUTDATA(curr, int, g_dev.cart.use_flashram);
     PUTDATA(curr, int, g_dev.cart.flashram.mode);
-    PUTDATA(curr, unsigned long long, g_dev.cart.flashram.status);
+    flashram_status = ((uint64_t)g_dev.cart.flashram.status[0] << 32) | g_dev.cart.flashram.status[1];
+    PUTDATA(curr, unsigned long long, flashram_status);
     PUTDATA(curr, unsigned int, g_dev.cart.flashram.erase_offset);
     PUTDATA(curr, unsigned int, g_dev.cart.flashram.write_pointer);
 


### PR DESCRIPTION
Default to MX29L1100 as it is the most common one and is what pj64 uses.

I don't understand Japanese, but it looked like Derby Stallion could save stuff so it is a potential fix for https://github.com/mupen64plus/mupen64plus-core/issues/458
Will need some more testing with other flashram games though before being merged.