### PR TITLE
Increase DebugMessage buffer size to prevent overflows

### DIFF
--- a/src/api/callbacks.c
+++ b/src/api/callbacks.c
@@ -54,7 +54,7 @@ m64p_error SetStateCallback(ptr_StateCallback pFunc, void *Context)
 
 void DebugMessage(int level, const char *message, ...)
 {
-  char msgbuf[256];
+  char msgbuf[512];
   va_list args;
 
   if (pDebugFunc == NULL)


### PR DESCRIPTION
When running on iOS simulator, some paths are really long. This was causing mupen64plus core to crash DebugMessage with a buffer overflow when printing out statements related to paths.