### PR TITLE
Add VidExt_GL_GetDefaultFramebuffer

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus-v2.0-API-Versioning.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-v2.0-API-Versioning.mediawiki
@@ -112,5 +112,7 @@ This is the most complicated interface, because it involves 3 components: the vi
 * '''VIDEXT_API_VERSION''' version 3.0.0:
 ** add VidExt_ResizeWindow() function in video extension.  This function is called by the video plugin to notify the window manager (SDL if no video extension is registered by the front-end) that the OpenGL render window size should change.
 ** add m64p_video_flags parameter to the VidExt_SetVideoMode() function.  Currently the flags are only used to notify the window manager that resizing is supported by the video plugin, and it should create a resizable window if possible.  This may be extended in the future to support other features.
+* '''VIDEXT_API_VERSION''' version 3.1.0:
+** add VidExt_GL_GetDefaultFramebuffer() function in video extension. This function should be called to get the name of the default FBO.
 * '''INPUT_API_VERSION''' version 2.0.1:
 ** add (optional) RenderCallback function to input plugin. This function is called by the core after rendering on screen text (OSD) and before the graphics plugin swaps the buffers. The purpose of this function is to enable the input plugin to draw on screen content, for example buttons in a touch input plugin. If this function is not present the core will ignore it and on screen rendering by the input plugin will be disabled.

--- a/doc/emuwiki-api-doc/Mupen64Plus-v2.0-Core-Video-Extension.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-v2.0-Core-Video-Extension.mediawiki
@@ -193,4 +193,17 @@ In the Core Video Extension function ResizeWindow, the SDL function SetVideoMode
 |This function is used to swap the front/back buffers after rendering an output video frame.
 |}
 <br />
-
+{| border="1"
+|Prototype
+|'''<tt>uint32_t VidExt_GL_GetDefaultFramebuffer(void)</tt>'''
+|-
+|Input Parameters
+|N/A
+|-
+|Requirements
+|The video extension must be initialized before calling this function.  The rendering window should already be created.
+|-
+|Usage
+|On some platforms (for instance, iOS) the default framebuffer object depends on the surface being rendered to, and might be different from 0. This function should be called to retrieve the name of the default FBO. Calling this function may have performance implications and it should not be called every time the default FBO is bound.
+|}
+<br />

--- a/src/api/api_export.ver
+++ b/src/api/api_export.ver
@@ -70,4 +70,5 @@ VidExt_SetCaption;
 VidExt_SetVideoMode;
 VidExt_ToggleFullScreen;
 VidExt_ResizeWindow;
+VidExt_GL_GetDefaultFramebuffer;
 local: *; };

--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -384,6 +384,7 @@ typedef struct {
   m64p_error (*VidExtFuncSetCaption)(const char *);
   m64p_error (*VidExtFuncToggleFS)(void);
   m64p_error (*VidExtFuncResizeWindow)(int, int);
+  uint32_t   (*VidExtFuncGLGetDefaultFramebuffer)(void);
 } m64p_video_extension_functions;
 
 #endif /* define M64P_TYPES_H */

--- a/src/api/m64p_vidext.h
+++ b/src/api/m64p_vidext.h
@@ -146,6 +146,20 @@ typedef m64p_error (*ptr_VidExt_GL_SwapBuffers)(void);
 EXPORT m64p_error CALL VidExt_GL_SwapBuffers(void);
 #endif
 
+/* VidExt_GL_GetDefaultFramebuffer()
+ *
+ * On some platforms (for instance, iOS) the default framebuffer object
+ * depends on the surface being rendered to, and might be different from 0.
+ * This function should be called after VidExt_SetVideoMode to retrieve the
+ * name of the default FBO.
+ * Calling this function may have performance implications
+ * and it should not be called every time the default FBO is bound.
+ */
+typedef uint32_t (*ptr_VidExt_GL_GetDefaultFramebuffer)(void);
+#if defined(M64P_CORE_PROTOTYPES)
+EXPORT uint32_t CALL VidExt_GL_GetDefaultFramebuffer(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/api/vidext.c
+++ b/src/api/vidext.c
@@ -42,7 +42,7 @@
 #endif
 
 /* local variables */
-static m64p_video_extension_functions l_ExternalVideoFuncTable = {11, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
+static m64p_video_extension_functions l_ExternalVideoFuncTable = {12, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 static int l_VideoExtensionActive = 0;
 static int l_VideoOutputActive = 0;
 static int l_Fullscreen = 0;
@@ -54,7 +54,7 @@ m64p_error OverrideVideoFunctions(m64p_video_extension_functions *VideoFunctionS
     /* check input data */
     if (VideoFunctionStruct == NULL)
         return M64ERR_INPUT_ASSERT;
-    if (VideoFunctionStruct->Functions < 11)
+    if (VideoFunctionStruct->Functions < 12)
         return M64ERR_INPUT_INVALID;
 
     /* disable video extension if any of the function pointers are NULL */
@@ -68,10 +68,11 @@ m64p_error OverrideVideoFunctions(m64p_video_extension_functions *VideoFunctionS
         VideoFunctionStruct->VidExtFuncGLSwapBuf == NULL ||
         VideoFunctionStruct->VidExtFuncSetCaption == NULL ||
         VideoFunctionStruct->VidExtFuncToggleFS == NULL ||
-        VideoFunctionStruct->VidExtFuncResizeWindow == NULL)
+        VideoFunctionStruct->VidExtFuncResizeWindow == NULL ||
+        VideoFunctionStruct->VidExtFuncGLGetDefaultFramebuffer == NULL)
     {
-        l_ExternalVideoFuncTable.Functions = 11;
-        memset(&l_ExternalVideoFuncTable.VidExtFuncInit, 0, 11 * sizeof(void *));
+        l_ExternalVideoFuncTable.Functions = 12;
+        memset(&l_ExternalVideoFuncTable.VidExtFuncInit, 0, 12 * sizeof(void *));
         l_VideoExtensionActive = 0;
         return M64ERR_SUCCESS;
     }
@@ -532,4 +533,10 @@ EXPORT m64p_error CALL VidExt_GL_SwapBuffers(void)
     return M64ERR_SUCCESS;
 }
 
+EXPORT uint32_t CALL VidExt_GL_GetDefaultFramebuffer(void)
+{
+    if (l_VideoExtensionActive)
+        return (*l_ExternalVideoFuncTable.VidExtFuncGLGetDefaultFramebuffer)();
 
+    return 0;
+}

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -30,7 +30,7 @@
 #define FRONTEND_API_VERSION 0x020102
 #define CONFIG_API_VERSION   0x020301
 #define DEBUG_API_VERSION    0x020000
-#define VIDEXT_API_VERSION   0x030000
+#define VIDEXT_API_VERSION   0x030100
 
 #define VERSION_PRINTF_SPLIT(x) (((x) >> 16) & 0xffff), (((x) >> 8) & 0xff), ((x) & 0xff)
 


### PR DESCRIPTION
On some platforms (for instance, iOS) the default framebuffer object depends on the surface being rendered to, and might be different from 0.

This is also true for Qt. If the rendering surface is a QOpenGLWidget, the application must call ```GLuint QOpenGLContext::defaultFramebufferObject()``` to get the name of the default FBO. See (http://doc.qt.io/qt-5/qopenglcontext.html#defaultFramebufferObject). If it is a QOpenGLWindow, then the default FBO is "0".

GTK is the same, it doesn't allow rendering into the "0" framebuffer, the application must render into a framebuffer created by GTK. RetroArch does the same thing.


This was recently identified as an issue for the Provenance project (https://github.com/Provenance-Emu/Provenance) which is an iOS app that includes mupen64plus.

@braindx @JoeMatt can you please review this and comment whether this will meet the requirements for your project?