### PR TITLE
Fix compile on MinGW

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -353,6 +353,7 @@ CC        = $(CROSS_COMPILE)gcc
 CXX       = $(CROSS_COMPILE)g++
 STRINGS   = $(CROSS_COMPILE)strings
 AS        = nasm
+TR       ?= tr
 RM       ?= rm -f
 INSTALL  ?= install
 MKDIR    ?= mkdir -p
@@ -701,7 +702,7 @@ $(ASM_DEFINES_OBJ): $(SRCDIR)/asm_defines/asm_defines.c
 # Script hackery for generating ASM include files for the new dynarec assembly code
 $(SRCDIR)/asm_defines/asm_defines_gas.h: $(SRCDIR)/asm_defines/asm_defines_nasm.h
 $(SRCDIR)/asm_defines/asm_defines_nasm.h: $(ASM_DEFINES_OBJ) ../../tools/gen_asm_defines.awk
-	$(STRINGS) "$<" | $(AWK) -v dest_dir="$(SRCDIR)/asm_defines" -f ../../tools/gen_asm_defines.awk
+	$(STRINGS) "$<" | $(TR) -d '\r' | $(AWK) -v dest_dir="$(SRCDIR)/asm_defines" -f ../../tools/gen_asm_defines.awk
 
 # standard build rules
 $(OBJDIR)/%.o: $(SRCDIR)/%.asm $(SRCDIR)/asm_defines/asm_defines_nasm.h


### PR DESCRIPTION
For some reason, recent builds on MinGW are failing, the asm_defines_nasm.h file looks like this:

```
)define offsetof_struct_cached_interp_invalid_code (0x00000000
)define offsetof_struct_r4300_core_cached_interp (0x00000af8
)define offsetof_struct_tlb_LUT_w (0x00400680
)define offsetof_struct_tlb_LUT_r (0x00000680
)define offsetof_struct_tlb_entries (0x00000000
)define offsetof_struct_cp0_tlb (0x000002ec
)define offsetof_struct_cp0_count_per_op (0x000002e8
)define offsetof_struct_cp0_last_addr (0x000002e4
)define offsetof_struct_cp0_next_interrupt (0x00000218
)define offsetof_struct_cp0_regs (0x00000000
)define offsetof_struct_r4300_core_cp0 (0x00900c60
)define offsetof_struct_r4300_core_return_address (0x00000a20
)define offsetof_struct_r4300_core_save_rip (0x00000a18
)define offsetof_struct_r4300_core_save_rsp (0x00000a10
)define offsetof_struct_r4300_core_stop (0x00000134
)define offsetof_struct_r4300_core_lo (0x00000108
)define offsetof_struct_r4300_core_hi (0x00000100
)define offsetof_struct_r4300_core_regs (0x00000000
)define offsetof_struct_device_r4300 (0x00000000
```

The output from ```strings``` seems to have Windows newlines, and then gawk can't properly parse the file. Piping it to dos2unix on the way fixes the issue.

dos2unix should be available on all Linux distributions, so I think this would be a pretty safe change. If someone know of a way to fix the gawk script to deal with Windows newlines that would probably work as well.