### PR TITLE
Add more FB writes and reads

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -173,7 +173,7 @@ void init_device(struct device* dev,
     init_mi(&dev->mi, &dev->r4300);
     init_pi(&dev->pi,
             dev, get_pi_dma_handler,
-            &dev->mi, &dev->ri, &dev->pif.cic);
+            &dev->mi, &dev->ri, &dev->pif.cic, &dev->dp);
     init_ri(&dev->ri, &dev->rdram);
     init_si(&dev->si, &dev->mi, &dev->pif, &dev->ri);
     init_vi(&dev->vi, vi_clock, expected_refresh_rate, &dev->mi, &dev->dp);

--- a/src/device/rcp/pi/pi_controller.h
+++ b/src/device/rcp/pi/pi_controller.h
@@ -28,6 +28,7 @@
 struct device;
 struct mi_controller;
 struct ri_controller;
+struct rdp_core;
 
 enum pi_registers
 {
@@ -65,6 +66,7 @@ struct pi_controller
     struct mi_controller* mi;
     struct ri_controller* ri;
     const struct cic* cic;
+    struct rdp_core* dp;
 };
 
 static uint32_t pi_reg(uint32_t address)
@@ -78,7 +80,8 @@ void init_pi(struct pi_controller* pi,
              struct device* dev, pi_dma_handler_getter get_pi_dma_handler,
              struct mi_controller* mi,
              struct ri_controller* ri,
-             const struct cic* cic);
+             const struct cic* cic,
+             struct rdp_core* dp);
 
 void poweron_pi(struct pi_controller* pi);
 

--- a/src/device/rcp/rdp/fb.h
+++ b/src/device/rcp/rdp/fb.h
@@ -57,4 +57,7 @@ void write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mas
 void protect_framebuffers(struct fb* fb);
 void unprotect_framebuffers(struct fb* fb);
 
+void pre_framebuffer_read(struct fb* fb, uint32_t address);
+void post_framebuffer_write(struct fb* fb, uint32_t address, uint32_t length);
+
 #endif

--- a/src/device/rcp/rsp/rsp_core.c
+++ b/src/device/rcp/rsp/rsp_core.c
@@ -50,6 +50,8 @@ static void dma_sp_write(struct rsp_core* sp)
     unsigned char *dram = (unsigned char*)sp->ri->rdram->dram;
 
     for(j=0; j<count; j++) {
+        pre_framebuffer_read(&sp->dp->fb, dramaddr);
+
         for(i=0; i<length; i++) {
             spmem[memaddr^S8] = dram[dramaddr^S8];
             memaddr++;
@@ -81,6 +83,8 @@ static void dma_sp_read(struct rsp_core* sp)
             memaddr++;
             dramaddr++;
         }
+
+        post_framebuffer_write(&sp->dp->fb, dramaddr - length, length);
         dramaddr+=skip;
     }
 }


### PR DESCRIPTION
There are a few other instances where the framebuffer might be modified. This tracks reads/writes in the PI and SP DMA's.

If you test the latest master version of GLideN64 with this PR Super Mario 64 no longer freezes.

It exposes another bug with have with the dynarec. When using the Cached Interpreter with FBInfo, you can see Mario's head in the Super Mario 64 intro. If you use the 64-bit dynarec, the head is missing