### PR TITLE
Fix potential crash with FBInfo and save states

### DIFF
--- a/src/device/rcp/rdp/fb.c
+++ b/src/device/rcp/rdp/fb.c
@@ -110,7 +110,6 @@ void init_fb(struct fb* fb,
 
 void poweron_fb(struct fb* fb)
 {
-
     memset(fb->dirty_page, 0, FB_DIRTY_PAGES_COUNT*sizeof(fb->dirty_page[0]));
     memset(fb->infos, 0, FB_INFOS_COUNT*sizeof(fb->infos[0]));
     fb->once = 1;

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -689,8 +689,7 @@ int savestates_load_m64p(char *filepath)
     }
 
     /* reset fb state */
-    memset(&g_dev.dp.fb, 0, sizeof(g_dev.dp.fb));
-    g_dev.dp.fb.once = 1;
+    poweron_fb(&g_dev.dp.fb);
 
     *r4300_cp0_last_addr(&g_dev.r4300.cp0) = *r4300_pc(&g_dev.r4300);
 
@@ -997,8 +996,7 @@ static int savestates_load_pj64(char *filepath, void *handle,
     poweron_flashram(&g_dev.cart.flashram);
 
     /* extra fb state */
-    memset(&g_dev.dp.fb, 0, sizeof(g_dev.dp.fb));
-    g_dev.dp.fb.once = 1;
+    poweron_fb(&g_dev.dp.fb);
 
     /* extra af-rtc state */
     g_dev.cart.af_rtc.control = 0x200;


### PR DESCRIPTION
I believe this should fix https://github.com/mupen64plus/mupen64plus-core/issues/489

Doing ```memset(&g_dev.dp.fb, 0, sizeof(g_dev.dp.fb));``` will wipe out ```fb->mem, fb->rdram, fb->r4300```, which is probably what was causing the crash.

Using poweron_fb will only wipe the necessary data

This regression was introduced in https://github.com/mupen64plus/mupen64plus-core/commit/99f00d78a2feec139a60ca7d59fb163daf8029b6

@fzurita perhaps you could test and @bsmiles32 you could review as well?