### PR TITLE
Big alloc fallback

### DIFF
--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -93,7 +93,7 @@ EXPORT m64p_error CALL CoreStartup(int APIVersion, const char *ConfigPath, const
         return M64ERR_INTERNAL;
 
     /* allocate base memory */
-    g_mem_base = malloc(0x20000000);
+    g_mem_base = init_mem_base();
     if (g_mem_base == NULL) {
         return M64ERR_NO_MEMORY;
     }
@@ -122,7 +122,7 @@ EXPORT m64p_error CALL CoreShutdown(void)
     SDL_Quit();
 
     /* deallocate base memory */
-    free(g_mem_base);
+    release_mem_base(g_mem_base);
     g_mem_base = NULL;
 
     l_CoreInit = 0;

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -162,22 +162,22 @@ void init_device(struct device* dev,
     init_r4300(&dev->r4300, &dev->mem, &dev->ri, interrupt_handlers,
             emumode, count_per_op, no_compiled_jump, special_rom, randomize_interrupt);
     init_rdp(&dev->dp, &dev->r4300, &dev->sp, &dev->ri);
-    init_rsp(&dev->sp, (uint32_t*)((uint8_t*)base + MM_RSP_MEM), &dev->r4300, &dev->dp, &dev->ri);
+    init_rsp(&dev->sp, mem_base_u32(base, MM_RSP_MEM), &dev->r4300, &dev->dp, &dev->ri);
     init_ai(&dev->ai, &dev->r4300, &dev->ri, &dev->vi, aout, iaout);
     init_pi(&dev->pi,
             dev, get_pi_dma_handler,
             &dev->r4300, &dev->ri);
-    init_ri(&dev->ri, (uint32_t*)((uint8_t*)base + MM_RDRAM_DRAM), dram_size);
+    init_ri(&dev->ri, mem_base_u32(base, MM_RDRAM_DRAM), dram_size);
     init_si(&dev->si,
-        (uint8_t*)base + MM_PIF_MEM,
+        (uint8_t*)mem_base_u32(base, MM_PIF_MEM),
         jbds, ijbds,
-        (uint8_t*)base + MM_CART_ROM + 0x40,
+        (uint8_t*)mem_base_u32(base, MM_CART_ROM + 0x40),
         &dev->r4300, &dev->ri);
     init_vi(&dev->vi, vi_clock, expected_refresh_rate, &dev->r4300);
 
     init_cart(&dev->cart,
             af_rtc_clock, iaf_rtc_clock,
-            (uint8_t*)base + MM_CART_ROM, rom_size,
+            (uint8_t*)mem_base_u32(base, MM_CART_ROM), rom_size,
             &dev->r4300,
             &dev->ri.rdram, &dev->si.pif.cic,
             eeprom_type, eeprom_storage, ieeprom_storage,

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -38,6 +38,7 @@
 #include "debugger/dbg_types.h"
 #endif
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -213,41 +214,78 @@ enum {
     MB_RSP_MEM  = MB_CART_ROM   + CART_ROM_MAX_SIZE,
     MB_DD_ROM   = MB_RSP_MEM    + SP_MEM_SIZE,
     MB_PIF_MEM  = MB_DD_ROM     + DD_ROM_MAX_SIZE,
-    MB_MAX_SIZE = MB_PIF_MEM    + PIF_ROM_SIZE + PIF_RAM_SIZE
+    MB_MAX_SIZE = MB_PIF_MEM    + PIF_ROM_SIZE + PIF_RAM_SIZE,
+    MB_MAX_SIZE_FULL = 0x20000000
 };
+
+/* Use LSB of mem_base pointer to encode mem_base mode
+ * 1: compressed, 0: full
+ */
+#define MEM_BASE_MODE(mem_base) ((uintptr_t)(mem_base) & 0x1)
+#define MEM_BASE_PTR(mem_base)  ((void*)((uintptr_t)(mem_base) & ~0x1))
+#define SET_MEM_BASE_MODE(mem_base) (mem_base = (void*)((uintptr_t)(mem_base) | 0x1))
 
 void* init_mem_base(void)
 {
-    return malloc(MB_MAX_SIZE);
+    void* mem_base;
+
+    /* First try the full mem base alloc */
+    mem_base = malloc(MB_MAX_SIZE_FULL);
+    if (mem_base == NULL) {
+        /* if it failed, try the compressed mem base alloc */
+        mem_base = malloc(MB_MAX_SIZE);
+        if (mem_base != NULL) {
+            /* Compressed mem base mode has LSB = 1 */
+            assert(MEM_BASE_MODE(mem_base) == 0);
+            SET_MEM_BASE_MODE(mem_base);
+            DebugMessage(M64MSG_INFO, "Using compressed mem base");
+        }
+    }
+    else {
+        /* Full mem base mode has LSB = 0 */
+        assert(MEM_BASE_MODE(mem_base) == 0);
+        DebugMessage(M64MSG_INFO, "Using full mem base");
+    }
+
+    return mem_base;
 }
 
 void release_mem_base(void* mem_base)
 {
-    free(mem_base);
+    free(MEM_BASE_PTR(mem_base));
 }
 
 uint32_t* mem_base_u32(void* mem_base, uint32_t address)
 {
     uint32_t* mem;
 
-    if (address < RDRAM_MAX_SIZE) {
-        mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_RDRAM_DRAM + MB_RDRAM_DRAM));
-    }
-    else if (address >= MM_CART_ROM) {
-        if ((address & UINT32_C(0xfff00000)) == MM_PIF_MEM) {
-            mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_PIF_MEM + MB_PIF_MEM));
-        } else {
-            mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_CART_ROM + MB_CART_ROM));
-        }
-    }
-    else if ((address & UINT32_C(0xfe000000)) ==  MM_DD_ROM) {
-        mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_DD_ROM + MB_DD_ROM));
-    }
-    else if ((address & UINT32_C(0xffffe000)) == MM_RSP_MEM) {
-        mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_RSP_MEM + MB_RSP_MEM));
+    if (MEM_BASE_MODE(mem_base) == 0) {
+        /* In full mem base mode, use simple pointer arithmetic */
+        mem = (uint32_t*)((uint8_t*)mem_base + address);
     }
     else {
-        mem = NULL;
+        /* In compressed mem base mode, select appropriate mem_base offset */
+        mem_base = MEM_BASE_PTR(mem_base);
+
+        if (address < RDRAM_MAX_SIZE) {
+            mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_RDRAM_DRAM + MB_RDRAM_DRAM));
+        }
+        else if (address >= MM_CART_ROM) {
+            if ((address & UINT32_C(0xfff00000)) == MM_PIF_MEM) {
+                mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_PIF_MEM + MB_PIF_MEM));
+            } else {
+                mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_CART_ROM + MB_CART_ROM));
+            }
+        }
+        else if ((address & UINT32_C(0xfe000000)) ==  MM_DD_ROM) {
+            mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_DD_ROM + MB_DD_ROM));
+        }
+        else if ((address & UINT32_C(0xffffe000)) == MM_RSP_MEM) {
+            mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_RSP_MEM + MB_RSP_MEM));
+        }
+        else {
+            mem = NULL;
+        }
     }
 
     return mem;

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -25,6 +25,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+enum { RDRAM_MAX_SIZE = 0x800000 };
+enum { CART_ROM_MAX_SIZE = 0x4000000 };
+enum { DD_ROM_MAX_SIZE = 0x400000 };
+
 typedef void (*read32fn)(void*,uint32_t,uint32_t*);
 typedef void (*write32fn)(void*,uint32_t,uint32_t,uint32_t);
 
@@ -110,6 +114,10 @@ void map_region(struct memory* mem,
                 uint16_t region,
                 int type,
                 const struct mem_handler* handler);
+
+void* init_mem_base(void);
+void release_mem_base(void* mem_base);
+uint32_t* mem_base_u32(void* mem_base, uint32_t address);
 
 void read_with_bp_checks(void* opaque, uint32_t address, uint32_t* value);
 void write_with_bp_checks(void* opaque, uint32_t address, uint32_t value, uint32_t mask);

--- a/src/device/pifbootrom/pifbootrom.c
+++ b/src/device/pifbootrom/pifbootrom.c
@@ -90,7 +90,7 @@ void pifbootrom_hle_execute(struct r4300_core* r4300)
     /* XXX: wait for PIF_3c[7] to be cleared */
 
     /* read and parse pif24 */
-    r4300_read_aligned_word(r4300, R4300_KSEG1 + MM_PIF_MEM + 0x7c0 + 0x24, &pif24);
+    r4300_read_aligned_word(r4300, R4300_KSEG1 + MM_PIF_MEM + PIF_ROM_SIZE + 0x24, &pif24);
     rom_type   = (pif24 >> 19) & 0x01;
     s7         = (pif24 >> 18) & 0x01;
     reset_type = (pif24 >> 17) & 0x01;
@@ -117,8 +117,8 @@ void pifbootrom_hle_execute(struct r4300_core* r4300)
     /* XXX: if XBus is used, wait until DPC_pipe_busy is cleared */
 
     /* copy IPL3 to dmem */
-    memcpy((unsigned char*)r4300->mem->base + MM_RSP_MEM + 0x40,
-           (unsigned char*)r4300->mem->base + rom_base + 0x40,
+    memcpy((unsigned char*)mem_base_u32(r4300->mem->base, MM_RSP_MEM + 0x40),
+           (unsigned char*)mem_base_u32(r4300->mem->base, rom_base + 0x40),
            0xfc0);
 
     /* XXX: compute IPL3 checksum */
@@ -129,7 +129,7 @@ void pifbootrom_hle_execute(struct r4300_core* r4300)
     /* XXX: wait for SI_RD_BUSY to be cleared, set PIF_3c[6] */
 
     /* required by CIC x105 */
-    uint32_t* imem = (uint32_t*)((uint8_t*)r4300->mem->base + MM_RSP_MEM + 0x1000);
+    uint32_t* imem = mem_base_u32(r4300->mem->base, MM_RSP_MEM + 0x1000);
     imem[0x0000/4] = 0x3c0dbfc0;
     imem[0x0004/4] = 0x8da807fc;
     imem[0x0008/4] = 0x25ad07c0;

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -326,7 +326,7 @@ uint32_t *fast_mem_access(struct r4300_core* r4300, uint32_t address)
 
     address &= UINT32_C(0x1ffffffc);
 
-    return (uint32_t*)((uint8_t*)r4300->mem->base + address);
+    return mem_base_u32(r4300->mem->base, address);
 }
 
 /* Read aligned word from memory.

--- a/src/device/si/pif.h
+++ b/src/device/si/pif.h
@@ -31,6 +31,7 @@ struct joybus_device_interface;
 struct si_controller;
 struct r4300_core;
 
+enum { PIF_ROM_SIZE = 0x7c0 };
 enum { PIF_RAM_SIZE = 0x40 };
 enum { PIF_CHANNELS_COUNT = 5 };
 
@@ -60,7 +61,7 @@ struct pif
 
 static uint32_t pif_ram_address(uint32_t address)
 {
-    return ((address & 0xfffc) - 0x7c0);
+    return ((address & 0xfffc) - PIF_ROM_SIZE);
 }
 
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1129,7 +1129,7 @@ m64p_error main_run(void)
     /* do byte-swapping if it's not been done yet */
     if (g_MemHasBeenBSwapped == 0)
     {
-        swap_buffer((uint8_t*)g_mem_base + MM_CART_ROM, 4, g_rom_size/4);
+        swap_buffer((uint8_t*)mem_base_u32(g_mem_base, MM_CART_ROM), 4, g_rom_size/4);
         g_MemHasBeenBSwapped = 1;
     }
 

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -30,8 +30,6 @@
 #include "device/si/pif.h"
 #include "osal/preproc.h"
 
-enum { RDRAM_MAX_SIZE = 0x800000 };
-
 /* globals */
 extern m64p_handle g_CoreConfig;
 

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -148,13 +148,13 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     g_MemHasBeenBSwapped = 0;
     /* allocate new buffer for ROM and copy into this buffer */
     g_rom_size = size;
-    swap_copy_rom((uint8_t*)g_mem_base + MM_CART_ROM, romimage, size, &imagetype);
+    swap_copy_rom((uint8_t*)mem_base_u32(g_mem_base, MM_CART_ROM), romimage, size, &imagetype);
 
-    memcpy(&ROM_HEADER, (uint8_t*)g_mem_base + MM_CART_ROM, sizeof(m64p_rom_header));
+    memcpy(&ROM_HEADER, (uint8_t*)mem_base_u32(g_mem_base, MM_CART_ROM), sizeof(m64p_rom_header));
 
     /* Calculate MD5 hash  */
     md5_init(&state);
-    md5_append(&state, (const md5_byte_t*)((uint8_t*)g_mem_base + MM_CART_ROM), g_rom_size);
+    md5_append(&state, (const md5_byte_t*)((uint8_t*)mem_base_u32(g_mem_base, MM_CART_ROM)), g_rom_size);
     md5_finish(&state, digest);
     for ( i = 0; i < 16; ++i )
         sprintf(buffer+i*2, "%02X", digest[i]);

--- a/src/plugin/plugin.c
+++ b/src/plugin/plugin.c
@@ -227,10 +227,10 @@ static m64p_error plugin_connect_gfx(m64p_dynlib_handle plugin_handle)
 static m64p_error plugin_start_gfx(void)
 {
     /* fill in the GFX_INFO data structure */
-    gfx_info.HEADER = (unsigned char *) g_mem_base + MM_CART_ROM;
-    gfx_info.RDRAM = (unsigned char *) g_mem_base + MM_RDRAM_DRAM;
-    gfx_info.DMEM = (unsigned char *) g_mem_base + MM_RSP_MEM;
-    gfx_info.IMEM = (unsigned char *) g_mem_base + MM_RSP_MEM + 0x1000;
+    gfx_info.HEADER = (unsigned char *)mem_base_u32(g_mem_base, MM_CART_ROM);
+    gfx_info.RDRAM = (unsigned char *)mem_base_u32(g_mem_base, MM_RDRAM_DRAM);
+    gfx_info.DMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM);
+    gfx_info.IMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM + 0x1000);
     gfx_info.MI_INTR_REG = &(g_dev.r4300.mi.regs[MI_INTR_REG]);
     gfx_info.DPC_START_REG = &(g_dev.dp.dpc_regs[DPC_START_REG]);
     gfx_info.DPC_END_REG = &(g_dev.dp.dpc_regs[DPC_END_REG]);
@@ -324,9 +324,9 @@ static m64p_error plugin_connect_audio(m64p_dynlib_handle plugin_handle)
 static m64p_error plugin_start_audio(void)
 {
     /* fill in the AUDIO_INFO data structure */
-    audio_info.RDRAM = (unsigned char *) g_mem_base + MM_RDRAM_DRAM;
-    audio_info.DMEM = (unsigned char *) g_mem_base + MM_RSP_MEM;
-    audio_info.IMEM = (unsigned char *) g_mem_base + MM_RSP_MEM + 0x1000;
+    audio_info.RDRAM = (unsigned char *)mem_base_u32(g_mem_base, MM_RDRAM_DRAM);
+    audio_info.DMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM);
+    audio_info.IMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM + 0x1000);
     audio_info.MI_INTR_REG = &(g_dev.r4300.mi.regs[MI_INTR_REG]);
     audio_info.AI_DRAM_ADDR_REG = &(g_dev.ai.regs[AI_DRAM_ADDR_REG]);
     audio_info.AI_LEN_REG = &(g_dev.ai.regs[AI_LEN_REG]);
@@ -470,9 +470,9 @@ static m64p_error plugin_connect_rsp(m64p_dynlib_handle plugin_handle)
 static m64p_error plugin_start_rsp(void)
 {
     /* fill in the RSP_INFO data structure */
-    rsp_info.RDRAM = (unsigned char *) g_mem_base + MM_RDRAM_DRAM;
-    rsp_info.DMEM = (unsigned char *) g_mem_base + MM_RSP_MEM;
-    rsp_info.IMEM = (unsigned char *) g_mem_base + MM_RSP_MEM + 0x1000;
+    rsp_info.RDRAM = (unsigned char *)mem_base_u32(g_mem_base, MM_RDRAM_DRAM);
+    rsp_info.DMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM);
+    rsp_info.IMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM + 0x1000);
     rsp_info.MI_INTR_REG = &g_dev.r4300.mi.regs[MI_INTR_REG];
     rsp_info.SP_MEM_ADDR_REG = &g_dev.sp.regs[SP_MEM_ADDR_REG];
     rsp_info.SP_DRAM_ADDR_REG = &g_dev.sp.regs[SP_DRAM_ADDR_REG];


### PR DESCRIPTION
Another try at the memory allocation failure encountered in some Android devices. As this is likely due to a shortage of virtual memory, in this PR we provide a fallback mechanism which requires much less memory.