### PR TITLE
Enable transferpak write

### DIFF
--- a/src/device/gb/gb_cart.c
+++ b/src/device/gb/gb_cart.c
@@ -135,6 +135,7 @@ static void write_ram(void* ram_storage, const struct storage_backend_interface*
             dst[i] &= mask;
         }
     }
+    iram_storage->save(ram_storage);
 }
 
 


### PR DESCRIPTION
Is there any reason why transfer pak writes are disabled? As far as I can tell, it's as simple as the change I did in this pull request.

I can understand why 64DD writes are disabled, but I think we could write it when emulation stops instead of writing the whole file every single write.

With this change, I was able to load a game boy RAM file, make some changes in pokemon stadium 2, save the changes, load the RAM file in a gamebody emulator in Pokemon Gold and I checked that the changes were applied.