### PR TITLE
if config parameter already exists, add help text if missing, before returning successfully

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -1242,10 +1242,14 @@ EXPORT m64p_error CALL ConfigSetDefaultInt(m64p_handle ConfigSectionHandle, cons
     if (section->magic != SECTION_MAGIC)
         return M64ERR_INPUT_INVALID;
 
-    /* if this parameter already exists, then just return successfully */
+    /* if this parameter already exists, add help text if missing, then return successfully */
     var = find_section_var(section, ParamName);
     if (var != NULL)
+    {
+        if (ParamHelp != NULL && var->comment == NULL)
+            var->comment = strdup(ParamHelp);
         return M64ERR_SUCCESS;
+    }
 
     /* otherwise create a new config_var object and add it to this section */
     var = config_var_create(ParamName, ParamHelp);
@@ -1273,10 +1277,14 @@ EXPORT m64p_error CALL ConfigSetDefaultFloat(m64p_handle ConfigSectionHandle, co
     if (section->magic != SECTION_MAGIC)
         return M64ERR_INPUT_INVALID;
 
-    /* if this parameter already exists, then just return successfully */
+    /* if this parameter already exists, add help text if missing, then return successfully */
     var = find_section_var(section, ParamName);
     if (var != NULL)
+    {
+        if (ParamHelp != NULL && var->comment == NULL)
+            var->comment = strdup(ParamHelp);
         return M64ERR_SUCCESS;
+    }
 
     /* otherwise create a new config_var object and add it to this section */
     var = config_var_create(ParamName, ParamHelp);
@@ -1304,10 +1312,14 @@ EXPORT m64p_error CALL ConfigSetDefaultBool(m64p_handle ConfigSectionHandle, con
     if (section->magic != SECTION_MAGIC)
         return M64ERR_INPUT_INVALID;
 
-    /* if this parameter already exists, then just return successfully */
+    /* if this parameter already exists, add help text if missing, then return successfully */
     var = find_section_var(section, ParamName);
     if (var != NULL)
+    {
+        if (ParamHelp != NULL && var->comment == NULL)
+            var->comment = strdup(ParamHelp);
         return M64ERR_SUCCESS;
+    }
 
     /* otherwise create a new config_var object and add it to this section */
     var = config_var_create(ParamName, ParamHelp);
@@ -1335,10 +1347,14 @@ EXPORT m64p_error CALL ConfigSetDefaultString(m64p_handle ConfigSectionHandle, c
     if (section->magic != SECTION_MAGIC)
         return M64ERR_INPUT_INVALID;
 
-    /* if this parameter already exists, then just return successfully */
+    /* if this parameter already exists, add help text if missing, then return successfully */
     var = find_section_var(section, ParamName);
     if (var != NULL)
+    {
+        if (ParamHelp != NULL && var->comment == NULL)
+            var->comment = strdup(ParamHelp);
         return M64ERR_SUCCESS;
+    }
 
     /* otherwise create a new config_var object and add it to this section */
     var = config_var_create(ParamName, ParamHelp);


### PR DESCRIPTION
This keeps the mupen64plus.cfg config file documented when setting the defaults.

Useful for Retropie (and similar) that has a scripted install for mupen64plus, setting a bunch of defaults. Since config help text does not get populated until the first time mupen64plus is run successfully, it led to these defaults being forever undocumented in the .cfg.