### PR TITLE
Avoid nameless union in r4300_core.h (this is a non standard extension)

### DIFF
--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -173,10 +173,8 @@ struct r4300_core
         uint64_t* rdword;
         uint32_t wmask;
         uint32_t address;
-        union {
-            uint32_t wword;
-            uint64_t wdword;
-        };
+        uint32_t wword;
+        uint64_t wdword;
     } recomp;
 #else
 #if NEW_DYNAREC == NEW_DYNAREC_ARM


### PR DESCRIPTION
There is still one usage of nameless union in m64p_plugin.h (BUTTONS) but as it is public API changing it would break backward compatibility.