### PR TITLE
Use virtual memory to allocate g_mem_base (if possible).

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -160,6 +160,7 @@ endif
 ifeq ($(OS), FREEBSD)
   TARGET = libmupen64plus$(POSTFIX).so.2.0.0
   SONAME = libmupen64plus$(POSTFIX).so.2
+  CFLAGS += -DHAVE_MMAP
   LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-dynamic -Wl,-soname,$(SONAME)
   LDLIBS += -L${LOCALBASE}/lib -lc
   ifeq ($(ARCH_DETECTED), 64BITS)
@@ -171,6 +172,7 @@ endif
 ifeq ($(OS), LINUX)
   TARGET = libmupen64plus$(POSTFIX).so.2.0.0
   SONAME = libmupen64plus$(POSTFIX).so.2
+  CFLAGS += -DHAVE_MMAP
   LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-dynamic -Wl,-soname,$(SONAME)
   LDLIBS += -ldl
   # only export api symbols
@@ -187,6 +189,7 @@ ifeq ($(OS), OSX)
   OSX_SDK_PATH = $(OSX_SDK_ROOT)/$(shell ls $(OSX_SDK_ROOT) | tail -1)
 
   TARGET = libmupen64plus$(POSTFIX).dylib
+  CFLAGS += -DHAVE_MMAP
   LDFLAGS += -framework CoreFoundation -dynamiclib
   LDLIBS += -ldl
   ifeq ($(ARCH_DETECTED), 64BITS)

--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -35,6 +35,7 @@
 #include "m64p_config.h"
 #include "m64p_frontend.h"
 #include "m64p_types.h"
+#include "device/memory/memory.h"
 #include "main/cheat.h"
 #include "main/eventloop.h"
 #include "main/main.h"
@@ -93,7 +94,7 @@ EXPORT m64p_error CALL CoreStartup(int APIVersion, const char *ConfigPath, const
         return M64ERR_INTERNAL;
 
     /* allocate base memory */
-    g_mem_base = malloc(0x20000000);
+    g_mem_base = init_mem_base();
     if (g_mem_base == NULL) {
         return M64ERR_NO_MEMORY;
     }
@@ -122,7 +123,7 @@ EXPORT m64p_error CALL CoreShutdown(void)
     SDL_Quit();
 
     /* deallocate base memory */
-    free(g_mem_base);
+    release_mem_base(g_mem_base);
     g_mem_base = NULL;
 
     l_CoreInit = 0;

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -122,5 +122,8 @@ void deactivate_memory_break_write(struct memory* mem, uint32_t address);
 int get_memory_type(struct memory* mem, uint32_t address);
 #endif
 
+void* init_mem_base(void);
+void release_mem_base(void* mem);
+
 #endif
 


### PR DESCRIPTION
This should fix issue https://github.com/mupen64plus/mupen64plus-core/issues/467

Basically, it replaces (if possible) the big malloc with virtual memory allocation in such a way that no unneeded physical pages gets allocated. When available (-DHAVE_MMAP) we use the mmap/munmap/mprotect functions, otherwise if it is a Windows plateform we use the VirtualAlloc/VirtualFree functions and otherwise only rely on the C standard library malloc/free and hope that internally, given the size of the alloc, it will use virtual memory.

I have tested myself on Linux with and without mmap, but couldn't test other platforms.