### PR TITLE
Remove GoldenEye TLB hack

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -95,7 +95,6 @@ void init_device(struct device* dev,
     unsigned int emumode,
     unsigned int count_per_op,
     int no_compiled_jump,
-    int special_rom,
     int randomize_interrupt,
     /* ai */
     void* aout, const struct audio_out_backend_interface* iaout,
@@ -167,7 +166,7 @@ void init_device(struct device* dev,
     init_rdram(&dev->rdram, mem_base_u32(base, MM_RDRAM_DRAM), dram_size);
 
     init_r4300(&dev->r4300, &dev->mem, &dev->mi, &dev->rdram, interrupt_handlers,
-            emumode, count_per_op, no_compiled_jump, special_rom, randomize_interrupt);
+            emumode, count_per_op, no_compiled_jump, randomize_interrupt);
     init_rdp(&dev->dp, &dev->sp, &dev->mi, &dev->mem, &dev->rdram, &dev->r4300);
     init_rsp(&dev->sp, mem_base_u32(base, MM_RSP_MEM), &dev->mi, &dev->dp, &dev->ri);
     init_ai(&dev->ai, &dev->mi, &dev->ri, &dev->vi, aout, iaout);

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -109,7 +109,6 @@ void init_device(struct device* dev,
     unsigned int emumode,
     unsigned int count_per_op,
     int no_compiled_jump,
-    int special_rom,
     int randomize_interrupt,
     /* ai */
     void* aout, const struct audio_out_backend_interface* iaout,

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -1678,7 +1678,7 @@ static void remove_hash(int vaddr)
 #error Unsupported dynarec architecture
 #endif
 
-static void tlb_hacks()
+static void tlb_speed_hacks()
 {
   // Goldeneye hack
   if (strncmp((char *) ROM_HEADER.Name, "GOLDENEYE",9) == 0)
@@ -2284,7 +2284,7 @@ static void invalidate_all_pages(void)
     else g_dev.r4300.new_dynarec_hot_state.memory_map[page]=-1;
     if(page==0x80000) page=0xC0000;
   }
-  tlb_hacks();
+  tlb_speed_hacks();
 }
 
 void invalidate_cached_code_new_dynarec(struct r4300_core* r4300, uint32_t address, size_t size)
@@ -7612,7 +7612,7 @@ void new_dynarec_init(void)
   for(n=526336;n<1048576;n++) // 0x80800000 .. 0xFFFFFFFF
     g_dev.r4300.new_dynarec_hot_state.memory_map[n]=-1;
 
-  tlb_hacks();
+  tlb_speed_hacks();
   arch_init();
 }
 

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -172,7 +172,11 @@ static void InterpretOpcode(struct r4300_core* r4300);
 
 void InterpretOpcode(struct r4300_core* r4300)
 {
-	uint32_t op = *fast_mem_access(r4300, *r4300_pc(r4300));
+	uint32_t* op_address = fast_mem_access(r4300, *r4300_pc(r4300));
+	if (op_address == NULL)
+		return;
+	uint32_t op = *op_address;
+
 	switch ((op >> 26) & 0x3F) {
 	case 0: /* SPECIAL prefix */
 		switch (op & 0x3F) {

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -318,6 +318,8 @@ uint32_t *fast_mem_access(struct r4300_core* r4300, uint32_t address)
 
     if ((address & UINT32_C(0xc0000000)) != UINT32_C(0x80000000)) {
         address = virtual_to_physical_address(r4300, address, 2);
+        if (address == 0) // TLB exception
+            return NULL;
     }
 
     address &= UINT32_C(0x1ffffffc);

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -41,7 +41,7 @@
 #include <time.h>
 
 void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers,
-    unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom, int randomize_interrupt)
+    unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int randomize_interrupt)
 {
     struct new_dynarec_hot_state* new_dynarec_hot_state =
 #if NEW_DYNAREC == NEW_DYNAREC_ARM
@@ -59,7 +59,6 @@ void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controll
     r4300->mem = mem;
     r4300->mi = mi;
     r4300->rdram = rdram;
-    r4300->special_rom = special_rom;
     r4300->randomize_interrupt = randomize_interrupt;
     srand(time(NULL));
 }

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -202,14 +202,13 @@ struct r4300_core
     struct mi_controller* mi;
     struct rdram* rdram;
 
-    uint32_t special_rom;
     uint32_t randomize_interrupt;
 };
 
 #define R4300_KSEG0 UINT32_C(0x80000000)
 #define R4300_KSEG1 UINT32_C(0xa0000000)
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int special_rom, int randomize_interrupt);
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int randomize_interrupt);
 void poweron_r4300(struct r4300_core* r4300);
 
 void run_r4300(struct r4300_core* r4300);

--- a/src/device/r4300/tlb.c
+++ b/src/device/r4300/tlb.c
@@ -122,32 +122,6 @@ uint32_t virtual_to_physical_address(struct r4300_core* r4300, uint32_t address,
     }
 #endif
 
-    if (address >= UINT32_C(0x7f000000) && address < UINT32_C(0x80000000) && r4300->special_rom == GOLDEN_EYE)
-    {
-        /**************************************************
-         GoldenEye 007 hack allows for use of TLB.
-         Recoded by okaygo to support all US, J, and E ROMS.
-        **************************************************/
-        switch (ROM_HEADER.Country_code & UINT16_C(0xFF))
-        {
-        case 0x45:
-            // U
-            return UINT32_C(0xb0034b30) + (address & UINT32_C(0xFFFFFF));
-            break;
-        case 0x4A:
-            // J
-            return UINT32_C(0xb0034b70) + (address & UINT32_C(0xFFFFFF));
-            break;
-        case 0x50:
-            // E
-            return UINT32_C(0xb00329f0) + (address & UINT32_C(0xFFFFFF));
-            break;
-        default:
-            // UNKNOWN COUNTRY CODE FOR GOLDENEYE USING AMERICAN VERSION HACK
-            return UINT32_C(0xb0034b30) + (address & UINT32_C(0xFFFFFF));
-            break;
-        }
-    }
     if (w == 1)
     {
         if (r4300->cp0.tlb.LUT_w[address>>12])

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1308,7 +1308,6 @@ m64p_error main_run(void)
                 emumode,
                 count_per_op,
                 no_compiled_jump,
-                ROM_PARAMS.special_rom,
                 randomize_interrupt,
                 &g_dev.ai, &g_iaudio_out_backend_plugin_compat,
                 rdram_size,

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -222,11 +222,6 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
     DebugMessage(M64MSG_VERBOSE, "PC = %" PRIX32, sl(ROM_HEADER.PC));
     DebugMessage(M64MSG_VERBOSE, "Save type: %d", ROM_SETTINGS.savetype);
 
-    if(strcmp(ROM_PARAMS.headername, "GOLDENEYE") == 0)
-        ROM_PARAMS.special_rom = GOLDEN_EYE;
-    else
-        ROM_PARAMS.special_rom = NORMAL_ROM;
-
     return M64ERR_SUCCESS;
 }
 

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -50,7 +50,6 @@ typedef struct _rom_params
    char headername[21];  /* ROM Name as in the header, removing trailing whitespace */
    unsigned char countperop;
    int disableextramem;
-   int special_rom;
 } rom_params;
 
 extern m64p_rom_header   ROM_HEADER;
@@ -95,13 +94,6 @@ enum
     FLASH_RAM,
     CONTROLLER_PACK,
     NONE
-};
-
-/*ROM specific hacks */
-enum
-{
-    NORMAL_ROM,
-    GOLDEN_EYE
 };
 
 /* Rom INI database structures and functions */


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-core/issues/447

This will need to be tested on every dynarec/interpreter. I've tested the Pure/Cached Interpreter as well as the 64-bit dynarec. I tested the x86 new dynarec a while ago, but it probably should be tested again. ARM should also be tested ( @fzurita )

The only game that should be affected is GoldenEye, however I did make a change to how the Pure Interpreter works generally.