### PR TITLE
Allow carts of up to 244 MB

### DIFF
--- a/src/device/cart/cart_rom.c
+++ b/src/device/cart/cart_rom.c
@@ -31,7 +31,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define CART_ROM_ADDR_MASK UINT32_C(0x03ffffff);
+#define CART_ROM_ADDR_MASK UINT32_C(0x0effffff);
 
 
 void init_cart_rom(struct cart_rom* cart_rom,

--- a/src/device/cart/cart_rom.h
+++ b/src/device/cart/cart_rom.h
@@ -42,7 +42,7 @@ struct cart_rom
 
 static osal_inline uint32_t rom_address(uint32_t address)
 {
-    return (address & 0x03fffffc);
+    return (address & 0x0efffffc);
 }
 
 void init_cart_rom(struct cart_rom* cart_rom,


### PR DESCRIPTION
From some discord conversations, some ROMs that are greater than 64MB are causing the core to crash. These ROMs run on the real console, so it's definitely an issue in the core. Making the below two changes allows these ROMs to run with no perceived issues. From discord conversations, the maximum allowed ROM is 244 MB.

Also, searching through the code, there are a number of other places where 0x3FFFFFF is being used as a mask. It's hard to tell how many of these places refer to ROM address offsets. So this change may allow data to be stored past 64MB, but game code past that point may still have issues.