### PR TITLE
Remove special_int (DO NOT MERGE)

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -115,7 +115,6 @@ void init_device(struct device* dev,
         { &dev->r4300,     check_int_handler           }, /* CHECK */
         { &dev->si,        si_end_of_dma_event         }, /* SI */
         { &dev->pi,        pi_end_of_dma_event         }, /* PI */
-        { &dev->r4300.cp0, special_int_handler         }, /* SPECIAL */
         { &dev->ai,        ai_end_of_dma_event         }, /* AI */
         { &dev->sp,        rsp_interrupt_event         }, /* SP */
         { &dev->dp,        rdp_interrupt_event         }, /* DP */

--- a/src/device/r4300/cached_interp.c
+++ b/src/device/r4300/cached_interp.c
@@ -67,6 +67,7 @@
 void cached_interp_##name(void) \
 { \
     DECLARE_R4300 \
+    uint64_t* cp0_count = r4300_cp0_get_count(&r4300->cp0); \
     const int take_jump = (condition); \
     const uint32_t jump_target = (destination); \
     int64_t *link_register = (link); \
@@ -94,12 +95,13 @@ void cached_interp_##name(void) \
         cp0_update_count(r4300); \
     } \
     r4300->cp0.last_addr = *r4300_pc(r4300); \
-    if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(r4300); \
+    if (*r4300_cp0_next_interrupt(&r4300->cp0) <= *cp0_count) gen_interrupt(r4300); \
 } \
  \
 void cached_interp_##name##_OUT(void) \
 { \
     DECLARE_R4300 \
+    uint64_t* cp0_count = r4300_cp0_get_count(&r4300->cp0); \
     const int take_jump = (condition); \
     const uint32_t jump_target = (destination); \
     int64_t *link_register = (link); \
@@ -127,21 +129,21 @@ void cached_interp_##name##_OUT(void) \
         cp0_update_count(r4300); \
     } \
     r4300->cp0.last_addr = *r4300_pc(r4300); \
-    if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(r4300); \
+    if (*r4300_cp0_next_interrupt(&r4300->cp0) <= *cp0_count) gen_interrupt(r4300); \
 } \
   \
 void cached_interp_##name##_IDLE(void) \
 { \
     DECLARE_R4300 \
-    uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0); \
+    uint64_t* cp0_count = r4300_cp0_get_count(&r4300->cp0); \
     const int take_jump = (condition); \
     int skip; \
     if (cop1 && check_cop1_unusable(r4300)) return; \
     if (take_jump) \
     { \
         cp0_update_count(r4300); \
-        skip = *r4300_cp0_next_interrupt(&r4300->cp0) - cp0_regs[CP0_COUNT_REG]; \
-        if (skip > 3) cp0_regs[CP0_COUNT_REG] += (skip & UINT32_C(0xFFFFFFFC)); \
+        skip = *r4300_cp0_next_interrupt(&r4300->cp0) - *cp0_count; \
+        if (skip > 3) *cp0_count += (skip & UINT32_C(0xFFFFFFFC)); \
         else cached_interp_##name(); \
     } \
     else cached_interp_##name(); \

--- a/src/device/r4300/cp0.c
+++ b/src/device/r4300/cp0.c
@@ -49,7 +49,7 @@ void init_cp0(struct cp0* cp0, unsigned int count_per_op, struct new_dynarec_hot
 void poweron_cp0(struct cp0* cp0)
 {
     uint32_t* cp0_regs;
-    unsigned int* cp0_next_interrupt;
+    uint64_t* cp0_next_interrupt;
 
     cp0_regs = r4300_cp0_regs(cp0);
     cp0_next_interrupt = r4300_cp0_next_interrupt(cp0);
@@ -69,7 +69,7 @@ void poweron_cp0(struct cp0* cp0)
     /* XXX: clarify what is done on poweron, in soft_reset and in execute... */
     cp0->interrupt_unsafe_state = 0;
     *cp0_next_interrupt = 0;
-    cp0->special_done = 0;
+    cp0->count = cp0_regs[CP0_COUNT_REG];
     cp0->last_addr = UINT32_C(0xbfc00000);
 
     init_interrupt(cp0);
@@ -93,7 +93,7 @@ uint32_t* r4300_cp0_last_addr(struct cp0* cp0)
     return &cp0->last_addr;
 }
 
-unsigned int* r4300_cp0_next_interrupt(struct cp0* cp0)
+uint64_t* r4300_cp0_next_interrupt(struct cp0* cp0)
 {
 #ifndef NEW_DYNAREC
     return &cp0->next_interrupt;
@@ -103,6 +103,10 @@ unsigned int* r4300_cp0_next_interrupt(struct cp0* cp0)
 #endif
 }
 
+uint64_t* r4300_cp0_get_count(struct cp0* cp0)
+{
+    return &cp0->count;
+}
 
 int check_cop1_unusable(struct r4300_core* r4300)
 {
@@ -121,12 +125,14 @@ void cp0_update_count(struct r4300_core* r4300)
 {
     struct cp0* cp0 = &r4300->cp0;
     uint32_t* cp0_regs = r4300_cp0_regs(cp0);
+    uint64_t* cp0_count = r4300_cp0_get_count(cp0);
 
 #ifdef NEW_DYNAREC
     if (r4300->emumode != EMUMODE_DYNAREC)
     {
 #endif
-        cp0_regs[CP0_COUNT_REG] += ((*r4300_pc(r4300) - cp0->last_addr) >> 2) * cp0->count_per_op;
+        *cp0_count += ((*r4300_pc(r4300) - cp0->last_addr) >> 2) * cp0->count_per_op;
+        cp0_regs[CP0_COUNT_REG] = *cp0_count & UINT64_C(0xFFFFFFFF);
         cp0->last_addr = *r4300_pc(r4300);
 #ifdef NEW_DYNAREC
     }

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -138,7 +138,7 @@ enum { INTERRUPT_NODES_POOL_CAPACITY = 16 };
 struct interrupt_event
 {
     int type;
-    unsigned int count;
+    uint64_t count;
 };
 
 struct node
@@ -166,7 +166,7 @@ struct interrupt_handler
     void (*callback)(void*);
 };
 
-enum { CP0_INTERRUPT_HANDLERS_COUNT = 12 };
+enum { CP0_INTERRUPT_HANDLERS_COUNT = 11 };
 
 enum {
     INTR_UNSAFE_R4300 = 0x01,
@@ -187,7 +187,7 @@ struct cp0
     struct interrupt_queue q;
 #ifndef NEW_DYNAREC
 	/* New dynarec uses a different memory layout */
-    unsigned int next_interrupt;
+    uint64_t next_interrupt;
 #endif
 
     struct interrupt_handler interrupt_handlers[CP0_INTERRUPT_HANDLERS_COUNT];
@@ -197,10 +197,9 @@ struct cp0
     struct new_dynarec_hot_state* new_dynarec_hot_state;
 #endif
 
-    int special_done;
-
     uint32_t last_addr;
     unsigned int count_per_op;
+    uint64_t count;
 
     struct tlb tlb;
 };
@@ -220,7 +219,8 @@ void poweron_cp0(struct cp0* cp0);
 
 uint32_t* r4300_cp0_regs(struct cp0* cp0);
 uint32_t* r4300_cp0_last_addr(struct cp0* cp0);
-unsigned int* r4300_cp0_next_interrupt(struct cp0* cp0);
+uint64_t* r4300_cp0_next_interrupt(struct cp0* cp0);
+uint64_t* r4300_cp0_get_count(struct cp0* cp0);
 
 int check_cop1_unusable(struct r4300_core* r4300);
 

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -37,9 +37,9 @@ void r4300_check_interrupt(struct r4300_core* r4300, uint32_t cause_ip, int set_
 
 void translate_event_queue(struct cp0* cp0, unsigned int base);
 void remove_event(struct interrupt_queue* q, int type);
-void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count);
+void add_interrupt_event_count(struct cp0* cp0, int type, uint64_t count);
 void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);
-unsigned int get_event(const struct interrupt_queue* q, int type);
+uint64_t get_event(const struct interrupt_queue* q, int type);
 int get_next_event_type(const struct interrupt_queue* q);
 unsigned int add_random_interrupt_time(struct r4300_core* r4300);
 void remove_interrupt_event(struct cp0* cp0);
@@ -51,7 +51,6 @@ void reset_hard_handler(void* opaque);
 
 void compare_int_handler(void* opaque);
 void check_int_handler(void* opaque);
-void special_int_handler(void* opaque);
 void nmi_int_handler(void* opaque);
 
 #define VI_INT      0x001

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -933,7 +933,8 @@ DECLARE_INSTRUCTION(ERET)
 {
     DECLARE_R4300
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
-    unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
+    uint64_t* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
+    uint64_t* cp0_count = r4300_cp0_get_count(&r4300->cp0);
 
     cp0_update_count(r4300);
     if (cp0_regs[CP0_STATUS_REG] & CP0_STATUS_ERL)
@@ -949,7 +950,7 @@ DECLARE_INSTRUCTION(ERET)
     r4300->llbit = 0;
     r4300_check_interrupt(r4300, CP0_CAUSE_IP2, r4300->mi->regs[MI_INTR_REG] & r4300->mi->regs[MI_INTR_MASK_REG]); // ???
     r4300->cp0.last_addr = PCADDR;
-    if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
+    if (*cp0_next_interrupt <= *cp0_count) { gen_interrupt(r4300); }
 }
 
 DECLARE_INSTRUCTION(SYNC)
@@ -1180,7 +1181,8 @@ DECLARE_INSTRUCTION(MTC0)
 {
     DECLARE_R4300
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
-    unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
+    uint64_t* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
+    uint64_t* cp0_count = r4300_cp0_get_count(&r4300->cp0);
 
     switch(rfs)
     {
@@ -1216,7 +1218,7 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_COUNT_REG:
         cp0_update_count(r4300);
         r4300->cp0.interrupt_unsafe_state |= INTR_UNSAFE_R4300;
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
+        if (*cp0_next_interrupt <= *cp0_count) { gen_interrupt(r4300); }
         r4300->cp0.interrupt_unsafe_state &= ~INTR_UNSAFE_R4300;
         translate_event_queue(&r4300->cp0, rrt32);
         cp0_regs[CP0_COUNT_REG] = rrt32;
@@ -1227,7 +1229,10 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_COMPARE_REG:
         cp0_update_count(r4300);
         remove_event(&r4300->cp0.q, COMPARE_INT);
-        add_interrupt_event_count(&r4300->cp0, COMPARE_INT, rrt32);
+        uint32_t delay = rrt32 - (cp0_regs[CP0_COUNT_REG] + r4300->cp0.count_per_op);
+        *cp0_count += r4300->cp0.count_per_op;
+        add_interrupt_event(&r4300->cp0, COMPARE_INT, delay);
+        *cp0_count -= r4300->cp0.count_per_op;
         cp0_regs[CP0_COMPARE_REG] = rrt32;
         cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_IP7;
         break;
@@ -1240,7 +1245,7 @@ DECLARE_INSTRUCTION(MTC0)
         ADD_TO_PC(1);
         r4300_check_interrupt(r4300, CP0_CAUSE_IP2, r4300->mi->regs[MI_INTR_REG] & r4300->mi->regs[MI_INTR_MASK_REG]); // ???
         r4300->cp0.interrupt_unsafe_state |= INTR_UNSAFE_R4300;
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
+        if (*cp0_next_interrupt <= *cp0_count) { gen_interrupt(r4300); }
         r4300->cp0.interrupt_unsafe_state &= ~INTR_UNSAFE_R4300;
         ADD_TO_PC(-1);
         break;

--- a/src/device/r4300/new_dynarec/new_dynarec.h
+++ b/src/device/r4300/new_dynarec/new_dynarec.h
@@ -52,7 +52,7 @@ struct new_dynarec_hot_state
 #else
     uint32_t dynarec_local[16];
 #endif
-    unsigned int next_interrupt;
+    uint64_t next_interrupt;
     int cycle_count;
     int pending_exception;
     int pcaddr;

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -46,6 +46,7 @@ static void InterpretOpcode(struct r4300_core* r4300);
 #define DECLARE_JUMP(name, destination, condition, link, likely, cop1) \
    static void name(struct r4300_core* r4300, uint32_t op) \
    { \
+      uint64_t* cp0_count = r4300_cp0_get_count(&r4300->cp0); \
       const int take_jump = (condition); \
       const uint32_t jump_target = (destination); \
       int64_t *link_register = (link); \
@@ -72,19 +73,19 @@ static void InterpretOpcode(struct r4300_core* r4300);
          cp0_update_count(r4300); \
       } \
       r4300->cp0.last_addr = r4300->interp_PC.addr; \
-      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(r4300); \
+      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= *cp0_count) gen_interrupt(r4300); \
    } \
    static void name##_IDLE(struct r4300_core* r4300, uint32_t op) \
    { \
-      uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0); \
+      uint64_t* cp0_count = r4300_cp0_get_count(&r4300->cp0); \
       const int take_jump = (condition); \
       int skip; \
       if (cop1 && check_cop1_unusable(r4300)) return; \
       if (take_jump) \
       { \
          cp0_update_count(r4300); \
-         skip = *r4300_cp0_next_interrupt(&r4300->cp0) - cp0_regs[CP0_COUNT_REG]; \
-         if (skip > 3) cp0_regs[CP0_COUNT_REG] += (skip & UINT32_C(0xFFFFFFFC)); \
+         skip = *r4300_cp0_next_interrupt(&r4300->cp0) - *cp0_count; \
+         if (skip > 3) *cp0_count += (skip & UINT32_C(0xFFFFFFFC)); \
          else name(r4300, op); \
       } \
       else name(r4300, op); \

--- a/src/device/rcp/ai/ai_controller.c
+++ b/src/device/rcp/ai/ai_controller.c
@@ -38,9 +38,9 @@
 
 static uint32_t get_remaining_dma_length(struct ai_controller* ai)
 {
-    unsigned int next_ai_event;
-    unsigned int remaining_dma_duration;
-    const uint32_t* cp0_regs;
+    uint64_t next_ai_event;
+    uint64_t remaining_dma_duration;
+    const uint64_t* cp0_count = r4300_cp0_get_count(&ai->mi->r4300->cp0);
 
     if (ai->fifo[0].duration == 0)
         return 0;
@@ -50,13 +50,12 @@ static uint32_t get_remaining_dma_length(struct ai_controller* ai)
     if (next_ai_event == 0)
         return 0;
 
-    cp0_regs = r4300_cp0_regs(&ai->mi->r4300->cp0);
-    if (next_ai_event <= cp0_regs[CP0_COUNT_REG])
+    if (next_ai_event <= *cp0_count)
         return 0;
 
-    remaining_dma_duration = next_ai_event - cp0_regs[CP0_COUNT_REG];
+    remaining_dma_duration = next_ai_event - *cp0_count;
 
-    uint64_t dma_length = (uint64_t)remaining_dma_duration * ai->fifo[0].length / ai->fifo[0].duration;
+    uint64_t dma_length = remaining_dma_duration * ai->fifo[0].length / ai->fifo[0].duration;
     return dma_length&~7;
 }
 

--- a/src/device/rcp/mi/mi_controller.c
+++ b/src/device/rcp/mi/mi_controller.c
@@ -91,8 +91,8 @@ void write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
     struct mi_controller* mi = (struct mi_controller*)opaque;
     uint32_t reg = mi_reg(address);
 
-    uint32_t* cp0_regs = r4300_cp0_regs(&mi->r4300->cp0);
-    unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&mi->r4300->cp0);
+    uint64_t* cp0_next_interrupt = r4300_cp0_next_interrupt(&mi->r4300->cp0);
+    uint64_t* cp0_count = r4300_cp0_get_count(&mi->r4300->cp0);
 
     switch(reg)
     {
@@ -107,7 +107,7 @@ void write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 
         r4300_check_interrupt(mi->r4300, CP0_CAUSE_IP2, mi->regs[MI_INTR_REG] & mi->regs[MI_INTR_MASK_REG]);
         cp0_update_count(mi->r4300);
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt(mi->r4300);
+        if (*cp0_next_interrupt <= *cp0_count) gen_interrupt(mi->r4300);
         break;
     }
 }

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -57,7 +57,7 @@ enum { GB_CART_FINGERPRINT_OFFSET = 0x134 };
 enum { DD_DISK_ID_OFFSET = 0x43670 };
 
 static const char* savestate_magic = "M64+SAVE";
-static const int savestate_latest_version = 0x00010500;  /* 1.5 */
+static const int savestate_latest_version = 0x00010600;  /* 1.6 */
 static const unsigned char pj64_magic[4] = { 0xC8, 0xA6, 0xD8, 0x23 };
 
 static savestates_job job = savestates_job_nothing;
@@ -435,6 +435,7 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
     *r4300_llbit(&dev->r4300) = GETDATA(curr, uint32_t);
     COPYARRAY(r4300_regs(&dev->r4300), curr, int64_t, 32);
     COPYARRAY(cp0_regs, curr, uint32_t, CP0_REGS_COUNT);
+    *r4300_cp0_get_count(&dev->r4300.cp0) = cp0_regs[CP0_COUNT_REG];
     *r4300_mult_lo(&dev->r4300) = GETDATA(curr, int64_t);
     *r4300_mult_hi(&dev->r4300) = GETDATA(curr, int64_t);
     cp1_reg *cp1_regs = r4300_cp1_regs(&dev->r4300.cp1);
@@ -994,6 +995,7 @@ static int savestates_load_pj64(struct device* dev,
 
     // CP0
     COPYARRAY(cp0_regs, curr, uint32_t, CP0_REGS_COUNT);
+    *r4300_cp0_get_count(&dev->r4300.cp0) = cp0_regs[CP0_COUNT_REG];
 
     set_fpr_pointers(&dev->r4300.cp1, cp0_regs[CP0_STATUS_REG]);
 
@@ -1890,7 +1892,7 @@ static int savestates_save_pj64(const struct device* dev,
     PUTARRAY(pj64_magic, curr, unsigned char, 4);
     PUTDATA(curr, unsigned int, SaveRDRAMSize);
     PUTARRAY(dev->cart.cart_rom.rom, curr, unsigned int, 0x40/4);
-    PUTDATA(curr, uint32_t, get_event(&dev->r4300.cp0.q, VI_INT) - cp0_regs[CP0_COUNT_REG]); // vi_timer
+    PUTDATA(curr, uint32_t, get_event(&dev->r4300.cp0.q, VI_INT) - *r4300_cp0_get_count(&dev->r4300.cp0)); // vi_timer
     PUTDATA(curr, uint32_t, *r4300_pc((struct r4300_core*)&dev->r4300));
     PUTARRAY(r4300_regs((struct r4300_core*)&dev->r4300), curr, int64_t, 32);
     const cp1_reg* cp1_regs = r4300_cp1_regs((struct cp1*)&dev->r4300.cp1);


### PR DESCRIPTION
There was some discussion about removing SPECIAL_INT in this PR:

https://github.com/mupen64plus/mupen64plus-core/pull/444

The most reasonable solution proposed (in my mind) is to make the counter a 64 bit register, and use the lower 32 bits for COUNT_REG.

I have tested this PR with both interpreters.

Left to be done:

- Dynarecs -> I'm really not great at assembly, I'm hoping someone else can take on this task

I tested a number of games, including ones that I know are sensitive to timing and interrupt changes, I didn't notice any regressions. In fact, this PR fixes https://github.com/mupen64plus/mupen64plus-core/issues/689

I think this change is worthwhile, it simplifies the interrupt code, and hopefully might remove any bugs that the SPECIAL_INT "hack" (for lack of a better term) might have caused