### PR TITLE
Always allocate 16MB RDRAM even though only 8MB is supported

### DIFF
--- a/src/device/memory/memory.c
+++ b/src/device/memory/memory.c
@@ -215,7 +215,7 @@ void apply_mem_mapping(struct memory* mem, const struct mem_mapping* mapping)
 
 enum {
     MB_RDRAM_DRAM = 0,
-    MB_CART_ROM = MB_RDRAM_DRAM + RDRAM_MAX_SIZE,
+    MB_CART_ROM = MB_RDRAM_DRAM + RDRAM_16MB_SIZE,
     MB_RSP_MEM  = MB_CART_ROM   + CART_ROM_MAX_SIZE,
     MB_DD_ROM   = MB_RSP_MEM    + SP_MEM_SIZE,
     MB_PIF_MEM  = MB_DD_ROM     + DD_ROM_MAX_SIZE,
@@ -272,7 +272,7 @@ uint32_t* mem_base_u32(void* mem_base, uint32_t address)
         /* In compressed mem base mode, select appropriate mem_base offset */
         mem_base = MEM_BASE_PTR(mem_base);
 
-        if (address < RDRAM_MAX_SIZE) {
+        if (address < RDRAM_16MB_SIZE) {
             mem = (uint32_t*)((uint8_t*)mem_base + (address - MM_RDRAM_DRAM + MB_RDRAM_DRAM));
         }
         else if (address >= MM_CART_ROM) {

--- a/src/device/memory/memory.h
+++ b/src/device/memory/memory.h
@@ -27,7 +27,9 @@
 
 #include "osal/preproc.h"
 
-enum { RDRAM_MAX_SIZE = 0x800000 };
+enum { RDRAM_16MB_SIZE = 0x1000000 };
+enum { RDRAM_8MB_SIZE = 0x800000 };
+enum { RDRAM_4MB_SIZE = 0x400000 };
 enum { CART_ROM_MAX_SIZE = 0x4000000 };
 enum { DD_ROM_MAX_SIZE = 0x400000 };
 

--- a/src/device/rdram/rdram.c
+++ b/src/device/rdram/rdram.c
@@ -138,7 +138,7 @@ void poweron_rdram(struct rdram* rdram)
     size_t module;
     size_t modules = get_modules_count(rdram);
     memset(rdram->regs, 0, RDRAM_MAX_MODULES_COUNT*RDRAM_REGS_COUNT*sizeof(uint32_t));
-    memset(rdram->dram, 0, rdram->dram_size);
+    memset(rdram->dram, 0, RDRAM_16MB_SIZE);
 
     DebugMessage(M64MSG_INFO, "Initializing %u RDRAM modules for a total of %u MB",
         modules, rdram->dram_size / (1024*1024));

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1311,8 +1311,7 @@ m64p_error main_run(void)
     else
         disable_extra_mem = ConfigGetParamInt(g_CoreConfig, "DisableExtraMem");
 
-
-    rdram_size = (disable_extra_mem == 0) ? 0x800000 : 0x400000;
+    rdram_size = (disable_extra_mem == 0) ? RDRAM_8MB_SIZE : RDRAM_4MB_SIZE;
 
     if (count_per_op <= 0)
         count_per_op = ROM_PARAMS.countperop;


### PR DESCRIPTION
Also, correctly check RDRAM size when saving and loading save states.

I think this will fix the crash that was reported here:

https://github.com/mupen64plus/mupen64plus-core/pull/606#issuecomment-458388545
