### PR TITLE
Force alignment of PI DMA

### DIFF
--- a/src/device/rcp/pi/pi_controller.c
+++ b/src/device/rcp/pi/pi_controller.c
@@ -52,8 +52,8 @@ enum
 
 static void dma_pi_read(struct pi_controller* pi)
 {
-    uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG];
-    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG];
+    uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] & ~UINT32_C(1);
+    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & ~UINT32_C(7);
     uint32_t length = (pi->regs[PI_RD_LEN_REG] & UINT32_C(0x00fffffe)) + 2;
     const uint8_t* dram = (uint8_t*)pi->ri->rdram->dram;
 
@@ -81,8 +81,8 @@ static void dma_pi_read(struct pi_controller* pi)
 
 static void dma_pi_write(struct pi_controller* pi)
 {
-    uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG];
-    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG];
+    uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] & ~UINT32_C(1);
+    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & ~UINT32_C(7);
     uint32_t length = (pi->regs[PI_WR_LEN_REG] & UINT32_C(0x00fffffe)) + 2;
     uint8_t* dram = (uint8_t*)pi->ri->rdram->dram;
 


### PR DESCRIPTION
This needs more testing, I'll report back once I've tested it more.

Fixes: https://github.com/project64/project64/issues/633

Taz Express tries to do an unaligned PI DMA transfer. Cart addresses must be 2-byte aligned and DRAM address must be 8-byte aligned.

This may/probably will break some ROM hacks (particularly some popular SM64 hacks). They don't work on a real console, and this is one of the main reasons.