### PR TITLE
Revert "Don't call SDL_PumpEvents() in core"

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -256,6 +256,7 @@ static void main_check_inputs(void)
 #ifdef WITH_LIRC
     lircCheckInput();
 #endif
+    SDL_PumpEvents();
 }
 
 /*********************************************************************************************************


### PR DESCRIPTION
This caused more problems than it solved, and it sounds like mupen64plus-ae has stubbed out SDL anyway

This reverts commit 87b1946868472d739a58eca69261634970e8537a.

https://github.com/mupen64plus/mupen64plus-core/pull/550