### PR TITLE
Remove DelaySI from wiki

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus-Core-Parameters.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-Core-Parameters.mediawiki
@@ -59,10 +59,6 @@ These are standard parameters which are used by the Mupen64Plus Core library.  T
 |M64TYPE_INT
 |Force number of cycles per emulated instruction when set greater than 0.
 |-
-|DelaySI
-|M64TYPE_BOOL
-|Delay interrupt after DMA SI read/write.
-|-
 |DisableSpecRecomp
 |M64TYPE_BOOL
 |Disable speculative precompilation in new dynarec.


### PR DESCRIPTION
This parameter was removed from the core in 0bcfd3cc7.