### PR TITLE
Device: RDRAM: Use the R4300 helpers to get the R4300 registers

### DIFF
--- a/src/device/rdram/rdram.c
+++ b/src/device/rdram/rdram.c
@@ -202,7 +202,7 @@ void write_rdram_regs(void* opaque, uint32_t address, uint32_t value, uint32_t m
 
         /* HACK: In the IPL3 procedure, at this point,
          * the amount of detected memory can be found in s4 */
-        size_t ipl3_rdram_size = rdram->r4300->regs[20] & UINT32_C(0x0fffffff);
+        size_t ipl3_rdram_size = r4300_regs(rdram->r4300)[20] & UINT32_C(0x0fffffff);
         if (ipl3_rdram_size != rdram->dram_size) {
             DebugMessage(M64MSG_ERROR, "IPL3 detected %u MB of RDRAM != %u MB",
                 ipl3_rdram_size / (1024*1024), rdram->dram_size / (1024*1024));


### PR DESCRIPTION
Since the "regs" member is not available on the r4300_core
structure when enabling ARM DYNAREC, accessing this member
directly will cause compilation errors with this setup.

Signed-off-by: Myy Miouyouyou <myy@miouyouyou.fr>