### PR TITLE
Increase Delay DP Interrupt time

### DIFF
--- a/src/device/rsp/rsp_core.c
+++ b/src/device/rsp/rsp_core.c
@@ -279,7 +279,7 @@ void do_SP_Task(struct rsp_core* sp)
         if (sp->r4300->mi.regs[MI_INTR_REG] & MI_INTR_DP)
         {
             cp0_update_count(sp->r4300);
-            add_interrupt_event(&sp->r4300->cp0, DP_INT, 1000);
+            add_interrupt_event(&sp->r4300->cp0, DP_INT, 4000);
             sp->r4300->mi.regs[MI_INTR_REG] &= ~MI_INTR_DP;
         }
         sp_delay_time = 1000;


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-core/issues/462

The 2 other games I know of that need this are Pokemon Snap (picture taking needs it), and Kirby 64 (HUD needs it). They both still work fine.