### PR TITLE
Don't set DPC_STATUS_START/END_VALID bits

### DIFF
--- a/src/device/rcp/rdp/rdp_core.c
+++ b/src/device/rcp/rdp/rdp_core.c
@@ -112,10 +112,8 @@ void write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mas
     {
     case DPC_START_REG:
         dp->dpc_regs[DPC_CURRENT_REG] = dp->dpc_regs[DPC_START_REG];
-        dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_START_VALID;
         break;
     case DPC_END_REG:
-        dp->dpc_regs[DPC_STATUS_REG] |= DPC_STATUS_END_VALID;
         gfx.processRDPList();
         signal_rcp_interrupt(dp->mi, MI_INTR_DP);
         break;


### PR DESCRIPTION
As noted here:
https://github.com/libretro/mupen64plus-libretro-nx/commit/8c87b431e0fe447d7bf2e3666623ee1e57ca80f3

DPC_STATUS_START_VALID and DPC_STATUS_END_VALID are never cleared, causing problems with some LLE RSP plugins