### PR TITLE
Make --nosaveoptions not ever save options.

### DIFF
--- a/src/main/eventloop.c
+++ b/src/main/eventloop.c
@@ -509,7 +509,6 @@ void event_initialize(void)
 int event_set_core_defaults(void)
 {
     float fConfigParamsVersion;
-    int bSaveConfig = 0;
 
     if (ConfigOpenSection("CoreEvents", &l_CoreEventsConfig) != M64ERR_SUCCESS || l_CoreEventsConfig == NULL)
     {
@@ -522,14 +521,12 @@ int event_set_core_defaults(void)
         DebugMessage(M64MSG_WARNING, "No version number in 'CoreEvents' config section. Setting defaults.");
         ConfigDeleteSection("CoreEvents");
         ConfigOpenSection("CoreEvents", &l_CoreEventsConfig);
-        bSaveConfig = 1;
     }
     else if (((int) fConfigParamsVersion) != ((int) CONFIG_PARAM_VERSION))
     {
         DebugMessage(M64MSG_WARNING, "Incompatible version %.2f in 'CoreEvents' config section: current is %.2f. Setting defaults.", fConfigParamsVersion, (float) CONFIG_PARAM_VERSION);
         ConfigDeleteSection("CoreEvents");
         ConfigOpenSection("CoreEvents", &l_CoreEventsConfig);
-        bSaveConfig = 1;
     }
     else if ((CONFIG_PARAM_VERSION - fConfigParamsVersion) >= 0.0001f)
     {
@@ -537,7 +534,6 @@ int event_set_core_defaults(void)
         float fVersion = CONFIG_PARAM_VERSION;
         ConfigSetParameter(l_CoreEventsConfig, "Version", M64TYPE_FLOAT, &fVersion);
         DebugMessage(M64MSG_INFO, "Updating parameter set version in 'CoreEvents' config section to %.2f", fVersion);
-        bSaveConfig = 1;
     }
 
     ConfigSetDefaultFloat(l_CoreEventsConfig, "Version", CONFIG_PARAM_VERSION,  "Mupen64Plus CoreEvents config parameter set version number.  Please don't change this version number.");
@@ -575,9 +571,6 @@ int event_set_core_defaults(void)
     ConfigSetDefaultString(l_CoreEventsConfig, JoyCmdName[joyForward], "",    "Joystick event string for fast-forward");
     ConfigSetDefaultString(l_CoreEventsConfig, JoyCmdName[joyAdvance], "",    "Joystick event string for advancing by one frame when paused");
     ConfigSetDefaultString(l_CoreEventsConfig, JoyCmdName[joyGameshark], "",  "Joystick event string for pressing the game shark button");
-
-    if (bSaveConfig)
-        ConfigSaveSection("CoreEvents");
 
     return 1;
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -266,21 +266,19 @@ static void main_check_inputs(void)
 int main_set_core_defaults(void)
 {
     float fConfigParamsVersion;
-    int bSaveConfig = 0, bUpgrade = 0;
+    int bUpgrade = 0;
 
     if (ConfigGetParameter(g_CoreConfig, "Version", M64TYPE_FLOAT, &fConfigParamsVersion, sizeof(float)) != M64ERR_SUCCESS)
     {
         DebugMessage(M64MSG_WARNING, "No version number in 'Core' config section. Setting defaults.");
         ConfigDeleteSection("Core");
         ConfigOpenSection("Core", &g_CoreConfig);
-        bSaveConfig = 1;
     }
     else if (((int) fConfigParamsVersion) != ((int) CONFIG_PARAM_VERSION))
     {
         DebugMessage(M64MSG_WARNING, "Incompatible version %.2f in 'Core' config section: current is %.2f. Setting defaults.", fConfigParamsVersion, (float) CONFIG_PARAM_VERSION);
         ConfigDeleteSection("Core");
         ConfigOpenSection("Core", &g_CoreConfig);
-        bSaveConfig = 1;
     }
     else if ((CONFIG_PARAM_VERSION - fConfigParamsVersion) >= 0.0001f)
     {
@@ -288,7 +286,6 @@ int main_set_core_defaults(void)
         ConfigSetParameter(g_CoreConfig, "Version", M64TYPE_FLOAT, &fVersion);
         DebugMessage(M64MSG_INFO, "Updating parameter set version in 'Core' config section to %.2f", fVersion);
         bUpgrade = 1;
-        bSaveConfig = 1;
     }
 
     /* parameters controlling the operation of the core */
@@ -324,9 +321,6 @@ int main_set_core_defaults(void)
                 ConfigSetParameter(g_CoreConfig, "SaveSRAMPath", M64TYPE_STRING, pccSaveStatePath);
         }
     }
-
-    if (bSaveConfig)
-        ConfigSaveSection("Core");
 
     /* set config parameters for keyboard and joystick commands */
     return event_set_core_defaults();


### PR DESCRIPTION
As a new mupen64plus user, I struggled with the configuration, due to two major categories of unexpected behavior:

1. Under some circumstances, the configuration was changed and saved even when I specified `--nosaveoptions`, potentially leading to undesired options being persisted in the configuration.
2. The program runs when there is no configuration, and it generates a configuration file, but command-line parameters are not always respected unless the configuration is present first.

I do not yet have a proposed solution for problem 2 above, but this should help for problem 1, at least when `--nosaveoptions` is specified. I would like to first get this patchset accepted, if possible. I will show an example of the problems below. Please let me know if I have not explained things clearly... it's kind of tricky.

I will also post a corresponding patchset for ui-console.

```
# Set up an alias for convenience; this will be used in examples:
$ alias mupen64plus='/usr/local/src/mupen64plus/install/bin/mupen64plus --plugindir /usr/local/src/mupen64plus/install/lib/mupen64plus/ --datadir /usr/local/src/mupen64plus/install/share/mupen64plus/ --corelib /usr/local/src/mupen64plus/install/lib/libmupen64plus.so.2 --testshots 0'
```

Example from master branch of core and ui-console:
```
# Clean out configuration:
$ rm ~/.config/mupen64plus/mupen64plus.cfg

# Do a test run with --nosaveoptions; expected behavior is for configuration to
# not be saved:
$ mupen64plus --nosaveoptions /tmp/test.rom 2>&1 | tail -n 1
Core Status: Rom closed.

# Test if configuration was saved:
$ test -f ~/.config/mupen64plus/mupen64plus.cfg ; echo $?
0

# The configuration was saved, contrary to expectation.
# Check joystick order in preparation for next test:
$ grep 'name = ' ~/.config/mupen64plus/mupen64plus.cfg
name = "Twin USB Joystick"
name = "Twin USB Joystick"
name = "DragonRise Inc.   Generic   USB  Joystick  "
name = ""

# Try a different joystick order:
$ mupen64plus --nosaveoptions --set 'Input-SDL-Control1[name]=DragonRise Inc.   Generic   USB  Joystick  ' --set 'Input-SDL-Control1[mode]=1' ~/files/roms/N64/Zelda64.rom 2>&1 | tail -n 1
Core Status: Rom closed.

# Check joystick order again; the expected behavior is that the order is
# unchanged, since --nosaveoptions was present:
$ grep 'name = ' ~/.config/mupen64plus/mupen64plus.cfg
name = "DragonRise Inc.   Generic   USB  Joystick  "
name = "Twin USB Joystick"
name = "Twin USB Joystick"
name = ""

# The joystick order was changed, contrary to expectation.
```

Now the same example using patched UI and core:
```
# (using the same alias as before)

# Clean out configuration:
$ rm ~/.config/mupen64plus/mupen64plus.cfg

# Do a test run with --nosaveoptions; expected behavior is for configuration to
# not be saved:
$ mupen64plus --nosaveoptions /tmp/test.rom 2>&1 | tail -n 1
Core Status: Rom closed.

# Test if configuration was saved:
$ test -f ~/.config/mupen64plus/mupen64plus.cfg ; echo $?
0

# Configuration was not saved, as expected. Now allow the configuration to be
# saved in preparation for the next test.
$ mupen64plus /tmp/test.rom 2>&1 | tail -n 1
Core Status: Rom closed.

# Check the joystick order before running the test:
$ grep 'name = ' ~/.config/mupen64plus/mupen64plus.cfg
name = "Twin USB Joystick"
name = "Twin USB Joystick"
name = "DragonRise Inc.   Generic   USB  Joystick  "
name = ""

# Try a different joystick order, with --nosaveoptions present:
$ mupen64plus --nosaveoptions --set 'Input-SDL-Control1[name]=DragonRise Inc.   Generic   USB  Joystick  ' --set 'Input-SDL-Control1[mode]=1' ~/files/roms/N64/Zelda64.rom 2>&1 | tail -n 1
Core Status: Rom closed.


# Check joystick order again; the expected behavior is that the order is
# unchanged, since --nosaveoptions was present:
$ grep 'name = ' ~/.config/mupen64plus/mupen64plus.cfg
name = "Twin USB Joystick"
name = "Twin USB Joystick"
name = "DragonRise Inc.   Generic   USB  Joystick  "
name = ""

# The order is indeed unchanged, as expected.
```

Thanks,
Corey