### PR TITLE
Don't deal with save states when RSP task is locked

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -167,7 +167,7 @@ void init_device(struct device* dev,
 
     init_rdram(&dev->rdram, mem_base_u32(base, MM_RDRAM_DRAM), dram_size, &dev->r4300);
 
-    init_r4300(&dev->r4300, &dev->mem, &dev->mi, &dev->rdram, interrupt_handlers,
+    init_r4300(&dev->r4300, &dev->mem, &dev->mi, &dev->sp, &dev->rdram, interrupt_handlers,
             emumode, count_per_op, no_compiled_jump, randomize_interrupt);
     init_rdp(&dev->dp, &dev->sp, &dev->mi, &dev->mem, &dev->rdram, &dev->r4300);
     init_rsp(&dev->sp, mem_base_u32(base, MM_RSP_MEM), &dev->mi, &dev->dp, &dev->ri);

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -510,7 +510,7 @@ void gen_interrupt(struct r4300_core* r4300)
         dyna_stop(r4300);
     }
 
-    if (!r4300->cp0.interrupt_unsafe_state)
+    if (!r4300->cp0.interrupt_unsafe_state && !r4300->sp->rsp_task_locked)
     {
         if (savestates_get_job() == savestates_job_load)
         {
@@ -603,7 +603,7 @@ void gen_interrupt(struct r4300_core* r4300)
             break;
     }
 
-    if (!r4300->cp0.interrupt_unsafe_state)
+    if (!r4300->cp0.interrupt_unsafe_state && !r4300->sp->rsp_task_locked)
     {
         if (savestates_get_job() == savestates_job_save)
         {

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -40,7 +40,7 @@
 #include <string.h>
 #include <time.h>
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers,
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rsp_core* sp, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers,
     unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int randomize_interrupt)
 {
     struct new_dynarec_hot_state* new_dynarec_hot_state =
@@ -58,6 +58,7 @@ void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controll
 
     r4300->mem = mem;
     r4300->mi = mi;
+    r4300->sp = sp;
     r4300->rdram = rdram;
     r4300->randomize_interrupt = randomize_interrupt;
     srand(time(NULL));

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -200,6 +200,7 @@ struct r4300_core
 
     struct memory* mem;
     struct mi_controller* mi;
+    struct rsp_core* sp;
     struct rdram* rdram;
 
     uint32_t randomize_interrupt;
@@ -208,7 +209,7 @@ struct r4300_core
 #define R4300_KSEG0 UINT32_C(0x80000000)
 #define R4300_KSEG1 UINT32_C(0xa0000000)
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int randomize_interrupt);
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rsp_core* sp, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int randomize_interrupt);
 void poweron_r4300(struct r4300_core* r4300);
 
 void run_r4300(struct r4300_core* r4300);


### PR DESCRIPTION
This is based off of @Gillou68310's work here: https://github.com/Gillou68310/mupen64plus-core/commit/d9129e1 to make sure that save states don't lock up in WDC/Stunt Racer.

@fzurita perhaps you could test this on the device that had the issue?

@bsmiles32 are you happy with how the pointer is passed around?