### PR TITLE
fix hard reset: reassign r4300_pc_struct after poweron call

### DIFF
--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -488,6 +488,7 @@ void reset_hard_handler(void* opaque)
     *r4300_cp0_next_interrupt(&r4300->cp0) = 624999;
     init_interrupt(&r4300->cp0);
     invalidate_r4300_cached_code(r4300, 0, 0);
+    *r4300_pc_struct(r4300) = &r4300->interp_PC;
     generic_jump_to(r4300, r4300->cp0.last_addr);
 }
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -488,8 +488,9 @@ void reset_hard_handler(void* opaque)
     *r4300_cp0_next_interrupt(&r4300->cp0) = 624999;
     init_interrupt(&r4300->cp0);
     invalidate_r4300_cached_code(r4300, 0, 0);
-    *r4300_pc_struct(r4300) = &r4300->interp_PC;
     generic_jump_to(r4300, r4300->cp0.last_addr);
+
+    run_device(r4300);
 }
 
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -488,9 +488,12 @@ void reset_hard_handler(void* opaque)
     *r4300_cp0_next_interrupt(&r4300->cp0) = 624999;
     init_interrupt(&r4300->cp0);
     invalidate_r4300_cached_code(r4300, 0, 0);
+    *r4300_pc_struct(r4300) = &r4300->interp_PC;
+#ifdef NEW_DYNAREC
+    new_dynarec_cleanup();
+    new_dynarec_init();
+#endif
     generic_jump_to(r4300, r4300->cp0.last_addr);
-
-    run_device(r4300);
 }
 
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -490,8 +490,11 @@ void reset_hard_handler(void* opaque)
     invalidate_r4300_cached_code(r4300, 0, 0);
     *r4300_pc_struct(r4300) = &r4300->interp_PC;
 #ifdef NEW_DYNAREC
-    new_dynarec_cleanup();
-    new_dynarec_init();
+    if(r4300->emumode >= 2)
+    {
+        new_dynarec_cleanup();
+        new_dynarec_init();
+    }
 #endif
     generic_jump_to(r4300, r4300->cp0.last_addr);
 }


### PR DESCRIPTION
Fixes trying to assign to a null pointer on hard reset
Should fix #639
