### PR TITLE
do not force saving config when file not present

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -70,7 +70,6 @@ typedef config_section *config_list;
 
 /* local variables */
 static int         l_ConfigInit = 0;
-static int         l_SaveConfigOnExit = 0;
 static char       *l_DataDirOverride = NULL;
 static char       *l_ConfigDirOverride = NULL;
 static config_list l_ConfigListActive = NULL;
@@ -474,7 +473,6 @@ m64p_error ConfigInit(const char *ConfigDirOverride, const char *DataDirOverride
     {
         DebugMessage(M64MSG_INFO, "Couldn't open configuration file '%s'.  Using defaults.", filepath);
         free(filepath);
-        l_SaveConfigOnExit = 1; /* auto-save the config file so that the defaults will be saved to disk */
         return M64ERR_SUCCESS;
     }
     free(filepath);
@@ -590,10 +588,6 @@ m64p_error ConfigInit(const char *ConfigDirOverride, const char *DataDirOverride
 
 m64p_error ConfigShutdown(void)
 {
-    /* first, save the file if necessary */
-    if (l_SaveConfigOnExit)
-        ConfigSaveFile();
-
     /* reset the initialized flag */
     if (!l_ConfigInit)
         return M64ERR_NOT_INIT;


### PR DESCRIPTION
Front-ends now ensure that configuration is saved (when desired) before
starting the game.