### PR TITLE
Preserve floating-point configuration values.

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -554,12 +554,17 @@ m64p_error ConfigInit(const char *ConfigDirOverride, const char *DataDirOverride
                 }
                 else if (is_numeric(l.value))
                 {
-                    int val_int = (int) strtol(l.value, NULL, 10);
-                    float val_float = (float) strtod(l.value, NULL);
-                    if ((val_float - val_int) != 0.0)
+                    /* preserve values as floats if they are written in the config as floats */
+                    if (strchr(l.value, '.'))
+                    {
+                        float val_float = (float) strtod(l.value, NULL);
                         ConfigSetDefaultFloat((m64p_handle) current_section, l.name, val_float, lastcomment);
+                    }
                     else
+                    {
+                        int val_int = (int) strtol(l.value, NULL, 10);
                         ConfigSetDefaultInt((m64p_handle) current_section, l.name, val_int, lastcomment);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Currently, if a floating-point configuration value is equal to an
integer, it gets rewritten as an integer.

Example:
The Video-Rice PolygonOffsetFactor parameter is registered in the source
as a float, default 0.0f. When configuration is not initially present
(the first run of the program), the internal type is M64TYPE_FLOAT, so
the core writes the value to the config file as '0.000000' (default
6-digit precision of fprintf). On the next run, the core reads the value
and translates it to M64TYPE_INT and then writes it to the config file
as '0'.

This patch changes the parsing so that floats are preserved as floats
even when they happen to have an integral value. This way, a user
reading the config file has a visual indication of which values may be
set to floating-point values.