### PR TITLE
Fix reset bug introduced in commit 1c01c233.

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -243,5 +243,7 @@ void hard_reset_device(struct device* dev)
 
 void soft_reset_device(struct device* dev)
 {
-    reset_pif(&dev->pif, 1); /* Soft reset */
+    /* schedule HW2 interrupt now and an NMI after 1/2 seconds */
+    add_interrupt_event(&dev->r4300.cp0, HW2_INT, 0);
+    add_interrupt_event(&dev->r4300.cp0, NMI_INT, 50000000);
 }

--- a/src/device/pif/pif.c
+++ b/src/device/pif/pif.c
@@ -166,12 +166,6 @@ void reset_pif(struct pif* pif, unsigned int reset_type)
 
     /* clear PIF flags */
     pif->ram[0x3f] = 0x00;
-
-    if (reset_type) {
-        /* schedule HW2 interrupt now and an NMI after 1/2 seconds */
-        add_interrupt_event(&pif->r4300->cp0, HW2_INT, 0);
-        add_interrupt_event(&pif->r4300->cp0, NMI_INT, 50000000);
-    }
 }
 
 void setup_channels_format(struct pif* pif)

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -439,6 +439,8 @@ void nmi_int_handler(void* opaque)
     struct r4300_core* r4300 = &dev->r4300;
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
 
+    reset_pif(&dev->pif, 1);
+
     // setup r4300 Status flags: reset TS and SR, set BEV, ERL, and SR
     cp0_regs[CP0_STATUS_REG] = (cp0_regs[CP0_STATUS_REG] & ~(CP0_STATUS_SR | CP0_STATUS_TS | UINT32_C(0x00080000))) | (CP0_STATUS_ERL | CP0_STATUS_BEV | CP0_STATUS_SR);
     cp0_regs[CP0_CAUSE_REG]  = 0x00000000;


### PR DESCRIPTION
Values comming from CIC at poweron/reset were written too early in PIF
RAM. There was a possibility of them getting overwritten by some SI DMA
requests (such as reading mempaks [Perfect Dark]) during the time window
between PIF_INT and NMI_INT.

Now we delay this until NMI_INT is triggered.