### PR TITLE
Build option to disable 64 Disk Drive support

### DIFF
--- a/README
+++ b/README
@@ -63,6 +63,7 @@ Type 'make' by itself to view all available build options:
      NO_ASM=1       == build without assembly (no dynamic recompiler or MMX/SSE code)
      USE_GLES=1     == build against GLESv2 instead of OpenGL
      VC=1           == build against Broadcom Videocore GLESv2
+     NO_64DD=1      == build without 64 Disk Drive support
      NEON=1         == (ARM only) build for hard floating point environments
      VFP_HARD=1     == (ARM only) full hardware floating point ABI
      SHAREDIR=path  == extra path to search for shared data files

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Type `make` by itself to view all available build options:
      NO_ASM=1       == build without assembly (no dynamic recompiler or MMX/SSE code)
      USE_GLES=1     == build against GLESv2 instead of OpenGL
      VC=1           == build against Broadcom Videocore GLESv2
+     NO_64DD=1      == build without 64 Disk Drive support
      NEON=1         == (ARM only) build for hard floating point environments
      VFP_HARD=1     == (ARM only) full hardware floating point ABI
      SHAREDIR=path  == extra path to search for shared data files

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -504,7 +504,6 @@ SOURCE = \
     $(SRCDIR)/device/controllers/paks/mempak.c \
     $(SRCDIR)/device/controllers/paks/rumblepak.c \
     $(SRCDIR)/device/controllers/paks/transferpak.c \
-    $(SRCDIR)/device/dd/dd_controller.c \
     $(SRCDIR)/device/device.c \
     $(SRCDIR)/device/gb/gb_cart.c \
     $(SRCDIR)/device/gb/mbc3_rtc.c \
@@ -547,6 +546,14 @@ SOURCE = \
     $(SRCDIR)/plugin/dummy_input.c \
     $(SRCDIR)/plugin/dummy_rsp.c \
     $(MINIZIP_SOURCE)
+
+# Include 64 Disk Drive support
+NO_64DD ?= 0
+ifeq ($(NO_64DD), 0)
+    SOURCE += $(SRCDIR)/device/dd/dd_controller.c
+else
+    CFLAGS += -DNO64DD
+endif
 
 # MD5 lib
 SOURCE += \

--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -190,6 +190,7 @@ typedef struct {
    */
   char* (*get_gb_cart_ram)(void* cb_data, int controller_num);
 
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
   /* Allow the frontend to specify the DD IPL ROM file to load
    * cb_data: points to frontend-defined callback data.
    * Returns a NULL-terminated string owned by the core specifying the DD IPL ROM filename to load
@@ -203,6 +204,7 @@ typedef struct {
    * Empty or NULL string results in no DD disk being loaded (eg. empty disk drive).
    */
   char* (*get_dd_disk)(void* cb_data);
+#endif /* build option to disable 64 Disk Drive support */
 } m64p_media_loader;
 
 /* ----------------------------------------- */

--- a/src/backends/file_storage.c
+++ b/src/backends/file_storage.c
@@ -26,7 +26,9 @@
 #include "api/callbacks.h"
 #include "api/m64p_types.h"
 #include "backends/api/storage_backend.h"
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 #include "device/dd/dd_controller.h"
+#endif /* build option to disable 64 Disk Drive support */
 #include "main/util.h"
 
 int open_file_storage(struct file_storage* fstorage, size_t size, const char* filename)
@@ -103,6 +105,7 @@ static void file_storage_parent_save(void* storage)
     file_storage_save(fstorage);
 }
 
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 static void file_storage_dd_sdk_dump_save(void* storage)
 {
     static uint8_t sdk_buffer[SDK_FORMAT_DUMP_SIZE];
@@ -131,7 +134,7 @@ static void file_storage_dd_sdk_dump_save(void* storage)
 
     free(filename);
 }
-
+#endif /* build option to disable 64 Disk Drive support */
 
 
 const struct storage_backend_interface g_ifile_storage =
@@ -156,9 +159,11 @@ const struct storage_backend_interface g_isubfile_storage =
     file_storage_parent_save
 };
 
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 const struct storage_backend_interface g_ifile_storage_dd_sdk_dump =
 {
     file_storage_data,
     file_storage_size,
     file_storage_dd_sdk_dump_save
 };
+#endif /* build option to disable 64 Disk Drive support */

--- a/src/backends/file_storage.h
+++ b/src/backends/file_storage.h
@@ -40,6 +40,8 @@ void close_file_storage(struct file_storage* storage);
 extern const struct storage_backend_interface g_ifile_storage;
 extern const struct storage_backend_interface g_ifile_storage_ro;
 extern const struct storage_backend_interface g_isubfile_storage;
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 extern const struct storage_backend_interface g_ifile_storage_dd_sdk_dump;
+#endif /* build option to disable 64 Disk Drive support */
 
 #endif

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -31,7 +31,9 @@
 #include "controllers/paks/mempak.h"
 #include "controllers/paks/rumblepak.h"
 #include "controllers/paks/transferpak.h"
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 #include "dd/dd_controller.h"
+#endif /* build option to disable 64 Disk Drive support */
 #include "gb/gb_cart.h"
 #include "memory/memory.h"
 #include "pif/pif.h"
@@ -70,10 +72,12 @@ enum { GAME_CONTROLLERS_COUNT = 4 };
 #define MM_SI_REGS          UINT32_C(0x04800000)
 
 #define MM_DOM2_ADDR1       UINT32_C(0x05000000)
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 #define MM_DD_C2S_BUFFER    UINT32_C(0x05000000)
 #define MM_DD_DS_BUFFER     UINT32_C(0x05000400)
 #define MM_DD_REGS          UINT32_C(0x05000500)
 #define MM_DD_MS_RAM        UINT32_C(0x05000580)
+#endif /* build option to disable 64 Disk Drive support */
 #define MM_DD_ROM           UINT32_C(0x06000000)
 
 #define MM_DOM2_ADDR2       UINT32_C(0x08000000)
@@ -107,8 +111,9 @@ struct device
     struct gb_cart gb_carts[GAME_CONTROLLERS_COUNT];
 
     struct cart cart;
-
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
     struct dd_controller dd;
+#endif /* build option to disable 64 Disk Drive support */
 };
 
 /* Setup device "static" properties.  */
@@ -138,11 +143,15 @@ void init_device(struct device* dev,
     void* eeprom_storage, const struct storage_backend_interface* ieeprom_storage,
     uint32_t flashram_type,
     void* flashram_storage, const struct storage_backend_interface* iflashram_storage,
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */   
+    void* sram_storage, const struct storage_backend_interface* isram_storage);
+#else
     void* sram_storage, const struct storage_backend_interface* isram_storage,
     /* dd */
     void* dd_rtc_clock, const struct clock_backend_interface* dd_rtc_iclock,
     size_t dd_rom_size,
     void* dd_disk, const struct storage_backend_interface* dd_idisk);
+#endif /* build option to disable 64 Disk Drive support */
 
 /* Setup device such that it's state is
  * what it should be after power on.

--- a/src/device/pif/cic.c
+++ b/src/device/pif/cic.c
@@ -45,8 +45,12 @@ void init_cic_using_ipl3(struct cic* cic, const void* ipl3)
         { "X103", CIC_X103, 0x78 },
         { "X105", CIC_X105, 0x91 },
         { "X106", CIC_X106, 0x85 },
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+        { "5167", CIC_5167, 0xdd }
+#else
         { "5167", CIC_5167, 0xdd },
         { "8303", CIC_8303, 0xdd }
+#endif /* build option to disable 64 Disk Drive support */
     };
 
     for (i = 0; i < 0xfc0/4; i++)
@@ -65,7 +69,9 @@ void init_cic_using_ipl3(struct cic* cic, const void* ipl3)
         case UINT64_C(0x000000D6D5BE5580): i = 5; break; /* CIC_X106 */
         case UINT64_C(0x000001053BC19870): i = 6; break; /* CIC 5167 */
         case UINT64_C(0x000000A5F80BF620): i = 0; break; /* CIC 5101 */
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
         case UINT64_C(0x000000D2E53EF008): i = 7; break; /* CIC 8303 */
+#endif /* build option to disable 64 Disk Drive support */
     }
 
     memcpy(cic, &cics[i], sizeof(*cic));

--- a/src/device/pif/cic.h
+++ b/src/device/pif/cic.h
@@ -30,8 +30,12 @@ enum cic_version
     CIC_X105,
     CIC_X106,
     CIC_5101,
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+    CIC_5167
+#else
     CIC_5167,
     CIC_8303
+#endif /* build option to disable 64 Disk Drive support */
 };
 
 struct cic

--- a/src/device/pif/pif.c
+++ b/src/device/pif/pif.c
@@ -146,7 +146,11 @@ void reset_pif(struct pif* pif, unsigned int reset_type)
     size_t i;
 
     /* HACK: for allowing pifbootrom execution */
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+    unsigned int rom_type = 0;
+#else
     unsigned int rom_type = (pif->cic.version == CIC_8303) ? 1 : 0;
+#endif /* build option to disable 64 Disk Drive support */
     unsigned int s7 = 0;
 
     /* 0:ColdReset, 1:NMI */

--- a/src/device/rcp/pi/pi_controller.h
+++ b/src/device/rcp/pi/pi_controller.h
@@ -27,8 +27,12 @@
 
 #include "osal/preproc.h"
 
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+struct device;
+#else
 struct cart;
 struct dd_controller;
+#endif /* build option to disable 64 Disk Drive support */
 struct mi_controller;
 struct ri_controller;
 struct rdp_core;
@@ -57,16 +61,23 @@ struct pi_dma_handler
     unsigned int (*dma_write)(void* opaque, uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
 };
 
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+typedef void (*pi_dma_handler_getter)(struct device* dev, uint32_t address, void** opaque, const struct pi_dma_handler** handler);
+#else
 typedef void (*pi_dma_handler_getter)(struct cart* cart, struct dd_controller* dd, uint32_t address, void** opaque, const struct pi_dma_handler** handler);
+#endif /* build option to disable 64 Disk Drive support */
 
 struct pi_controller
 {
     uint32_t regs[PI_REGS_COUNT];
 
     pi_dma_handler_getter get_pi_dma_handler;
-
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+    struct device* dev;
+#else
     struct cart* cart;
     struct dd_controller* dd;
+#endif /* build option to disable 64 Disk Drive support */
     struct mi_controller* mi;
     struct ri_controller* ri;
     struct rdp_core* dp;
@@ -80,9 +91,13 @@ static osal_inline uint32_t pi_reg(uint32_t address)
 
 
 void init_pi(struct pi_controller* pi,
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+             struct device* dev, pi_dma_handler_getter get_pi_dma_handler,
+#else
              pi_dma_handler_getter get_pi_dma_handler,
              struct cart* cart,
              struct dd_controller* dd,
+#endif /* build option to disable 64 Disk Drive support */
              struct mi_controller* mi,
              struct ri_controller* ri,
              struct rdp_core* dp);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -996,6 +996,7 @@ static void open_eep_file(struct file_storage* fstorage)
     }
 }
 
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 static void load_dd_rom(uint8_t* rom, size_t* rom_size)
 {
     /* ask the core loader for DD disk filename */
@@ -1126,7 +1127,7 @@ no_disk:
     free(dd_disk_filename);
     *dd_idisk = NULL;
 }
-
+#endif /* build option to disable 64 Disk Drive support */
 
 struct gb_cart_data
 {
@@ -1280,8 +1281,10 @@ m64p_error main_run(void)
     struct file_storage eep;
     struct file_storage fla;
     struct file_storage sra;
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
     size_t dd_rom_size;
     struct file_storage dd_disk;
+#endif /* build option to disable 64 Disk Drive support */
 
     int control_ids[GAME_CONTROLLERS_COUNT];
     struct controller_input_compat cin_compats[GAME_CONTROLLERS_COUNT];
@@ -1380,6 +1383,7 @@ m64p_error main_run(void)
     open_fla_file(&fla);
     open_sra_file(&sra);
 
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
     /* Load 64DD IPL ROM and Disk */
     const struct clock_backend_interface* dd_rtc_iclock = NULL;
     const struct storage_backend_interface* dd_idisk = NULL;
@@ -1390,6 +1394,7 @@ m64p_error main_run(void)
         dd_rtc_iclock = &g_iclock_ctime_plus_delta;
         load_dd_disk(&dd_disk, &dd_idisk);
     }
+#endif /* build option to disable 64 Disk Drive support */
 
     /* setup pif channel devices */
     void* joybus_devices[PIF_CHANNELS_COUNT];
@@ -1543,10 +1548,14 @@ m64p_error main_run(void)
                 &eep, &g_ifile_storage,
                 flashram_type,
                 &fla, &g_ifile_storage,
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+                &sra, &g_ifile_storage);
+#else
                 &sra, &g_ifile_storage,
                 NULL, dd_rtc_iclock,
                 dd_rom_size,
                 &dd_disk, dd_idisk);
+#endif /* build option to disable 64 Disk Drive support */
 
     // Attach rom to plugins
     if (!gfx.romOpen())
@@ -1620,7 +1629,9 @@ m64p_error main_run(void)
     close_file_storage(&fla);
     close_file_storage(&eep);
     close_file_storage(&mpk);
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
     close_file_storage(&dd_disk);
+#endif /* build option to disable 64 Disk Drive support */
 
     if (ConfigGetParamBool(g_CoreConfig, "OnScreenDisplay"))
     {
@@ -1659,7 +1670,9 @@ on_gfx_open_failure:
     close_file_storage(&fla);
     close_file_storage(&eep);
     close_file_storage(&mpk);
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
     close_file_storage(&dd_disk);
+#endif /* build option to disable 64 Disk Drive support */
 
     return M64ERR_PLUGIN_FAIL;
 }

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -54,7 +54,9 @@
 enum { GB_CART_FINGERPRINT_SIZE = 0x1c };
 enum { GB_CART_FINGERPRINT_OFFSET = 0x134 };
 
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 enum { DD_DISK_ID_OFFSET = 0x43670 };
+#endif /* build option to disable 64 Disk Drive support */
 
 static const char* savestate_magic = "M64+SAVE";
 static const int savestate_latest_version = 0x00010500;  /* 1.5 */
@@ -783,7 +785,7 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
             dev->rdram.regs[i][RDRAM_ADDR_SELECT_REG]  = GETDATA(curr, uint32_t);
             dev->rdram.regs[i][RDRAM_DEVICE_MANUF_REG] = GETDATA(curr, uint32_t);
         }
-
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
         if (version >= 0x00010400) {
             /* verify if DD data is present (and matches what's currently loaded) */
             uint32_t disk_id = GETDATA(curr, uint32_t);
@@ -830,7 +832,7 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
                 curr += (3+DD_ASIC_REGS_COUNT)*sizeof(uint32_t) + 0x100 + 0x40 + 2*sizeof(int64_t) + 2*sizeof(unsigned int);
             }
         }
-
+#endif /* build option to disable 64 Disk Drive support */
         if (version >= 0x00010500)
         {
 #ifdef NEW_DYNAREC
@@ -896,11 +898,12 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
             memcpy(dev->rdram.regs[i], dev->rdram.regs[0], RDRAM_REGS_COUNT*sizeof(dev->rdram.regs[0][0]));
             dev->rdram.regs[i][RDRAM_DEVICE_ID_REG] = ri_address_to_id_field(i * 0x200000) << 2;
         }
-
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
         /* dd state */
         if (dev->dd.rom_size > 0 && dev->dd.idisk != NULL) {
             poweron_dd(&dev->dd);
         }
+#endif /* build option to disable 64 Disk Drive support */
     }
 
     /* Zilmar-Spec plugin expect a call with control_id = -1 when RAM processing is done */
@@ -1251,12 +1254,12 @@ static int savestates_load_pj64(struct device* dev,
         memcpy(dev->rdram.regs[i], dev->rdram.regs[0], RDRAM_REGS_COUNT*sizeof(dev->rdram.regs[0][0]));
         dev->rdram.regs[i][RDRAM_DEVICE_ID_REG] = ri_address_to_id_field(i * 0x200000) << 2;
     }
-
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
     /* dd state */
     if (dev->dd.rom_size > 0 && dev->dd.idisk != NULL) {
         poweron_dd(&dev->dd);
     }
-
+#endif /* build option to disable 64 Disk Drive support */
     savestates_load_set_pc(&dev->r4300, *r4300_cp0_last_addr(&dev->r4300.cp0));
 
     // assert(savestateData+savestateSize == curr)
@@ -1809,7 +1812,7 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
         PUTDATA(curr, uint32_t, dev->rdram.regs[i][RDRAM_ADDR_SELECT_REG]);
         PUTDATA(curr, uint32_t, dev->rdram.regs[i][RDRAM_DEVICE_MANUF_REG]);
     }
-
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
     uint32_t* disk_id = ((dev->dd.rom_size > 0) && dev->dd.idisk != NULL)
         ? (uint32_t*)(dev->dd.idisk->data(dev->dd.disk) + DD_DISK_ID_OFFSET)
         : NULL;
@@ -1852,7 +1855,7 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
         PUTDATA(curr, uint32_t, dev->dd.bm_zone);
         PUTDATA(curr, uint32_t, dev->dd.bm_track_offset);
     }
-
+#endif /* build option to disable 64 Disk Drive support */
 #ifdef NEW_DYNAREC
     PUTDATA(curr, uint32_t, stop_after_jal);
 #else

--- a/src/plugin/plugin.c
+++ b/src/plugin/plugin.c
@@ -22,7 +22,9 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
 #include <string.h>
+#endif /* build option to disable 64 Disk Drive support */
 
 #include "api/callbacks.h"
 #include "api/m64p_common.h"
@@ -228,6 +230,7 @@ static m64p_error plugin_connect_gfx(m64p_dynlib_handle plugin_handle)
 
 static m64p_error plugin_start_gfx(void)
 {
+#if !defined(NO64DD) /* build option to disable 64 Disk Drive support */
     uint8_t media = *((uint8_t*)mem_base_u32(g_mem_base, MM_CART_ROM) + (0x3b ^ S8));
 
     /* Here we feed 64DD IPL ROM header to GFX plugin if 64DD is present.
@@ -244,9 +247,14 @@ static m64p_error plugin_start_gfx(void)
         : MM_CART_ROM;
 
     free(dd_ipl_rom_filename);
+#endif /* build option to disable 64 Disk Drive support */
 
     /* fill in the GFX_INFO data structure */
+#if defined(NO64DD) /* build option to disable 64 Disk Drive support */
+    gfx_info.HEADER = (unsigned char *)mem_base_u32(g_mem_base, MM_CART_ROM);
+#else
     gfx_info.HEADER = (unsigned char *)mem_base_u32(g_mem_base, rom_base);
+#endif /* build option to disable 64 Disk Drive support */
     gfx_info.RDRAM = (unsigned char *)mem_base_u32(g_mem_base, MM_RDRAM_DRAM);
     gfx_info.DMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM);
     gfx_info.IMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM + 0x1000);


### PR DESCRIPTION
There is a longstanding [issue](https://github.com/mupen64plus/mupen64plus-core/issues/577)  since the addition of the 64 Disk Drive support.  This is causing some ARM devices to segfault at emulator start.

This commit adds a build option `64DISKDRIVE`.
It defaults to `64DISKDRIVE=1` as I expect most devices are unaffected.
Those platforms vulnerable to it can use `64DISKDRIVE=0`.

Many Thanks