### PR TITLE
Remove write_cart_rom

### DIFF
--- a/src/device/cart/cart_rom.c
+++ b/src/device/cart/cart_rom.c
@@ -46,8 +46,6 @@ void init_cart_rom(struct cart_rom* cart_rom,
 
 void poweron_cart_rom(struct cart_rom* cart_rom)
 {
-    cart_rom->last_write = 0;
-    cart_rom->rom_written = 0;
 }
 
 
@@ -56,22 +54,7 @@ void read_cart_rom(void* opaque, uint32_t address, uint32_t* value)
     struct cart_rom* cart_rom = (struct cart_rom*)opaque;
     uint32_t addr = rom_address(address);
 
-    if (cart_rom->rom_written)
-    {
-        *value = cart_rom->last_write;
-        cart_rom->rom_written = 0;
-    }
-    else
-    {
-        *value = *(uint32_t*)(cart_rom->rom + addr);
-    }
-}
-
-void write_cart_rom(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
-{
-    struct cart_rom* cart_rom = (struct cart_rom*)opaque;
-    cart_rom->last_write = value & mask;
-    cart_rom->rom_written = 1;
+    *value = *(uint32_t*)(cart_rom->rom + addr);
 }
 
 unsigned int cart_rom_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length)

--- a/src/device/cart/cart_rom.h
+++ b/src/device/cart/cart_rom.h
@@ -34,9 +34,6 @@ struct cart_rom
     uint8_t* rom;
     size_t rom_size;
 
-    uint32_t last_write;
-    uint32_t rom_written;
-
     struct r4300_core* r4300;
 };
 
@@ -52,7 +49,6 @@ void init_cart_rom(struct cart_rom* cart_rom,
 void poweron_cart_rom(struct cart_rom* cart_rom);
 
 void read_cart_rom(void* opaque, uint32_t address, uint32_t* value);
-void write_cart_rom(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 unsigned int cart_rom_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
 unsigned int cart_rom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -151,7 +151,7 @@ void init_device(struct device* dev,
         { A(MM_RI_REGS, 0xffff), M64P_MEM_RI, { &dev->ri, RW(ri_regs) } },
         { A(MM_SI_REGS, 0xffff), M64P_MEM_SI, { &dev->si, RW(si_regs) } },
         { A(MM_DOM2_ADDR2, 0x1ffff), M64P_MEM_FLASHRAMSTAT, { &dev->cart, RW(cart_dom2)  } },
-        { A(MM_CART_ROM, rom_size-1), M64P_MEM_ROM, { &dev->cart.cart_rom, RW(cart_rom) } },
+        { A(MM_CART_ROM, rom_size-1), M64P_MEM_ROM, { &dev->cart.cart_rom, R(cart_rom), W(open_bus) } },
         { A(MM_PIF_MEM, 0xffff), M64P_MEM_PIF, { &dev->pif, RW(pif_ram) } }
     };
 

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -514,8 +514,7 @@ int savestates_load_m64p(char *filepath)
         g_dev.ai.delayed_carry = GETDATA(curr, uint32_t);
 
         /* extra cart_rom state */
-        g_dev.cart.cart_rom.last_write = GETDATA(curr, uint32_t);
-        g_dev.cart.cart_rom.rom_written = GETDATA(curr, uint32_t);
+        curr += 2*sizeof(uint32_t);
 
         /* extra sp state */
         g_dev.sp.rsp_task_locked = GETDATA(curr, uint32_t);
@@ -626,10 +625,6 @@ int savestates_load_m64p(char *filepath)
         /* extra ai state */
         g_dev.ai.last_read = 0;
         g_dev.ai.delayed_carry = 0;
-
-        /* extra cart_rom state */
-        g_dev.cart.cart_rom.last_write = 0;
-        g_dev.cart.cart_rom.rom_written = 0;
 
         /* extra sp state */
         g_dev.sp.rsp_task_locked = 0;
@@ -901,10 +896,6 @@ static int savestates_load_pj64(char *filepath, void *handle,
     g_dev.pi.regs[PI_BSD_DOM2_PGS_REG] = GETDATA(curr, uint32_t);
     g_dev.pi.regs[PI_BSD_DOM2_RLS_REG] = GETDATA(curr, uint32_t);
     read_func(handle, g_dev.pi.regs, PI_REGS_COUNT*sizeof(g_dev.pi.regs[0]));
-
-    /* extra cart_rom state */
-    g_dev.cart.cart_rom.last_write = 0;
-    g_dev.cart.cart_rom.rom_written = 0;
 
     // ri_register
     g_dev.ri.regs[RI_MODE_REG]         = GETDATA(curr, uint32_t);
@@ -1506,8 +1497,8 @@ int savestates_save_m64p(char *filepath)
     PUTDATA(curr, uint32_t, g_dev.ai.last_read);
     PUTDATA(curr, uint32_t, g_dev.ai.delayed_carry);
 
-    PUTDATA(curr, uint32_t, g_dev.cart.cart_rom.last_write);
-    PUTDATA(curr, uint32_t, g_dev.cart.cart_rom.rom_written);
+    PUTDATA(curr, uint32_t, 0);
+    PUTDATA(curr, uint32_t, 0);
 
     PUTDATA(curr, uint32_t, g_dev.sp.rsp_task_locked);
 


### PR DESCRIPTION
This doesn't seem to be needed anymore.
All-Star Baseball 2001, International Track & Field 2000, Midway's
Greatest Arcade Hits Vol. 1 are still playable.

Something (maybe in the TLB handling code) must have made these bootable again, without the write_cart_rom hack(?).

See https://github.com/mupen64plus/mupen64plus-core/issues/311, https://github.com/mupen64plus/mupen64plus-core/issues/221