### PR TITLE
MPAL's refresh rate is 60 Hz

### DIFF
--- a/src/device/rcp/vi/vi_controller.c
+++ b/src/device/rcp/vi/vi_controller.c
@@ -49,10 +49,9 @@ unsigned int vi_expected_refresh_rate_from_tv_standard(m64p_system_type tv_stand
     switch (tv_standard)
     {
     case SYSTEM_PAL:
-    case SYSTEM_MPAL:
         return 50;
-
     case SYSTEM_NTSC:
+    case SYSTEM_MPAL:
     default:
         return 60;
     }


### PR DESCRIPTION
See: https://en.wikipedia.org/wiki/PAL-M

>It is unique among analog TV systems in that it combines the 525-line 30 frames-per-second System M with the PAL colour encoding system (using very nearly the NTSC colour subcarrier frequency), unlike all other countries which pair PAL with 625-line systems and NTSC with 525-line systems.