### PR TITLE
Allow valid interpretations of strings as non-strings

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -91,6 +91,11 @@ static int is_numeric(const char *string)
     return (rval == 1);
 }
 
+static int can_be_numeric_type(config_var *var, m64p_type ParamType) {
+    return (var->type == ParamType || var->type == M64TYPE_INT ||
+            (var->type == M64TYPE_STRING && is_numeric(var->val.string)));
+}
+
 /* This function returns a pointer to the pointer of the requested section
  * (i.e. a pointer the next field of the previous element, or to the first node).
  *
@@ -1155,17 +1160,17 @@ EXPORT m64p_error CALL ConfigGetParameter(m64p_handle ConfigSectionHandle, const
     {
         case M64TYPE_INT:
             if (MaxSize < (int)sizeof(int)) return M64ERR_INPUT_INVALID;
-            if (var->type != M64TYPE_INT && var->type != M64TYPE_FLOAT) return M64ERR_WRONG_TYPE;
+            if (! can_be_numeric_type(var, M64TYPE_FLOAT)) return M64ERR_WRONG_TYPE;
             *((int *) ParamValue) = ConfigGetParamInt(ConfigSectionHandle, ParamName);
             break;
         case M64TYPE_FLOAT:
             if (MaxSize < (int)sizeof(float)) return M64ERR_INPUT_INVALID;
-            if (var->type != M64TYPE_INT && var->type != M64TYPE_FLOAT) return M64ERR_WRONG_TYPE;
+            if (! can_be_numeric_type(var, M64TYPE_FLOAT)) return M64ERR_WRONG_TYPE;
             *((float *) ParamValue) = ConfigGetParamFloat(ConfigSectionHandle, ParamName);
             break;
         case M64TYPE_BOOL:
             if (MaxSize < (int)sizeof(int)) return M64ERR_INPUT_INVALID;
-            if (var->type != M64TYPE_BOOL && var->type != M64TYPE_INT) return M64ERR_WRONG_TYPE;
+            if (! can_be_numeric_type(var, M64TYPE_BOOL)) return M64ERR_WRONG_TYPE;
             *((int *) ParamValue) = ConfigGetParamBool(ConfigSectionHandle, ParamName);
             break;
         case M64TYPE_STRING:

--- a/src/api/config.c
+++ b/src/api/config.c
@@ -1436,7 +1436,7 @@ EXPORT float CALL ConfigGetParamFloat(m64p_handle ConfigSectionHandle, const cha
         return 0.0;
     }
 
-    /* translate the actual variable type to an int */
+    /* translate the actual variable type to a float */
     switch(var->type)
     {
         case M64TYPE_INT:
@@ -1480,7 +1480,7 @@ EXPORT int CALL ConfigGetParamBool(m64p_handle ConfigSectionHandle, const char *
         return 0;
     }
 
-    /* translate the actual variable type to an int */
+    /* translate the actual variable type to an int (0 or 1) */
     switch(var->type)
     {
         case M64TYPE_INT:
@@ -1525,7 +1525,7 @@ EXPORT const char * CALL ConfigGetParamString(m64p_handle ConfigSectionHandle, c
         return "";
     }
 
-    /* translate the actual variable type to an int */
+    /* translate the actual variable type to a string */
     switch(var->type)
     {
         case M64TYPE_INT:


### PR DESCRIPTION
From the commit message of the second patch:
```
The various ConfigGetParamX() functions can handle string inputs
already, but ConfigGetParameter() rejects such inputs beforehand.

Modify ConfigGetParameter() to validate that a string represents a
numeric value. If so, then ConfigGetParamX() can handle the input.
Factor the checks into a new function to keep them from getting too 
long.

Use case:
Values read from the ui-console command line are always strings, by
necessity. When the config file is empty (or somehow lacking the 
specified parameter), then ui-console cannot know the desired type, so
it defaults to storing the parameter as a string. Without this patch,
this can result in plugin code ignoring a validly-specified
command-line parameter.

Use case:
Without this patch, if a user unknowingly specifies a float or integer
value in the config file within double-quotes, this can result in plugin
code ignoring the parameter.
```

Thanks,
Corey