### PR TITLE
Fix FBInfo

### DIFF
--- a/src/device/rdp/fb.h
+++ b/src/device/rdp/fb.h
@@ -29,11 +29,12 @@
 struct rdp_core;
 
 enum { FB_INFOS_COUNT = 6 };
-enum { FB_DIRTY_PAGES_COUNT = 0x800 };
+enum { FB_READ_ADDRESS_COUNT = 0x800 };
 
 struct fb
 {
-    unsigned char dirty_page[FB_DIRTY_PAGES_COUNT];
+    uint32_t read_address[FB_READ_ADDRESS_COUNT];
+    uint32_t read_address_counter;
     FrameBufferInfo infos[FB_INFOS_COUNT];
     unsigned int once;
 };

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -654,8 +654,7 @@ int savestates_load_m64p(char *filepath)
     }
 
     /* reset fb state */
-    memset(&g_dev.dp.fb, 0, sizeof(g_dev.dp.fb));
-    g_dev.dp.fb.once = 1;
+    poweron_fb(&g_dev.dp.fb);
 
     *r4300_cp0_last_addr(&g_dev.r4300.cp0) = *r4300_pc(&g_dev.r4300);
 
@@ -959,8 +958,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     poweron_flashram(&g_dev.cart.flashram);
 
     /* extra fb state */
-    memset(&g_dev.dp.fb, 0, sizeof(g_dev.dp.fb));
-    g_dev.dp.fb.once = 1;
+    poweron_fb(&g_dev.dp.fb);
 
     /* extra af-rtc state */
     g_dev.cart.af_rtc.control = 0x200;


### PR DESCRIPTION
This should be ready to merge.

This doesn't fix FBInfo with the new dynarec, it writes directly to RDRAM, so someone who is more familiar with the new dynarec will need to find a way to have it call write_rdram_fb/read_rdram_fb for the addresses in fb->infos[].addr

You can test this out in Mario Kart (Luigi's Raceway with the monitor), or Dr Mario (the pills), or Pokemon Snap (the red dot) using a recent version of GLideN64.

If someone knows a better/more eloquent way to determine the actual address & length in write_rdram_fb() I'm all ears, right now I just have a switch statement going through the various mask possibilities.

FBInfo in general still has some issues, Super Mario and Donkey Kong both freeze, but they also freeze in 1964, which is supposed to have a good (but slow) implementation of FBInfo. The puzzle transition in Banjo-Kazooie also has issues, but it seems to be timing related, changing CountPerOp will affect how much of the puzzle transition appears. But I figured if we are going to support this feature, we should have a good implementation, even if the GFX plugin could probably still use some work