### PR TITLE
Only align cart address in PI DMA

### DIFF
--- a/src/device/rcp/pi/pi_controller.c
+++ b/src/device/rcp/pi/pi_controller.c
@@ -54,7 +54,7 @@ enum
 static void dma_pi_read(struct pi_controller* pi)
 {
     uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] & ~UINT32_C(1);
-    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & ~UINT32_C(7);
+    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG];
     uint32_t length = (pi->regs[PI_RD_LEN_REG] & UINT32_C(0x00fffffe)) + 2;
     const uint8_t* dram = (uint8_t*)pi->ri->rdram->dram;
 
@@ -83,7 +83,7 @@ static void dma_pi_read(struct pi_controller* pi)
 static void dma_pi_write(struct pi_controller* pi)
 {
     uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] & ~UINT32_C(1);
-    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & ~UINT32_C(7);
+    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG];
     uint32_t length = (pi->regs[PI_WR_LEN_REG] & UINT32_C(0x00fffffe)) + 2;
     uint8_t* dram = (uint8_t*)pi->ri->rdram->dram;
 


### PR DESCRIPTION
This PR fixes:

https://github.com/mupen64plus/mupen64plus-core/issues/600

Cart and DRAM addresses were aligned to fix an issue in Taz Express:

https://github.com/mupen64plus/mupen64plus-core/pull/541

However, this broke saving in Command & Conquer. I tried a couple things, like just aligned PI DMA Writes, Command & Conquer wouldn't boot at all then.

The thing that makes both games (Taz and C&C) work is just aligning the cart addresses.

I'll admit that I don't really understand why, the documentation says:

> We summarize restrictions on DMA transfers as follows:
> 1) RDRAM address must be 8-byte aligned---the three least significant bits of address
must be zeroes.
> 2) BSD address must be 2-byte aligned---the least significant bit of address must be zero.
> 3) Length of DMA must be a multiple of 8 bytes (specified as the byte count - 1)---the
three least significant bits of the length register should always be ones.
> 4) Maximum transfer size is 16 MByte.