### PR TITLE
Two new debugger APIs: 'DebugBreakpointTriggeredBy' and 'DebugVirtualToPhysical'

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus-v2.0-Core-Debugger.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-v2.0-Core-Debugger.mediawiki
@@ -229,6 +229,35 @@ Most libmupen64plus functions return an <tt>m64p_error</tt> return code, which i
 |}
 <br />
 {| border="1"
+|Prototype
+|'''<tt>void DebugBreakpointTriggeredBy(uint32_t *flags, uint32_t *accessed)</tt>'''
+|-
+|Input Parameters
+|'''<tt>flags</tt>''' Pointer to store the breakpoint flag trigger reason for the most recent breakpoint<br />
+'''<tt>accessed</tt>''' Pointer to store the trigger address for the most recent breakpoint
+|-
+|Requirements
+|The Mupen64Plus library must be built with debugger support and must be initialized, the emulator core must be executing a ROM, and the debugger must be active before calling this function.
+|-
+|Usage
+|This function is used to programmatically access the trigger reason and address for the most recently triggered breakpoint. The meaning of the '''<tt>flags</tt>''' value are the same as the '''<tt>m64p_dbg_bkp_flags</tt>''' enumerated in [[Mupen64Plus v2.0 headers#m64p_types.h|m64p_types.h]]. For memory read/write breakpoints, the value of '''<tt>accessed</tt>''' will be set to the ''physical'' address accessed; exec breakpoints will not populate this value as the necessary information is already encoded in the program counter.
+|}
+<br />
+{| border="1"
+|Prototype
+|'''<tt>uint32_t DebugVirtualToPhysical(uint32_t address)</tt>'''
+|-
+|Input Parameters
+|'''<tt>address</tt>''' A ''virtual'' address in R4300 memory
+|-
+|Requirements
+|The Mupen64Plus library must be built with debugger support and must be initialized, the emulator core must be executing a ROM, and the debugger must be active before calling this function.
+|-
+|Usage
+|This function resolves the ''physical'' address in R4300 memory corresponding to the provided ''virtual'' address. Memory read and write breakpoints only operate in terms of physical addresses, thus this function is provided to assist in the necessary virtual to physical translations.
+|}
+<br />
+{| border="1"
 !Command!!Return Value!!Function!!<tt>index</tt> Parameter!!<tt>ptr</tt> Parameter
 |-
 |M64P_BKP_CMD_ADD_ADDR

--- a/src/api/api_export.ver
+++ b/src/api/api_export.ver
@@ -59,6 +59,7 @@ DebugSetCallbacks;
 DebugSetCoreCompare;
 DebugSetRunState;
 DebugStep;
+DebugVirtualToPhysical;
 PluginGetVersion;
 VidExt_GL_GetProcAddress;
 VidExt_GL_SetAttribute;

--- a/src/api/api_export.ver
+++ b/src/api/api_export.ver
@@ -40,6 +40,7 @@ CoreShutdown;
 CoreStartup;
 DebugBreakpointCommand;
 DebugBreakpointLookup;
+DebugBreakpointTriggeredBy;
 DebugDecodeOp;
 DebugGetCPUDataPtr;
 DebugGetState;

--- a/src/api/debugger.c
+++ b/src/api/debugger.c
@@ -35,6 +35,7 @@
 #include "device/device.h"
 #include "device/memory/memory.h"
 #include "device/r4300/r4300_core.h"
+#include "device/r4300/tlb.h"
 #include "m64p_debugger.h"
 #include "m64p_types.h"
 #include "main/main.h"
@@ -428,5 +429,25 @@ EXPORT void CALL DebugBreakpointTriggeredBy(uint32_t *flags, uint32_t *accessed)
     *accessed = breakpointAccessed;
 #else
     DebugMessage(M64MSG_ERROR, "Bug: DebugBreakpointTriggeredBy() called, but Debugger not supported in Core library");
+#endif
+}
+
+EXPORT uint32_t CALL DebugVirtualToPhysical(uint32_t address)
+{
+#ifdef DBG
+    struct device* dev = &g_dev;
+    struct r4300_core* r4300 = &dev->r4300;
+
+    if ((address & UINT32_C(0xc0000000)) != UINT32_C(0x80000000)) {
+        address = virtual_to_physical_address(r4300, address, 0);
+        if (address == 0) {
+            return 0;
+        }
+    }
+
+    address &= UINT32_C(0x1fffffff);
+    return address;
+#else
+    DebugMessage(M64MSG_ERROR, "Bug: DebugVirtualToPhysical() called, but Debugger not supported in Core library");
 #endif
 }

--- a/src/api/debugger.c
+++ b/src/api/debugger.c
@@ -107,6 +107,12 @@ EXPORT m64p_error CALL DebugSetRunState(m64p_dbg_runstate runstate)
 {
 #ifdef DBG
     g_dbg_runstate = runstate; /* in debugger/debugger.c */
+    if (runstate == M64P_DBG_RUNSTATE_RUNNING)
+    {
+        /* clear out last breakpoint state when resuming */
+        breakpointFlag = 0;
+        breakpointAccessed = 0;
+    }
     return M64ERR_SUCCESS;
 #else
     return M64ERR_UNSUPPORTED;
@@ -415,3 +421,12 @@ EXPORT int CALL DebugBreakpointCommand(m64p_dbg_bkp_command command, unsigned in
 #endif
 }
 
+EXPORT void CALL DebugBreakpointTriggeredBy(uint32_t *flags, uint32_t *accessed)
+{
+#ifdef DBG
+    *flags = breakpointFlag;
+    *accessed = breakpointAccessed;
+#else
+    DebugMessage(M64MSG_ERROR, "Bug: DebugBreakpointTriggeredBy() called, but Debugger not supported in Core library");
+#endif
+}

--- a/src/api/m64p_debugger.h
+++ b/src/api/m64p_debugger.h
@@ -204,6 +204,16 @@ typedef void (*ptr_DebugBreakpointTriggeredBy)(uint32_t *, uint32_t *);
 EXPORT void CALL DebugBreakpointTriggeredBy(uint32_t *, uint32_t *);
 #endif
 
+/* DebugVirtualToPhysical()
+ *
+ * This function is used to translate virtual addresses to physical addresses.
+ * Memory read/write breakpoints operate on physical addresses.
+ */
+typedef uint32_t (*ptr_DebugVirtualToPhysical)(uint32_t);
+#if defined(M64P_CORE_PROTOTYPES)
+EXPORT uint32_t CALL DebugVirtualToPhysical(uint32_t);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/api/m64p_debugger.h
+++ b/src/api/m64p_debugger.h
@@ -194,6 +194,16 @@ typedef int (*ptr_DebugBreakpointCommand)(m64p_dbg_bkp_command, unsigned int, m6
 EXPORT int CALL DebugBreakpointCommand(m64p_dbg_bkp_command, unsigned int, m64p_breakpoint *);
 #endif
 
+/* DebugBreakpointTriggeredBy()
+ *
+ * This function is used to retrieve the trigger flags and address for the
+ * most recently triggered breakpoint.
+ */
+typedef void (*ptr_DebugBreakpointTriggeredBy)(uint32_t *, uint32_t *);
+#if defined(M64P_CORE_PROTOTYPES)
+EXPORT void CALL DebugBreakpointTriggeredBy(uint32_t *, uint32_t *);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/debugger/dbg_breakpoints.c
+++ b/src/debugger/dbg_breakpoints.c
@@ -186,6 +186,8 @@ int check_breakpoints_on_mem_access(uint32_t pc, uint32_t address, uint32_t size
     if (g_dbg_runstate == M64P_DBG_RUNSTATE_RUNNING) {
         bpt = lookup_breakpoint(address, size, flags);
         if (bpt != -1) {
+            breakpointAccessed = address;
+            breakpointFlag = flags;
             if (BPT_CHECK_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_LOG))
                 log_breakpoint(pc, flags, address);
 

--- a/src/debugger/dbg_debugger.c
+++ b/src/debugger/dbg_debugger.c
@@ -38,6 +38,9 @@ static SDL_sem *sem_pending_steps;
 
 uint32_t previousPC;
 
+uint32_t breakpointAccessed;
+uint32_t breakpointFlag;
+
 //]=-=-=-=-=-=-=-=-=-=-=[ Initialisation du Debugger ]=-=-=-=-=-=-=-=-=-=-=-=[
 
 void init_debugger()
@@ -73,6 +76,8 @@ void update_debugger(uint32_t pc)
         if (bpt != -1) {
             g_dbg_runstate = M64P_DBG_RUNSTATE_PAUSED;
 
+            breakpointAccessed = 0;
+            breakpointFlag = M64P_BKP_FLAG_EXEC;
             if (BPT_CHECK_FLAG(g_Breakpoints[bpt], M64P_BKP_FLAG_LOG))
                 log_breakpoint(pc, M64P_BKP_FLAG_EXEC, 0);
         }

--- a/src/debugger/dbg_debugger.h
+++ b/src/debugger/dbg_debugger.h
@@ -31,6 +31,9 @@ extern m64p_dbg_runstate g_dbg_runstate;
 
 extern uint32_t previousPC;
 
+extern uint32_t breakpointAccessed;
+extern uint32_t breakpointFlag;
+
 void init_debugger(void);
 void update_debugger(uint32_t pc);
 void destroy_debugger(void);


### PR DESCRIPTION
This pull request adds two new debugger APIs:
- DebugBreakpointTriggeredBy: this retrieves the flag (e.g. M64P_BKP_FLAG_READ, M64P_BKP_FLAG_WRITE) and trigger address for the currently triggered breakpoint. Existing code can log to the console upon triggering a breakpoint (if M64P_BKP_FLAG_LOG is set), but these values were not programmatically accessible to a debugging front-end.
- DebugVirtualToPhysical: this retrieves the physical R4300 memory address corresponding to a virtual R4300 memory address. Memory breakpoints, unlike memory read/write commands, do not undergo virtual to physical address translation prior to being set, so debugging front-ends require a programmatic method of translating on their own.

Adding virtual address translation to breakpoint creation looks to be tricky, since internally they operate on physical addresses, thus you would need to reverse that translation to accurately report on the corresponding virtual address that has been accessed. By exposing translation capabilities to debugging front ends, this process can be controlled and visible to the user.