### PR TITLE
Fix write_memory_8

### DIFF
--- a/src/debugger/dbg_memory.c
+++ b/src/debugger/dbg_memory.c
@@ -333,12 +333,13 @@ uint8_t read_memory_8(struct device* dev, uint32_t addr)
 
 void write_memory_8(struct device* dev, uint32_t addr, uint8_t value)
 {
+    uint32_t word;
     uint32_t mask;
 
     mask = 0xFF << ((3 - (addr & 3)) * 8);
-    value <<= ((3 - (addr & 3)) * 8);
+    word = value << ((3 - (addr & 3)) * 8);
     
-    r4300_write_aligned_word(&dev->r4300, addr, value, mask);
+    r4300_write_aligned_word(&dev->r4300, addr, word, mask);
 }
 
 uint32_t get_memory_flags(struct device* dev, uint32_t addr)


### PR DESCRIPTION
This was overflowing a u8, causing zeroes to be written most of
the time instead of the intended value.