### PR TITLE
Fix joy_max for initialize loop

### DIFF
--- a/src/main/eventloop.c
+++ b/src/main/eventloop.c
@@ -461,7 +461,7 @@ void event_initialize(void)
                 if (phrase_str[1] == '*')
                 {
                     joy_min = 0;
-                    joy_max = NumJoysticks;
+                    joy_max = NumJoysticks - 1;
                 }
                 else if (phrase_str[1] >= '0' && phrase_str[1] <= '9')
                 {


### PR DESCRIPTION
During SDL joystick initialization needed for core events hotkeys, the loop of all controllers, in case of a J* hotkey should stop on the last found controller (ex.: for four controllers, should go from J0 to J3, instead of J4).