### PR TITLE
Fix DSLLV in x86 dynarec

### DIFF
--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -1667,7 +1667,6 @@ void gendsllv(struct r4300_core* r4300)
     else
     {
         int temp1, temp2;
-        force_32(r4300, ECX);
         temp1 = lru_register(r4300);
         temp2 = lru_register_exc1(r4300, temp1);
         free_register(r4300, temp1);
@@ -1792,7 +1791,6 @@ void gendsrlv(struct r4300_core* r4300)
     else
     {
         int temp1, temp2;
-        force_32(r4300, ECX);
         temp1 = lru_register(r4300);
         temp2 = lru_register_exc1(r4300, temp1);
         free_register(r4300, temp1);
@@ -1917,7 +1915,6 @@ void gendsrav(struct r4300_core* r4300)
     else
     {
         int temp1, temp2;
-        force_32(r4300, ECX);
         temp1 = lru_register(r4300);
         temp2 = lru_register_exc1(r4300, temp1);
         free_register(r4300, temp1);

--- a/src/device/r4300/x86/regcache.c
+++ b/src/device/r4300/x86/regcache.c
@@ -547,39 +547,6 @@ void set_64_register_state(struct r4300_core* r4300, int reg1, int reg2, unsigne
     r4300->regcache_state.dirty[reg2] = d;
 }
 
-void force_32(struct r4300_core* r4300, int reg)
-{
-    if (r4300->regcache_state.r64[reg] != -1)
-    {
-        struct precomp_instr *last = r4300->regcache_state.last_access[reg]+1;
-
-        while (last <= r4300->recomp.dst)
-        {
-            if (r4300->regcache_state.dirty[reg])
-                last->reg_cache_infos.needed_registers[reg] = r4300->regcache_state.reg_content[reg];
-            else
-                last->reg_cache_infos.needed_registers[reg] = NULL;
-
-            if (r4300->regcache_state.dirty[r4300->regcache_state.r64[reg]])
-                last->reg_cache_infos.needed_registers[r4300->regcache_state.r64[reg]] = r4300->regcache_state.reg_content[r4300->regcache_state.r64[reg]];
-            else
-                last->reg_cache_infos.needed_registers[r4300->regcache_state.r64[reg]] = NULL;
-
-            last++;
-        }
-
-        if (r4300->regcache_state.dirty[reg])
-        {
-            mov_m32_reg32(r4300->regcache_state.reg_content[reg], reg);
-            mov_m32_reg32(r4300->regcache_state.reg_content[r4300->regcache_state.r64[reg]], r4300->regcache_state.r64[reg]);
-            r4300->regcache_state.dirty[reg] = 0;
-        }
-        r4300->regcache_state.last_access[r4300->regcache_state.r64[reg]] = NULL;
-        r4300->regcache_state.free_since[r4300->regcache_state.r64[reg]] = r4300->recomp.dst+1;
-        r4300->regcache_state.r64[reg] = -1;
-    }
-}
-
 void allocate_register_manually(struct r4300_core* r4300, int reg, unsigned int *addr)
 {
     int i;

--- a/src/device/r4300/x86/regcache.h
+++ b/src/device/r4300/x86/regcache.h
@@ -42,7 +42,6 @@ void set_register_state(struct r4300_core* r4300, int reg, unsigned int *addr, i
 void set_64_register_state(struct r4300_core* r4300, int reg1, int reg2, unsigned int *addr, int dirty);
 void allocate_register_manually(struct r4300_core* r4300, int reg, unsigned int *addr);
 void allocate_register_manually_w(struct r4300_core* r4300, int reg, unsigned int *addr, int load);
-void force_32(struct r4300_core* r4300, int reg);
 int lru_register_exc1(struct r4300_core* r4300, int exc1);
 void simplify_access(struct r4300_core* r4300);
 


### PR DESCRIPTION
This is based on @richard42's advice in https://github.com/mupen64plus/mupen64plus-core/issues/542#issuecomment-369840016

Removing the force_32 function does indeed fix Indiana Jones in the x86 dynarec.

I also ran PeterLemon's CPUDSLLV.N64, CPUDSRAV.N64, and CPUDSRLV.N64 test ROM's and we still pass those tests (we passed before this change as well).

I really don't know anything about assembly or the dynarec, I was jus testing/implementing @richard42's suggestion and it seems to work, so I created this PR