### PR TITLE
Clear CLOCK_REG when requested

### DIFF
--- a/src/device/rcp/rdp/rdp_core.c
+++ b/src/device/rcp/rdp/rdp_core.c
@@ -31,11 +31,11 @@
 static void update_dpc_status(struct rdp_core* dp, uint32_t w)
 {
     /* clear / set xbus_dmem_dma */
-    if (w & DPC_STATUS_CLR_XBUS_DMEM_DMA) dp->dpc_regs[DPC_STATUS_REG] &= ~DPC_STATUS_XBUS_DMEM_DMA;
-    if (w & DPC_STATUS_SET_XBUS_DMEM_DMA) dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_XBUS_DMEM_DMA;
+    if (w & DPC_CLR_XBUS_DMEM_DMA) dp->dpc_regs[DPC_STATUS_REG] &= ~DPC_STATUS_XBUS_DMEM_DMA;
+    if (w & DPC_SET_XBUS_DMEM_DMA) dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_XBUS_DMEM_DMA;
 
     /* clear / set freeze */
-    if (w & DPC_STATUS_CLR_FREEZE)
+    if (w & DPC_CLR_FREEZE)
     {
         dp->dpc_regs[DPC_STATUS_REG] &= ~DPC_STATUS_FREEZE;
 
@@ -45,11 +45,14 @@ static void update_dpc_status(struct rdp_core* dp, uint32_t w)
             gfx.updateScreen();
         dp->do_on_unfreeze = 0;
     }
-    if (w & DPC_STATUS_SET_FREEZE) dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_FREEZE;
+    if (w & DPC_SET_FREEZE) dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_FREEZE;
 
     /* clear / set flush */
-    if (w & DPC_STATUS_CLR_FLUSH) dp->dpc_regs[DPC_STATUS_REG] &= ~DPC_STATUS_FLUSH;
-    if (w & DPC_STATUS_SET_FLUSH) dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_FLUSH;
+    if (w & DPC_CLR_FLUSH) dp->dpc_regs[DPC_STATUS_REG] &= ~DPC_STATUS_FLUSH;
+    if (w & DPC_SET_FLUSH) dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_FLUSH;
+
+    /* clear clock counter */
+    if (w & DPC_CLR_CLOCK_CTR) dp->dpc_regs[DPC_CLOCK_REG] = 0;
 }
 
 
@@ -70,6 +73,8 @@ void poweron_rdp(struct rdp_core* dp)
 {
     memset(dp->dpc_regs, 0, DPC_REGS_COUNT*sizeof(uint32_t));
     memset(dp->dps_regs, 0, DPS_REGS_COUNT*sizeof(uint32_t));
+    dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_START_GCLK;
+
     dp->do_on_unfreeze = 0;
 
     poweron_fb(&dp->fb);
@@ -107,8 +112,10 @@ void write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mas
     {
     case DPC_START_REG:
         dp->dpc_regs[DPC_CURRENT_REG] = dp->dpc_regs[DPC_START_REG];
+        dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_START_VALID;
         break;
     case DPC_END_REG:
+        dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_END_VALID;
         gfx.processRDPList();
         signal_rcp_interrupt(dp->mi, MI_INTR_DP);
         break;

--- a/src/device/rcp/rdp/rdp_core.h
+++ b/src/device/rcp/rdp/rdp_core.h
@@ -36,14 +36,21 @@ enum
     DPC_STATUS_XBUS_DMEM_DMA = 0x001,
     DPC_STATUS_FREEZE        = 0x002,
     DPC_STATUS_FLUSH         = 0x004,
+    DPC_STATUS_START_GCLK    = 0x008,
     DPC_STATUS_CBUF_READY    = 0x080,
+    DPC_STATUS_END_VALID     = 0x200,
+    DPC_STATUS_START_VALID   = 0x400,
     /* DPC status - write */
-    DPC_STATUS_CLR_XBUS_DMEM_DMA = 0x001,
-    DPC_STATUS_SET_XBUS_DMEM_DMA = 0x002,
-    DPC_STATUS_CLR_FREEZE        = 0x004,
-    DPC_STATUS_SET_FREEZE        = 0x008,
-    DPC_STATUS_CLR_FLUSH         = 0x010,
-    DPC_STATUS_SET_FLUSH         = 0x020,
+    DPC_CLR_XBUS_DMEM_DMA        = 0x001,
+    DPC_SET_XBUS_DMEM_DMA        = 0x002,
+    DPC_CLR_FREEZE               = 0x004,
+    DPC_SET_FREEZE               = 0x008,
+    DPC_CLR_FLUSH                = 0x010,
+    DPC_SET_FLUSH                = 0x020,
+    DPC_CLR_TMEM_CTR             = 0x040,
+    DPC_CLR_PIPE_CTR             = 0x080,
+    DPC_CLR_CMD_CTR              = 0x100,
+    DPC_CLR_CLOCK_CTR            = 0x200
 };
 
 enum dpc_registers


### PR DESCRIPTION
I have seen some interest lately in emulating the DPC_CLOCK_REG register. See for example https://github.com/cxd4/rsp/issues/14

This should be a harmless change, we currently don't clear the CLOCK_REG when the game writes DPC_CLR_CLOCK_CTR to DPC_STATUS_REG. Given that some RSP/GFX plugins might start incrementing this register, we should implement clearing it. I know of a few games that write DPC_CLR_CLOCK_CTR (Gauntlet Legends and Taz Express come to mind).

Also, DPC_STATUS_START_GCLK should be set on boot, I'm not aware of any game where this makes a difference though.

Renamed some of the status flags to match what is in rcp.h