### PR TITLE
Fix VI interrupt not being called in certain cases

### DIFF
--- a/src/device/rcp/vi/vi_controller.h
+++ b/src/device/rcp/vi/vi_controller.h
@@ -71,6 +71,7 @@ static osal_inline uint32_t vi_reg(uint32_t address)
 
 unsigned int vi_clock_from_tv_standard(m64p_system_type tv_standard);
 unsigned int vi_expected_refresh_rate_from_tv_standard(m64p_system_type tv_standard);
+void set_vi_vertical_interrupt(struct vi_controller* vi);
 
 void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected_refresh_rate,
              struct mi_controller* mi, struct rdp_core* dp);


### PR DESCRIPTION
Not sure if this affects any commercial roms, but it at least enables certain homebrew roms to display something (like some of [these test roms](https://github.com/PeterLemon/N64))