### PR TITLE
Fix errors introduced in #444

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -17217,7 +17217,7 @@ SaveType=Eeprom 4KB
 [EC2BCB1B7FC7D068BE1F39E79E49A842]
 GoodName=Xena Warrior Princess - The Talisman of Fate (E) [!]
 CRC=0A1667C7 293346A6
-Status=3
+CountPerOp=3
 Players=4
 SaveType=None
 Mempak=Yes
@@ -17226,7 +17226,7 @@ Rumble=Yes
 [1AC234649D28F09E82C0D11ABB17F03B]
 GoodName=Xena Warrior Princess - The Talisman of Fate (U) [!]
 CRC=0553AE9D EAD8E0C1
-Status=3
+CountPerOp=3
 Players=4
 SaveType=None
 Mempak=Yes

--- a/src/device/rcp/ai/ai_controller.c
+++ b/src/device/rcp/ai/ai_controller.c
@@ -64,7 +64,7 @@ static unsigned int get_dma_duration(struct ai_controller* ai)
 {
     unsigned int samples_per_sec = ai->vi->clock / (1 + ai->regs[AI_DACRATE_REG]);
     unsigned int bytes_per_sample = 4; /* XXX: assume 16bit stereo - should depends on bitrate instead */
-    unsigned int cpu_counts_per_sec = ai->vi->delay * ai->vi->expected_refresh_rate; /* estimate cpu counts/sec using VI */
+    unsigned int cpu_counts_per_sec = ai->vi->delay == 0 ? ai->vi->clock : ai->vi->delay * ai->vi->expected_refresh_rate; /* estimate cpu counts/sec using VI */
 
     return ai->regs[AI_LEN_REG] * (cpu_counts_per_sec / (bytes_per_sample * samples_per_sec));
 }


### PR DESCRIPTION
These changes allow Rugrats and Xena to boot. Tested booting many other games, no regressions found.