### PR TITLE
Fix handlers[i].{read,write}32 comparison in dynarec.

### DIFF
--- a/src/device/r4300/x86/assemble.h
+++ b/src/device/r4300/x86/assemble.h
@@ -552,6 +552,13 @@ static osal_inline void mov_reg32_preg32pimm32(int reg1, int reg2, unsigned int 
    put32(imm32);
 }
 
+static osal_inline void lea_reg32_preg32x2preg32(int reg1, int reg2, int reg3)
+{
+   put8(0x8D);
+   put8(0x04 | (reg1 << 3));
+   put8(0x40 | (reg2 << 3) | reg3);
+}
+
 static osal_inline void mov_reg32_preg32x4pimm32(int reg1, int reg2, unsigned int imm32)
 {
    put8(0x8B);

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -260,16 +260,25 @@ void genlb(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(95);
 
@@ -317,16 +326,25 @@ void genlbu(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(76);
 
@@ -372,16 +390,25 @@ void genlh(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(95);
 
@@ -429,16 +456,25 @@ void genlhu(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(76);
 
@@ -489,16 +525,25 @@ void genlw(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(40);
 
@@ -527,16 +572,25 @@ void genlwu(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(40);
 
@@ -577,16 +631,25 @@ void genld(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(46);
 
@@ -634,16 +697,25 @@ void gensb(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].write32);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(68);
 
@@ -706,16 +778,25 @@ void gensh(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].write32);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(68);
 
@@ -778,16 +859,25 @@ void gensw(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].write32);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(46);
 
@@ -846,16 +936,25 @@ void gensd(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].write32);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(42);
 
@@ -4076,6 +4175,7 @@ void genlwc1(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
     }
@@ -4114,6 +4214,7 @@ void genldc1(struct r4300_core* r4300)
     else
     {
         shr_reg32_imm8(EAX, 16);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].read32);
         cmp_reg32_imm32(EAX, (unsigned int)read_rdram_dram);
     }
@@ -4148,16 +4249,25 @@ void genswc1(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)(&r4300_regs(r4300)[r4300->recomp.dst->f.lf.base]));
     add_eax_imm32((int)r4300->recomp.dst->f.lf.offset);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].write32);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(46);
 
@@ -4206,16 +4316,25 @@ void gensdc1(struct r4300_core* r4300)
     mov_eax_memoffs32((unsigned int *)(&r4300_regs(r4300)[r4300->recomp.dst->f.lf.base]));
     add_eax_imm32((int)r4300->recomp.dst->f.lf.offset);
     mov_reg32_reg32(EBX, EAX);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
         shr_reg32_imm8(EAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg32_preg32x2preg32(EAX, EAX, EAX);
         mov_reg32_preg32x4pimm32(EAX, EAX, (unsigned int)r4300->mem->handlers[0].write32);
         cmp_reg32_imm32(EAX, (unsigned int)write_rdram_dram);
+
+        jump_end_rel8();
     }
     je_rj(42);
 

--- a/src/device/r4300/x86_64/assemble.h
+++ b/src/device/r4300/x86_64/assemble.h
@@ -782,6 +782,14 @@ static osal_inline void mov_reg64_preg64pimm8(int reg1, int reg2, unsigned int i
    put8(imm8);
 }
 
+static osal_inline void lea_reg64_preg64x2preg64(int reg1, int reg2, int reg3)
+{
+   put8(0x48);
+   put8(0x8D);
+   put8(0x04 | (reg1 << 3));
+   put8(0x40 | (reg2 << 3) | reg3);
+}
+
 static osal_inline void mov_reg64_preg64x8preg64(int reg1, int reg2, int reg3)
 {
    put8(0x48);

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -386,18 +386,26 @@ void genlb(struct r4300_core* r4300)
 
     ld_register_alloc2(r4300, &gpr1, &gpr2, &base1, &base2);
 
-    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_reg32_imm32(gpr1, 0xDF800000);
-        cmp_reg32_imm32(gpr1, 0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(base2, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(gpr1, 16);
+    /* is address in RDRAM ? */
+    and_reg32_imm32(gpr1, 0xDF800000);
+    cmp_reg32_imm32(gpr1, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(gpr1, 16);
+        and_reg32_imm32(gpr1, 0x1fff);
+        lea_reg64_preg64x2preg64(gpr1, gpr1, gpr1);
+        mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(gpr1, gpr1, base1);
-        cmp_reg64_reg64(gpr1, base2);
+        mov_reg64_imm64(base1, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(gpr1, base1);
+
+        jump_end_rel8();
     }
     je_rj(0);
     jump_start_rel8();
@@ -451,18 +459,26 @@ void genlbu(struct r4300_core* r4300)
 
     ld_register_alloc2(r4300, &gpr1, &gpr2, &base1, &base2);
 
-    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
-    if(r4300->recomp.fast_memory)
-    {
-        and_reg32_imm32(gpr1, 0xDF800000);
-        cmp_reg32_imm32(gpr1, 0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(base2, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(gpr1, 16);
+    /* is address in RDRAM ? */
+    and_reg32_imm32(gpr1, 0xDF800000);
+    cmp_reg32_imm32(gpr1, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(gpr1, 16);
+        and_reg32_imm32(gpr1, 0x1fff);
+        lea_reg64_preg64x2preg64(gpr1, gpr1, gpr1);
+        mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(gpr1, gpr1, base1);
-        cmp_reg64_reg64(gpr1, base2);
+        mov_reg64_imm64(base1, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(gpr1, base1);
+
+        jump_end_rel8();
     }
     je_rj(0);
     jump_start_rel8();
@@ -516,18 +532,26 @@ void genlh(struct r4300_core* r4300)
 
     ld_register_alloc2(r4300, &gpr1, &gpr2, &base1, &base2);
 
-    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_reg32_imm32(gpr1, 0xDF800000);
-        cmp_reg32_imm32(gpr1, 0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(base2, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(gpr1, 16);
+    /* is address in RDRAM ? */
+    and_reg32_imm32(gpr1, 0xDF800000);
+    cmp_reg32_imm32(gpr1, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(gpr1, 16);
+        and_reg32_imm32(gpr1, 0x1fff);
+        lea_reg64_preg64x2preg64(gpr1, gpr1, gpr1);
+        mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(gpr1, gpr1, base1);
-        cmp_reg64_reg64(gpr1, base2);
+        mov_reg64_imm64(base1, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(gpr1, base1);
+
+        jump_end_rel8();
     }
     je_rj(0);
     jump_start_rel8();
@@ -580,18 +604,26 @@ void genlhu(struct r4300_core* r4300)
 
     ld_register_alloc2(r4300, &gpr1, &gpr2, &base1, &base2);
 
-    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_reg32_imm32(gpr1, 0xDF800000);
-        cmp_reg32_imm32(gpr1, 0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(base2, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(gpr1, 16);
+    /* is address in RDRAM ? */
+    and_reg32_imm32(gpr1, 0xDF800000);
+    cmp_reg32_imm32(gpr1, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(gpr1, 16);
+        and_reg32_imm32(gpr1, 0x1fff);
+        lea_reg64_preg64x2preg64(gpr1, gpr1, gpr1);
+        mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(gpr1, gpr1, base1);
-        cmp_reg64_reg64(gpr1, base2);
+        mov_reg64_imm64(base1, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(gpr1, base1);
+
+        jump_end_rel8();
     }
     je_rj(0);
     jump_start_rel8();
@@ -652,18 +684,26 @@ void genlw(struct r4300_core* r4300)
 
     ld_register_alloc(r4300, &gpr1, &gpr2, &base1, &base2);
 
-    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_reg32_imm32(gpr1, 0xDF800000);
-        cmp_reg32_imm32(gpr1, 0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(base2, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(gpr1, 16);
+    /* is address in RDRAM ? */
+    and_reg32_imm32(gpr1, 0xDF800000);
+    cmp_reg32_imm32(gpr1, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(gpr1, 16);
+        and_reg32_imm32(gpr1, 0x1fff);
+        lea_reg64_preg64x2preg64(gpr1, gpr1, gpr1);
+        mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(gpr1, gpr1, base1);
-        cmp_reg64_reg64(gpr1, base2);
+        mov_reg64_imm64(base1, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(gpr1, base1);
+
+        jump_end_rel8();
     }
     jne_rj(21);
 
@@ -701,18 +741,26 @@ void genlwu(struct r4300_core* r4300)
 
     ld_register_alloc(r4300, &gpr1, &gpr2, &base1, &base2);
 
-    mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_reg32_imm32(gpr1, 0xDF800000);
-        cmp_reg32_imm32(gpr1, 0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(base2, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(gpr1, 16);
+    /* is address in RDRAM ? */
+    and_reg32_imm32(gpr1, 0xDF800000);
+    cmp_reg32_imm32(gpr1, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(gpr1, 16);
+        and_reg32_imm32(gpr1, 0x1fff);
+        lea_reg64_preg64x2preg64(gpr1, gpr1, gpr1);
+        mov_reg64_imm64(base1, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(gpr1, gpr1, base1);
-        cmp_reg64_reg64(gpr1, base2);
+        mov_reg64_imm64(base1, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(gpr1, base1);
+
+        jump_end_rel8();
     }
     je_rj(0);
     jump_start_rel8();
@@ -765,18 +813,27 @@ void genld(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].read32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(62);
 
@@ -792,7 +849,6 @@ void genld(struct r4300_core* r4300)
 
     mov_reg64_imm64(RSI, (unsigned long long) r4300->ri->rdram.dram); // 10
     and_reg32_imm32(EBX, 0x7FFFFF); // 6
-
     mov_reg32_preg64preg64(EAX, RBX, RSI); // 3
     mov_reg32_preg64preg64pimm32(EBX, RBX, RSI, 4); // 7
     shl_reg64_imm8(RAX, 32); // 4
@@ -837,18 +893,27 @@ void gensb(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) write_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(88);
 
@@ -917,18 +982,27 @@ void gensh(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) write_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(88);
 
@@ -1002,18 +1076,27 @@ void gensw(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) write_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(63);
 
@@ -1085,18 +1168,27 @@ void gensd(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)r4300->recomp.dst->f.i.rs);
     add_eax_imm32((int)r4300->recomp.dst->f.i.immediate);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) write_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(59);
 
@@ -4266,18 +4358,27 @@ void genlwc1(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)(&r4300_regs(r4300)[r4300->recomp.dst->f.lf.base]));
     add_eax_imm32((int)r4300->recomp.dst->f.lf.offset);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].read32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(52);
 
@@ -4311,18 +4412,27 @@ void genldc1(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)(&r4300_regs(r4300)[r4300->recomp.dst->f.lf.base]));
     add_eax_imm32((int)r4300->recomp.dst->f.lf.offset);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].read32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) read_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].read32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) read_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(52);
 
@@ -4360,18 +4470,27 @@ void genswc1(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)(&r4300_regs(r4300)[r4300->recomp.dst->f.lf.base]));
     add_eax_imm32((int)r4300->recomp.dst->f.lf.offset);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) write_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(63);
 
@@ -4428,18 +4547,27 @@ void gensdc1(struct r4300_core* r4300)
     mov_xreg32_m32rel(EAX, (unsigned int *)(&r4300_regs(r4300)[r4300->recomp.dst->f.lf.base]));
     add_eax_imm32((int)r4300->recomp.dst->f.lf.offset);
     mov_reg32_reg32(EBX, EAX);
-    mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
-    if (r4300->recomp.fast_memory)
-    {
-        and_eax_imm32(0xDF800000);
-        cmp_eax_imm32(0x80000000);
-    }
-    else
-    {
-        mov_reg64_imm64(RDI, (unsigned long long) write_rdram_dram);
-        shr_reg32_imm8(EAX, 16);
+
+    /* is address in RDRAM ? */
+    and_reg32_imm32(EAX, 0xDF800000);
+    cmp_reg32_imm32(EAX, 0x80000000);
+
+    /* when fast_memory is true, we know that there is
+     * no custom read handler so skip this test entirely */
+    if (!r4300->recomp.fast_memory) {
+        /* not in RDRAM anyway so skip the read32 check */
+        jne_rj(0);
+        jump_start_rel8();
+
+        shr_reg64_imm8(RAX, 16);
+        and_reg32_imm32(EAX, 0x1fff);
+        lea_reg64_preg64x2preg64(RAX, RAX, RAX);
+        mov_reg64_imm64(RSI, (unsigned long long) r4300->mem->handlers[0].write32);
         mov_reg64_preg64x8preg64(RAX, RAX, RSI);
-        cmp_reg64_reg64(RAX, RDI);
+        mov_reg64_imm64(RSI, (unsigned long long) write_rdram_dram);
+        cmp_reg64_reg64(RAX, RSI);
+
+        jump_end_rel8();
     }
     je_rj(59);
 


### PR DESCRIPTION
Edit: There was another regression introduced also during the memory refactoring; handlers array is now indexed with physical addresses instead of physical, so we need to mask higher bits.

So everything should be good now. I used Derby Stallion for testing because it crashed with the dynarec almost instantaneously.

---- Previous message

I'm trying to fix computation of handlers[i].{read,write]32 inside dynarec but not done yet.
*It crashes dynarec for now*

Offsets computation are wrong now because each element of handlers array is sizeof(struct mem_handler), not just sizeof(void*). Given that struct mem_handler is basically 3 pointers we just need to multiply by 3 the array index to fix the computation. At least that is what I think, but doing so seems to crash... so anyone has a suggestion ?

Commit message below :

This regression has been introduced in
commit 82b20c8a1b48cf09a081b31a7a963fc1985bf86a.

Implementation assumes that sizeof(mem_handler) is 3 * sizeof(void*)
therefore we just need to multiply (address >> 16) by 3 to get the right
offset. Multiplication by 3 can be achieved with lea dst, [reg + 2*reg]
instruction.