### PR TITLE
Make stop_after_jal a save state parameter instead of configuration

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus-Core-Parameters.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-Core-Parameters.mediawiki
@@ -59,10 +59,6 @@ These are standard parameters which are used by the Mupen64Plus Core library.  T
 |M64TYPE_INT
 |Force number of cycles per emulated instruction when set greater than 0.
 |-
-|DisableSpecRecomp
-|M64TYPE_BOOL
-|Disable speculative precompilation in new dynarec.
-|-
 |}
 
 These configuration parameters are used in the Core's event loop to detect keyboard and joystick commands.  They are stored in a configuration section called "CoreEvents" and may be altered by the front-end in order to adjust the behaviour of the emulator.  These may be adjusted at any time and the effect of the change should occur immediately.  The Keysym value stored is actually <tt>(SDLMod << 16) || SDLKey</tt>, so that keypresses with modifiers like shift, control, or alt may be used.

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -7613,6 +7613,7 @@ void new_dynarec_init(void)
   // Copy this into local area so we don't have to put it in every literal pool
   g_dev.r4300.new_dynarec_hot_state.invc_ptr=g_dev.r4300.cached_interp.invalid_code;
 #endif
+  stop_after_jal=0;
   // TLB
   using_tlb=0;
   for(n=0;n<524288;n++) // 0 .. 0x7FFFFFFF

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -306,7 +306,6 @@ int main_set_core_defaults(void)
     ConfigSetDefaultString(g_CoreConfig, "SaveSRAMPath", "", "Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used");
     ConfigSetDefaultString(g_CoreConfig, "SharedDataPath", "", "Path to a directory to search when looking for shared data files");
     ConfigSetDefaultInt(g_CoreConfig, "CountPerOp", 0, "Force number of cycles per emulated instruction");
-    ConfigSetDefaultBool(g_CoreConfig, "DisableSpecRecomp", 1, "Disable speculative precompilation in new dynarec");
     ConfigSetDefaultBool(g_CoreConfig, "RandomizeInterrupt", 1, "Randomize PI/SI Interrupt Timing");
     ConfigSetDefaultInt(g_CoreConfig, "SiDmaDuration", -1, "Duration of SI DMA (-1: use per game settings)");
     ConfigSetDefaultString(g_CoreConfig, "GbCameraVideoCaptureBackend1", DEFAULT_VIDEO_CAPTURE_BACKEND, "Gameboy Camera Video Capture backend");
@@ -1306,10 +1305,6 @@ m64p_error main_run(void)
     savestates_select_slot(ConfigGetParamInt(g_CoreConfig, "CurrentStateSlot"));
     no_compiled_jump = ConfigGetParamBool(g_CoreConfig, "NoCompiledJump");
     randomize_interrupt = ConfigGetParamBool(g_CoreConfig, "RandomizeInterrupt");
-#ifdef NEW_DYNAREC
-    stop_after_jal = ConfigGetParamBool(g_CoreConfig, "DisableSpecRecomp");
-#endif
-
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
 
     if (ROM_PARAMS.disableextramem)


### PR DESCRIPTION
That way it can be used when loading save states instead of having speculate recompilation always disabled for compatibility with save states.