### PR TITLE
Get rid of USE_SDL flag

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -284,7 +284,7 @@ ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
       $(warning Using SDL 1.2 libraries)
     endif
   endif
-  SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags) -DUSE_SDL
+  SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
   SDL_LDLIBS += $(shell $(SDL_CONFIG) --libs)
 endif
 CFLAGS += $(SDL_CFLAGS)

--- a/src/main/cheat.c
+++ b/src/main/cheat.c
@@ -22,10 +22,8 @@
 
 // gameshark and xploder64 reference: http://doc.kodewerx.net/hacking_n64.html 
 
-#ifdef USE_SDL
 #include <SDL.h>
 #include <SDL_thread.h>
-#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -67,9 +65,7 @@ typedef struct cheat {
 
 // local variables
 static LIST_HEAD(active_cheats);
-#ifdef USE_SDL
 static SDL_mutex *cheat_mutex = NULL;
-#endif
 
 // private functions
 static unsigned short read_address_16bit(unsigned int address)
@@ -199,18 +195,14 @@ static cheat_t *find_or_create_cheat(const char *name)
 // public functions
 void cheat_init(void)
 {
-#if USE_SDL
     cheat_mutex = SDL_CreateMutex();
-#endif
 }
 
 void cheat_uninit(void)
 {
-#ifdef USE_SDL
     if (cheat_mutex != NULL)
         SDL_DestroyMutex(cheat_mutex);
     cheat_mutex = NULL;
-#endif
 }
 
 void cheat_apply_cheats(int entry)
@@ -222,13 +214,11 @@ void cheat_apply_cheats(int entry)
     if (list_empty(&active_cheats))
         return;
 
-#ifdef USE_SDL
     if (cheat_mutex == NULL || SDL_LockMutex(cheat_mutex) != 0)
     {
         DebugMessage(M64MSG_ERROR, "Internal error: failed to lock mutex in cheat_apply_cheats()");
         return;
     }
-#endif
 
     list_for_each_entry_t(cheat, &active_cheats, cheat_t, list) {
         if (cheat->enabled)
@@ -318,9 +308,7 @@ void cheat_apply_cheats(int entry)
         }
     }
 
-#ifdef USE_SDL
     SDL_UnlockMutex(cheat_mutex);
-#endif
 }
 
 
@@ -332,13 +320,11 @@ void cheat_delete_all(void)
     if (list_empty(&active_cheats))
         return;
 
-#ifdef USE_SDL
     if (cheat_mutex == NULL || SDL_LockMutex(cheat_mutex) != 0)
     {
         DebugMessage(M64MSG_ERROR, "Internal error: failed to lock mutex in cheat_delete_all()");
         return;
     }
-#endif
 
     list_for_each_entry_safe_t(cheat, safe_cheat, &active_cheats, cheat_t, list) {
         free(cheat->name);
@@ -351,9 +337,7 @@ void cheat_delete_all(void)
         free(cheat);
     }
 
-#ifdef USE_SDL
     SDL_UnlockMutex(cheat_mutex);
-#endif
 }
 
 int cheat_set_enabled(const char *name, int enabled)
@@ -363,28 +347,22 @@ int cheat_set_enabled(const char *name, int enabled)
     if (list_empty(&active_cheats))
         return 0;
 
-#ifdef USE_SDL
     if (cheat_mutex == NULL || SDL_LockMutex(cheat_mutex) != 0)
     {
         DebugMessage(M64MSG_ERROR, "Internal error: failed to lock mutex in cheat_set_enabled()");
         return 0;
     }
-#endif
 
     list_for_each_entry_t(cheat, &active_cheats, cheat_t, list) {
         if (strcmp(name, cheat->name) == 0)
         {
             cheat->enabled = enabled;
-#ifdef USE_SDL
             SDL_UnlockMutex(cheat_mutex);
-#endif
             return 1;
         }
     }
 
-#ifdef USE_SDL
     SDL_UnlockMutex(cheat_mutex);
-#endif
     return 0;
 }
 
@@ -393,21 +371,17 @@ int cheat_add_new(const char *name, m64p_cheat_code *code_list, int num_codes)
     cheat_t *cheat;
     int i, j;
 
-#ifdef USE_SDL
     if (cheat_mutex == NULL || SDL_LockMutex(cheat_mutex) != 0)
     {
         DebugMessage(M64MSG_ERROR, "Internal error: failed to lock mutex in cheat_add_new()");
         return 0;
     }
-#endif
 
     /* create a new cheat function or erase the codes in an existing cheat function */
     cheat = find_or_create_cheat(name);
     if (cheat == NULL)
     {
-#ifdef USE_SDL
         SDL_UnlockMutex(cheat_mutex);
-#endif
         return 0;
     }
 
@@ -445,9 +419,7 @@ int cheat_add_new(const char *name, m64p_cheat_code *code_list, int num_codes)
         }
     }
 
-#ifdef USE_SDL
     SDL_UnlockMutex(cheat_mutex);
-#endif
     return 1;
 }
 

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -22,10 +22,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifdef USE_SDL
 #include <SDL.h>
 #include <SDL_thread.h>
-#endif
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -82,9 +80,7 @@ static char *fname = NULL;
 static unsigned int slot = 0;
 static int autoinc_save_slot = 0;
 
-#ifdef USE_SDL
 static SDL_mutex *savestates_lock;
-#endif
 
 struct savestate_work {
     char *filepath;
@@ -216,17 +212,13 @@ int savestates_load_m64p(char *filepath)
 
     uint32_t* cp0_regs = r4300_cp0_regs(&g_dev.r4300.cp0);
 
-#ifdef USE_SDL
     SDL_LockMutex(savestates_lock);
-#endif
 
     f = gzopen(filepath, "rb");
     if(f==NULL)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Could not open state file: %s", filepath);
-#ifdef USE_SDL
         SDL_UnlockMutex(savestates_lock);
-#endif
         return 0;
     }
 
@@ -235,9 +227,7 @@ int savestates_load_m64p(char *filepath)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Could not read header from state file %s", filepath);
         gzclose(f);
-#ifdef USE_SDL
         SDL_UnlockMutex(savestates_lock);
-#endif
         return 0;
     }
     curr = header;
@@ -246,9 +236,7 @@ int savestates_load_m64p(char *filepath)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "State file: %s is not a valid Mupen64plus savestate.", filepath);
         gzclose(f);
-#ifdef USE_SDL
         SDL_UnlockMutex(savestates_lock);
-#endif
         return 0;
     }
     curr += 8;
@@ -261,9 +249,7 @@ int savestates_load_m64p(char *filepath)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "State version (%08x) isn't compatible. Please update Mupen64Plus.", version);
         gzclose(f);
-#ifdef USE_SDL
         SDL_UnlockMutex(savestates_lock);
-#endif
         return 0;
     }
 
@@ -271,9 +257,7 @@ int savestates_load_m64p(char *filepath)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "State ROM MD5 does not match current ROM.");
         gzclose(f);
-#ifdef USE_SDL
         SDL_UnlockMutex(savestates_lock);
-#endif
         return 0;
     }
     curr += 32;
@@ -285,9 +269,7 @@ int savestates_load_m64p(char *filepath)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Insufficient memory to load state.");
         gzclose(f);
-#ifdef USE_SDL
         SDL_UnlockMutex(savestates_lock);
-#endif
         return 0;
     }
     if (version == 0x00010000) /* original savestate version */
@@ -298,9 +280,7 @@ int savestates_load_m64p(char *filepath)
             main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Could not read Mupen64Plus savestate 1.0 data from %s", filepath);
             free(savestateData);
             gzclose(f);
-#ifdef USE_SDL
             SDL_UnlockMutex(savestates_lock);
-#endif
             return 0;
         }
     }
@@ -313,9 +293,7 @@ int savestates_load_m64p(char *filepath)
             main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Could not read Mupen64Plus savestate 1.1 data from %s", filepath);
             free(savestateData);
             gzclose(f);
-#ifdef USE_SDL
             SDL_UnlockMutex(savestates_lock);
-#endif
             return 0;
         }
     }
@@ -329,17 +307,13 @@ int savestates_load_m64p(char *filepath)
             main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Could not read Mupen64Plus savestate 1.2 data from %s", filepath);
             free(savestateData);
             gzclose(f);
-#ifdef USE_SDL
             SDL_UnlockMutex(savestates_lock);
-#endif
             return 0;
         }
     }
 
     gzclose(f);
-#ifdef USE_SDL
     SDL_UnlockMutex(savestates_lock);
-#endif
 
     // Parse savestate
     g_dev.ri.rdram.regs[RDRAM_CONFIG_REG]       = GETDATA(curr, uint32_t);
@@ -1192,9 +1166,7 @@ static void savestates_save_m64p_work(struct work_struct *work)
     gzFile f;
     struct savestate_work *save = container_of(work, struct savestate_work, work);
 
-#ifdef USE_SDL
     SDL_LockMutex(savestates_lock);
-#endif
 
     // Write the state to a GZIP file
     f = gzopen(save->filepath, "wb");
@@ -1220,9 +1192,7 @@ static void savestates_save_m64p_work(struct work_struct *work)
     free(save->filepath);
     free(save);
 
-#ifdef USE_SDL
     SDL_UnlockMutex(savestates_lock);
-#endif
 }
 
 int savestates_save_m64p(char *filepath)
@@ -1811,19 +1781,15 @@ int savestates_save(void)
 
 void savestates_init(void)
 {
-#ifdef USE_SDL
     savestates_lock = SDL_CreateMutex();
     if (!savestates_lock) {
         DebugMessage(M64MSG_ERROR, "Could not create savestates list lock");
         return;
     }
-#endif
 }
 
 void savestates_deinit(void)
 {
-#ifdef USE_SDL
     SDL_DestroyMutex(savestates_lock);
-#endif
     savestates_clear_job();
 }


### PR DESCRIPTION
I added this flag a while ago as the beginning of an effort to make SDL usage optional in the core. It never got very far, other parts of the core still rely on SDL, so there is no use for this flag.

Also, I never actually added the USE_SDL flag to the MSVC project files, so the MSVC version probably hasn't been dealing with the SDL mutex at all.