### PR TITLE
CountPerOp=1 for Densha de Go! 64

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -3371,6 +3371,7 @@ CRC=17C54A61 4A83F2E7
 Players=1
 SaveType=Eeprom 16KB
 Rumble=Yes
+CountPerOp=1
 
 [BA99C445ADC6994C97FE6463F3E0EC10]
 GoodName=Densha de Go! 64 (J) [f1] (PAL)
@@ -15639,6 +15640,11 @@ CRC=B6BC0FB0 E3812198
 Players=2
 Rumble=Yes
 
+[6E51B140A9B0C30D6F55CA7942A969FC]
+GoodName=Tsumi to Batsu - Hoshi no Keishousha (J) [T+Eng1.0_Zoinkity]
+CRC=B73AB6F6 296267DD
+RefMD5=A0657BC99E169153FD46AECCFDE748F3
+
 [13FAA58604597E4EDC608070F8E0AE24]
 GoodName=Turok - Dinosaur Hunter (E) (V1.0) [!]
 CRC=2F7009DD FC3BAC53
@@ -16778,7 +16784,6 @@ GoodName=Wave Race 64 - Shindou Edition (J) (V1.2) [!]
 CRC=535DF3E2 609789F1
 Players=2
 SaveType=Eeprom 4KB
-CountPerOp=3
 Mempak=Yes
 Rumble=Yes
 


### PR DESCRIPTION
This fixes audio crackling and it seems to keep the audio from randomly playing too fast.

I also added one game and removed CountPerOp=3 from Wave Race 64 - Shindou Edition. CPO=3 makes the game run slower and it isn't required to boot the game anymore.