### PR TITLE
Remove CountPerOp=1 for Vigilante games

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -16165,7 +16165,6 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
-CountPerOp=1
 
 [637B9A40BED777FC96EB1BD07EA74783]
 GoodName=Vigilante 8 (E) [h1C]
@@ -16179,7 +16178,6 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
-CountPerOp=1
 
 [B69B84083D1B4EC99A465B3067F74417]
 GoodName=Vigilante 8 (F) [b1]
@@ -16193,7 +16191,6 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
-CountPerOp=1
 
 [D616ADF6441ACBBD0E6BEF023A8F6031]
 GoodName=Vigilante 8 (U) [!]
@@ -16202,7 +16199,6 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
-CountPerOp=1
 
 [9F42209E413A1A92C788BF7BC26BFB7B]
 GoodName=Vigilante 8 (U) [b1]
@@ -16236,7 +16232,6 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
-CountPerOp=1
 
 [60CDF7445FAD2ABA05C958F46691501B]
 GoodName=Vigilante 8 - 2nd Offense (U) [!]
@@ -16245,7 +16240,6 @@ Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
-CountPerOp=1
 
 [5E30D0208FC4CB810A464E5DEFFB29A3]
 GoodName=Vigilante 8 - 2nd Offense (U) [f1] (PAL)


### PR DESCRIPTION
The Vigilante games are very demanding on the CPU. Having CountPerOp=1 makes this even more pronounced.

@AmbientMalice you seem to know a lot of the history behind these settings. Do you know why the Vigilante games have CountPerOp=1? I assume we just copied it over from PJ64

I tested the games briefly and they seem to work the same using CountPerOp=2, but much less CPU usage.