### PR TITLE
Don't call SDL_PumpEvents() in core

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -213,7 +213,6 @@ static void main_check_inputs(void)
 #ifdef WITH_LIRC
     lircCheckInput();
 #endif
-    SDL_PumpEvents();
 }
 
 /*********************************************************************************************************


### PR DESCRIPTION
SDL_PumpEvents is described as:

```
SDL_PumpEvents() gathers all the pending input information from devices and places it in the event queue
```

It is related to the input functions. In the past, mupen64plus-ae has used a slightly modified version of SDL2, but now I am trying to update it to use a vanilla version of 2.0.8, however it crashes when calling SDL_PumpEvents(). Presumably because there is no keyboard and SDL_INIT_JOYSTICK is never called. The input subsystem is not setup.

I moved SDL_PumpEvents to the beginning of the ```GetKeys()``` function in input-sdl. I tested using a keyboard and a joystick, both in-game inputs and events (like pause/quit game) still work with keyboard or joystick. See https://github.com/mupen64plus/mupen64plus-input-sdl/pull/68