### PR TITLE
Modify DPC_STATUS_FREEZE hack

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -177,7 +177,7 @@ void init_device(struct device* dev,
             &dev->mi, &dev->ri, &dev->pif.cic);
     init_ri(&dev->ri, &dev->rdram);
     init_si(&dev->si, &dev->mi, &dev->pif, &dev->ri);
-    init_vi(&dev->vi, vi_clock, expected_refresh_rate, &dev->mi);
+    init_vi(&dev->vi, vi_clock, expected_refresh_rate, &dev->mi, &dev->dp);
 
     init_pif(&dev->pif,
         (uint8_t*)mem_base_u32(base, MM_PIF_MEM),

--- a/src/device/rcp/rdp/rdp_core.h
+++ b/src/device/rcp/rdp/rdp_core.h
@@ -68,11 +68,17 @@ enum dps_registers
     DPS_REGS_COUNT
 };
 
+enum
+{
+    DELAY_DP_INT = 0x001,
+    DELAY_UPDATESCREEN = 0x002
+};
 
 struct rdp_core
 {
     uint32_t dpc_regs[DPC_REGS_COUNT];
     uint32_t dps_regs[DPS_REGS_COUNT];
+    unsigned char do_on_unfreeze;
 
     struct fb fb;
 

--- a/src/device/rcp/vi/vi_controller.c
+++ b/src/device/rcp/vi/vi_controller.c
@@ -59,11 +59,12 @@ unsigned int vi_expected_refresh_rate_from_tv_standard(m64p_system_type tv_stand
 }
 
 void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected_refresh_rate,
-             struct mi_controller* mi)
+             struct mi_controller* mi, struct rdp_core* dp)
 {
     vi->clock = clock;
     vi->expected_refresh_rate = expected_refresh_rate;
     vi->mi = mi;
+    vi->dp = dp;
 }
 
 void poweron_vi(struct vi_controller* vi)
@@ -146,7 +147,10 @@ void write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 void vi_vertical_interrupt_event(void* opaque)
 {
     struct vi_controller* vi = (struct vi_controller*)opaque;
-    gfx.updateScreen();
+    if (vi->dp->do_on_unfreeze & DELAY_DP_INT)
+        vi->dp->do_on_unfreeze |= DELAY_UPDATESCREEN;
+    else
+        gfx.updateScreen();
 
     /* allow main module to do things on VI event */
     new_vi();

--- a/src/device/rcp/vi/vi_controller.h
+++ b/src/device/rcp/vi/vi_controller.h
@@ -26,6 +26,7 @@
 #include "api/m64p_types.h"
 
 struct mi_controller;
+struct rdp_core;
 
 enum vi_registers
 {
@@ -58,6 +59,7 @@ struct vi_controller
     unsigned int count_per_scanline;
 
     struct mi_controller* mi;
+    struct rdp_core* dp;
 };
 
 static uint32_t vi_reg(uint32_t address)
@@ -70,7 +72,7 @@ unsigned int vi_clock_from_tv_standard(m64p_system_type tv_standard);
 unsigned int vi_expected_refresh_rate_from_tv_standard(m64p_system_type tv_standard);
 
 void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected_refresh_rate,
-             struct mi_controller* mi);
+             struct mi_controller* mi, struct rdp_core* dp);
 
 void poweron_vi(struct vi_controller* vi);
 

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -599,6 +599,9 @@ int savestates_load_m64p(char *filepath)
 
         /* extra si state */
         g_dev.si.dma_dir = GETDATA(curr, uint8_t);
+
+        /* extra dp state */
+        g_dev.dp.do_on_unfreeze = GETDATA(curr, uint8_t);
     }
     else {
         /* extra ai state */
@@ -646,6 +649,9 @@ int savestates_load_m64p(char *filepath)
 
         /* extra si state */
         g_dev.si.dma_dir = SI_NO_DMA;
+
+        /* extra dp state */
+        g_dev.dp.do_on_unfreeze = 0;
     }
 
     /* Zilmar-Spec plugin expect a call with control_id = -1 when RAM processing is done */
@@ -835,6 +841,9 @@ static int savestates_load_pj64(char *filepath, void *handle,
 
     /* extra si state */
     g_dev.si.dma_dir = SI_NO_DMA;
+
+    /* extra dp state */
+    g_dev.dp.do_on_unfreeze = 0;
 
     // ai_register
     g_dev.ai.regs[AI_DRAM_ADDR_REG] = GETDATA(curr, uint32_t);
@@ -1510,6 +1519,8 @@ int savestates_save_m64p(char *filepath)
     PUTDATA(curr, unsigned int, g_dev.vi.count_per_scanline);
 
     PUTDATA(curr, uint8_t, g_dev.si.dma_dir);
+
+    PUTDATA(curr, uint8_t, g_dev.dp.do_on_unfreeze);
 
     init_work(&save->work, savestates_save_m64p_work);
     queue_work(&save->work);

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -70,7 +70,7 @@ enum { GB_CART_FINGERPRINT_SIZE = 0x1c };
 enum { GB_CART_FINGERPRINT_OFFSET = 0x134 };
 
 static const char* savestate_magic = "M64+SAVE";
-static const int savestate_latest_version = 0x00010100;  /* 1.1 */
+static const int savestate_latest_version = 0x00010200;  /* 1.2 */
 static const unsigned char pj64_magic[4] = { 0xC8, 0xA6, 0xD8, 0x23 };
 
 static savestates_job job = savestates_job_nothing;


### PR DESCRIPTION
Right now the hack works like this:

If DPC_STATUS_FREEZE bit is set when RSP task should run, run the RSP task when DPC_STATUS_FREEZE is unset.

This works mostly ok, but we did have to add ```dp->sp->regs[SP_STATUS_REG] &= ~SP_STATUS_YIELD;``` to get Perfect Dark working in LLE, as well as the ```!get_event(&dp->r4300->cp0.q, SP_INT)``` check to get it working in HLE. Also, the "puzzle effect" in Banjo-Kazooie is half-black when using FBInfo in GLideN64.

What this change does:

If DPC_STATUS_FREEZE is set when RSP task should run, still run the RSP task, but delay the DP Interrupt until the DPC_STATUS_FREEZE bit is unset. The RSP should still run even in the RDP is frozen.

If a VI Interrupt happens when DPC_STATUS_FREEZE is set, delay updating the screen until its unset. This should simulate the RDP not finishing until the DPC_STATUS_FREEZE bit is unset.

I tested every Rare game in HLE and LLE and they all work still, no hacky checks like we had before. Additionally, the "puzzle effect" in Banjo-Kazooie now works with FBinfo in GLIdeN64.

I updated the savestate to include this, I noticed we aren't actually using the v1.2 save states currently, I updated the file to start using v1.2, @bsmiles32 I don't know if you held that back on purpose or not.


Testing is welcome, Rare games are the only ones I know of that use this bit. Additionally, it seems like many LLE GFX plugins are unsetting the DPC_STATUS_FREEZE bit (GLideN64 and angrylion-plus do this). I submitted a PR to angrylion-plus to stop doing this (https://github.com/ata4/angrylion-rdp-plus/pull/41) and I'll submit one to GLideN64 as well, unsetting that bit breaks this system.