### PR TITLE
Allow 16MB of RDRAM

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -132,7 +132,7 @@ void init_device(struct device* dev,
         /* clear mappings */
         { 0x00000000, 0xffffffff, M64P_MEM_NOTHING, { NULL, RW(open_bus) } },
         /* memory map */
-        { A(MM_RDRAM_DRAM, dram_size-1), M64P_MEM_RDRAM, { &dev->rdram, RW(rdram_dram) } },
+        { A(MM_RDRAM_DRAM, RDRAM_16MB_SIZE-1), M64P_MEM_RDRAM, { &dev->rdram, RW(rdram_dram) } },
         { A(MM_RDRAM_REGS, 0xfffff), M64P_MEM_RDRAMREG, { &dev->rdram, RW(rdram_regs) } },
         { A(MM_RSP_MEM, 0xffff), M64P_MEM_RSPMEM, { &dev->sp, RW(rsp_mem) } },
         { A(MM_RSP_REGS, 0xffff), M64P_MEM_RSPREG, { &dev->sp, RW(rsp_regs) } },

--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -215,7 +215,7 @@ void apply_mem_mapping(struct memory* mem, const struct mem_mapping* mapping)
 
 enum {
     MB_RDRAM_DRAM = 0,
-    MB_CART_ROM = MB_RDRAM_DRAM + RDRAM_MAX_SIZE,
+    MB_CART_ROM = MB_RDRAM_DRAM + RDRAM_16MB_SIZE,
     MB_RSP_MEM  = MB_CART_ROM   + CART_ROM_MAX_SIZE,
     MB_DD_ROM   = MB_RSP_MEM    + SP_MEM_SIZE,
     MB_PIF_MEM  = MB_DD_ROM     + DD_ROM_MAX_SIZE,
@@ -272,7 +272,7 @@ uint32_t* mem_base_u32(void* mem_base, uint32_t address)
         /* In compressed mem base mode, select appropriate mem_base offset */
         mem_base = MEM_BASE_PTR(mem_base);
 
-        if (address < RDRAM_MAX_SIZE) {
+        if (address < RDRAM_16MB_SIZE) {
             mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_RDRAM_DRAM + MB_RDRAM_DRAM));
         }
         else if (address >= MM_CART_ROM) {

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -27,7 +27,9 @@
 
 #include "osal/preproc.h"
 
-enum { RDRAM_MAX_SIZE = 0x800000 };
+enum { RDRAM_16MB_SIZE = 0x1000000 };
+enum { RDRAM_8MB_SIZE = 0x800000 };
+enum { RDRAM_4MB_SIZE = 0x400000 };
 enum { CART_ROM_MAX_SIZE = 0x4000000 };
 enum { DD_ROM_MAX_SIZE = 0x400000 };
 

--- a/src/device/rdram/rdram.c
+++ b/src/device/rdram/rdram.c
@@ -138,7 +138,7 @@ void poweron_rdram(struct rdram* rdram)
     size_t module;
     size_t modules = get_modules_count(rdram);
     memset(rdram->regs, 0, RDRAM_MAX_MODULES_COUNT*RDRAM_REGS_COUNT*sizeof(uint32_t));
-    memset(rdram->dram, 0, rdram->dram_size);
+    memset(rdram->dram, 0, RDRAM_16MB_SIZE);
 
     DebugMessage(M64MSG_INFO, "Initializing %u RDRAM modules for a total of %u MB",
         modules, rdram->dram_size / (1024*1024));

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1311,8 +1311,7 @@ m64p_error main_run(void)
     else
         disable_extra_mem = ConfigGetParamInt(g_CoreConfig, "DisableExtraMem");
 
-
-    rdram_size = (disable_extra_mem == 0) ? 0x800000 : 0x400000;
+    rdram_size = (disable_extra_mem == 0) ? RDRAM_8MB_SIZE : RDRAM_4MB_SIZE;
 
     if (count_per_op <= 0)
         count_per_op = ROM_PARAMS.countperop;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -296,7 +296,7 @@ int main_set_core_defaults(void)
     ConfigSetDefaultInt(g_CoreConfig, "R4300Emulator", 1, "Use Pure Interpreter if 0, Cached Interpreter if 1, or Dynamic Recompiler if 2 or more");
 #endif
     ConfigSetDefaultBool(g_CoreConfig, "NoCompiledJump", 0, "Disable compiled jump commands in dynamic recompiler (should be set to False) ");
-    ConfigSetDefaultBool(g_CoreConfig, "DisableExtraMem", 0, "Disable 4MB expansion RAM pack. May be necessary for some games");
+    ConfigSetDefaultInt(g_CoreConfig, "RdramSize", 1, "RDRAM size (0: 4MB, 1: 8MB, 2: 16MB)");
     ConfigSetDefaultBool(g_CoreConfig, "AutoStateSlotIncrement", 0, "Increment the save state slot after each save operation");
     ConfigSetDefaultBool(g_CoreConfig, "EnableDebugger", 0, "Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support");
     ConfigSetDefaultInt(g_CoreConfig, "CurrentStateSlot", 0, "Save state slot (0-9) to use when saving/loading the emulator state");
@@ -1306,12 +1306,30 @@ m64p_error main_run(void)
     randomize_interrupt = ConfigGetParamBool(g_CoreConfig, "RandomizeInterrupt");
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
 
-    if (ROM_PARAMS.disableextramem)
-        disable_extra_mem = ROM_PARAMS.disableextramem;
-    else
-        disable_extra_mem = ConfigGetParamInt(g_CoreConfig, "DisableExtraMem");
 
-    rdram_size = (disable_extra_mem == 0) ? RDRAM_8MB_SIZE : RDRAM_4MB_SIZE;
+    if (ROM_PARAMS.disableextramem)
+    {
+        rdram_size = RDRAM_4MB_SIZE;
+    }
+    else
+    {
+        int rdramSizeParam = ConfigGetParamInt(g_CoreConfig, "RdramSize");
+
+        switch (rdramSizeParam)
+        {
+            case 0:
+                rdram_size = RDRAM_4MB_SIZE;
+                break;
+            case 1:
+                rdram_size = RDRAM_8MB_SIZE;
+                break;
+            case 2:
+                rdram_size = RDRAM_16MB_SIZE;
+                break;
+            default:
+                rdram_size = RDRAM_8MB_SIZE;
+        }
+    }
 
     if (count_per_op <= 0)
         count_per_op = ROM_PARAMS.countperop;


### PR DESCRIPTION
So allegedly the N64 allowed for up to expansions paks of 16MB. I modified the code to allow that. @bsmiles32 Does everything look right?