### PR TITLE
Rework interrupt scheduling

### DIFF
--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -188,6 +188,7 @@ struct cp0
 #ifndef NEW_DYNAREC
 	/* New dynarec uses a different memory layout */
     unsigned int next_interrupt;
+    int cycle_count;
 #endif
 
     struct interrupt_handler interrupt_handlers[CP0_INTERRUPT_HANDLERS_COUNT];
@@ -196,8 +197,6 @@ struct cp0
 	/* New dynarec uses a different memory layout */
     struct new_dynarec_hot_state* new_dynarec_hot_state;
 #endif
-
-    int special_done;
 
     uint32_t last_addr;
     unsigned int count_per_op;
@@ -221,6 +220,11 @@ void poweron_cp0(struct cp0* cp0);
 uint32_t* r4300_cp0_regs(struct cp0* cp0);
 uint32_t* r4300_cp0_last_addr(struct cp0* cp0);
 unsigned int* r4300_cp0_next_interrupt(struct cp0* cp0);
+
+/* cycle_count is a negative number representing the
+   number of cycles left until next interrupt is taken.
+   Next interrupt is taken whether cycle_count value is positive or null */
+int* r4300_cp0_cycle_count(struct cp0* cp0);
 
 int check_cop1_unusable(struct r4300_core* r4300);
 

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -102,31 +102,13 @@ static int before_event(const struct cp0* cp0, unsigned int evt1, unsigned int e
 {
     const uint32_t* cp0_regs = r4300_cp0_regs((struct cp0*)cp0); /* OK to cast away const qualifier */
     uint32_t count = cp0_regs[CP0_COUNT_REG];
+    int* cp0_cycle_count = r4300_cp0_cycle_count((struct cp0*)cp0);
 
-    if (evt1 - count < UINT32_C(0x80000000))
-    {
-        if (evt2 - count < UINT32_C(0x80000000))
-        {
-            if ((evt1 - count) < (evt2 - count)) return 1;
-            else return 0;
-        }
-        else
-        {
-            if ((count - evt2) < UINT32_C(0x10000000))
-            {
-                switch(type2)
-                {
-                    case SPECIAL_INT:
-                        if (cp0->special_done) return 1;
-                        else return 0;
-                        break;
-                    default:
-                        return 0;
-                }
-            }
-            else return 1;
-        }
-    }
+    /* At least one other interrupt is pending */
+    if (*cp0_cycle_count > 0)
+        count -= *cp0_cycle_count;
+
+    if ((evt1 - count) < (evt2 - count)) return 1;
     else return 0;
 }
 
@@ -154,15 +136,9 @@ void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count)
 {
     struct node* event;
     struct node* e;
-    int special;
     const uint32_t* cp0_regs = r4300_cp0_regs(cp0);
     unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(cp0);
-
-    special = (type == SPECIAL_INT);
-
-    if (cp0_regs[CP0_COUNT_REG] > UINT32_C(0x80000000)) {
-        cp0->special_done = 0;
-    }
+    int* cp0_cycle_count = r4300_cp0_cycle_count(cp0);
 
     if (get_event(&cp0->q, type)) {
         DebugMessage(M64MSG_WARNING, "two events of type 0x%x in interrupt queue", type);
@@ -183,18 +159,20 @@ void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count)
         cp0->q.first = event;
         event->next = NULL;
         *cp0_next_interrupt = cp0->q.first->data.count;
+        *cp0_cycle_count = cp0_regs[CP0_COUNT_REG] - cp0->q.first->data.count;
     }
-    else if (before_event(cp0, count, cp0->q.first->data.count, cp0->q.first->data.type) && !special)
+    else if (before_event(cp0, count, cp0->q.first->data.count, cp0->q.first->data.type))
     {
         event->next = cp0->q.first;
         cp0->q.first = event;
         *cp0_next_interrupt = cp0->q.first->data.count;
+        *cp0_cycle_count = cp0_regs[CP0_COUNT_REG] - cp0->q.first->data.count;
     }
     else
     {
         for (e = cp0->q.first;
             e->next != NULL &&
-            (!before_event(cp0, count, e->next->data.count, e->next->data.type) || special);
+            (!before_event(cp0, count, e->next->data.count, e->next->data.type));
             e = e->next);
 
         if (e->next == NULL)
@@ -204,8 +182,7 @@ void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count)
         }
         else
         {
-            if (!special)
-                for(; e->next != NULL && e->next->data.count == count; e = e->next);
+            for(; e->next != NULL && e->next->data.count == count; e = e->next);
 
             event->next = e->next;
             e->next = event;
@@ -217,17 +194,19 @@ void remove_interrupt_event(struct cp0* cp0)
 {
     struct node* e;
     const uint32_t* cp0_regs = r4300_cp0_regs(cp0);
-    uint32_t count = cp0_regs[CP0_COUNT_REG];
     unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(cp0);
+    int* cp0_cycle_count = r4300_cp0_cycle_count(cp0);
 
     e = cp0->q.first;
     cp0->q.first = e->next;
     free_node(&cp0->q.pool, e);
 
-    *cp0_next_interrupt = (cp0->q.first != NULL
-         && (cp0->q.first->data.count > count
-         || (count - cp0->q.first->data.count) < UINT32_C(0x80000000)))
+    *cp0_next_interrupt = (cp0->q.first != NULL)
         ? cp0->q.first->data.count
+        : 0;
+
+    *cp0_cycle_count = (cp0->q.first != NULL)
+        ? (cp0_regs[CP0_COUNT_REG] - cp0->q.first->data.count)
         : 0;
 }
 
@@ -287,7 +266,8 @@ void remove_event(struct interrupt_queue* q, int type)
 void translate_event_queue(struct cp0* cp0, unsigned int base)
 {
     struct node* e;
-    const uint32_t* cp0_regs = r4300_cp0_regs(cp0);
+    uint32_t* cp0_regs = r4300_cp0_regs(cp0);
+    int* cp0_cycle_count = r4300_cp0_cycle_count(cp0);
 
     remove_event(&cp0->q, COMPARE_INT);
     remove_event(&cp0->q, SPECIAL_INT);
@@ -296,8 +276,18 @@ void translate_event_queue(struct cp0* cp0, unsigned int base)
     {
         e->data.count = (e->data.count - cp0_regs[CP0_COUNT_REG]) + base;
     }
+
+    cp0_regs[CP0_COUNT_REG] = base;
+    add_interrupt_event_count(cp0, SPECIAL_INT, ((cp0_regs[CP0_COUNT_REG] & UINT32_C(0x80000000)) ^ UINT32_C(0x80000000)));
+
+    /* Add count_per_op to avoid wrong event order in case CP0_COUNT_REG == CP0_COMPARE_REG */
+    cp0_regs[CP0_COUNT_REG] += cp0->count_per_op;
+    *cp0_cycle_count += cp0->count_per_op;
     add_interrupt_event_count(cp0, COMPARE_INT, cp0_regs[CP0_COMPARE_REG]);
-    add_interrupt_event_count(cp0, SPECIAL_INT, 0);
+    cp0_regs[CP0_COUNT_REG] -= cp0->count_per_op;
+
+    /* Update next interrupt in case first event is COMPARE_INT */
+    *cp0_cycle_count = cp0_regs[CP0_COUNT_REG] - cp0->q.first->data.count;
 }
 
 int save_eventqueue_infos(const struct cp0* cp0, char *buf)
@@ -321,6 +311,7 @@ int save_eventqueue_infos(const struct cp0* cp0, char *buf)
 void load_eventqueue_infos(struct cp0* cp0, const char *buf)
 {
     int len = 0;
+    uint32_t* cp0_regs = r4300_cp0_regs(cp0);
 
     clear_queue(&cp0->q);
 
@@ -331,14 +322,16 @@ void load_eventqueue_infos(struct cp0* cp0, const char *buf)
         add_interrupt_event_count(cp0, type, count);
         len += 8;
     }
+
+    remove_event(&cp0->q, SPECIAL_INT);
+    add_interrupt_event_count(cp0, SPECIAL_INT, ((cp0_regs[CP0_COUNT_REG] & UINT32_C(0x80000000)) ^ UINT32_C(0x80000000)));
 }
 
 void init_interrupt(struct cp0* cp0)
 {
-    cp0->special_done = 1;
-
     clear_queue(&cp0->q);
-    add_interrupt_event_count(cp0, SPECIAL_INT, 0);
+    add_interrupt_event_count(cp0, SPECIAL_INT, 0x80000000);
+    add_interrupt_event_count(cp0, COMPARE_INT, 0);
 }
 
 void r4300_check_interrupt(struct r4300_core* r4300, uint32_t cause_ip, int set_cause)
@@ -346,6 +339,7 @@ void r4300_check_interrupt(struct r4300_core* r4300, uint32_t cause_ip, int set_
     struct node* event;
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
     unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
+    int* cp0_cycle_count = r4300_cp0_cycle_count(&r4300->cp0);
 
     if (set_cause) {
         cp0_regs[CP0_CAUSE_REG] = (cp0_regs[CP0_CAUSE_REG] | cause_ip) & ~CP0_CAUSE_EXCCODE_MASK;
@@ -369,6 +363,7 @@ void r4300_check_interrupt(struct r4300_core* r4300, uint32_t cause_ip, int set_
 
         event->data.count = *cp0_next_interrupt = cp0_regs[CP0_COUNT_REG];
         event->data.type = CHECK_INT;
+        *cp0_cycle_count = 0;
 
         if (r4300->cp0.q.first == NULL)
         {
@@ -404,10 +399,16 @@ void compare_int_handler(void* opaque)
 {
     struct r4300_core* r4300 = (struct r4300_core*)opaque;
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
+    int* cp0_cycle_count = r4300_cp0_cycle_count(&r4300->cp0);
 
+    /* Add count_per_op to avoid wrong event order in case CP0_COUNT_REG == CP0_COMPARE_REG */
     cp0_regs[CP0_COUNT_REG] += r4300->cp0.count_per_op;
+    *cp0_cycle_count += r4300->cp0.count_per_op;
     add_interrupt_event_count(&r4300->cp0, COMPARE_INT, cp0_regs[CP0_COMPARE_REG]);
     cp0_regs[CP0_COUNT_REG] -= r4300->cp0.count_per_op;
+
+    /* Update next interrupt in case first event is COMPARE_INT */
+    *cp0_cycle_count = cp0_regs[CP0_COUNT_REG] - r4300->cp0.q.first->data.count;
 
     raise_maskable_interrupt(r4300, CP0_CAUSE_IP7);
 }
@@ -417,18 +418,16 @@ void check_int_handler(void* opaque)
     exception_general((struct r4300_core*)opaque);
 }
 
+/* Special interrupt is a fake interrupt which porpose is
+   to ensure the number of cycles between current cycle 
+   and next interrupt will never exceed 2^31 */
 void special_int_handler(void* opaque)
 {
     struct cp0* cp0 = (struct cp0*)opaque;
     const uint32_t* cp0_regs = r4300_cp0_regs(cp0);
 
-    if (cp0_regs[CP0_COUNT_REG] > UINT32_C(0x10000000)) {
-        return;
-    }
-
-    cp0->special_done = 1;
     remove_interrupt_event(cp0);
-    add_interrupt_event_count(cp0, SPECIAL_INT, 0);
+    add_interrupt_event_count(cp0, SPECIAL_INT, ((cp0_regs[CP0_COUNT_REG] & UINT32_C(0x80000000)) ^ UINT32_C(0x80000000)));
 }
 
 /* XXX: this should only require r4300 struct not device ? */
@@ -485,6 +484,7 @@ void reset_hard_handler(void* opaque)
     pif_bootrom_hle_execute(r4300);
     r4300->cp0.last_addr = UINT32_C(0xa4000040);
     *r4300_cp0_next_interrupt(&r4300->cp0) = 624999;
+    *r4300_cp0_cycle_count(&r4300->cp0) = 0;
     init_interrupt(&r4300->cp0);
     invalidate_r4300_cached_code(r4300, 0, 0);
     generic_jump_to(r4300, r4300->cp0.last_addr);
@@ -504,6 +504,7 @@ void gen_interrupt(struct r4300_core* r4300)
 {
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
     unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
+    int* cp0_cycle_count = r4300_cp0_cycle_count(&r4300->cp0);
 
     if (*r4300_stop(r4300) == 1)
     {
@@ -535,9 +536,12 @@ void gen_interrupt(struct r4300_core* r4300)
         uint32_t dest = r4300->skip_jump;
         r4300->skip_jump = 0;
 
-        *cp0_next_interrupt = (r4300->cp0.q.first->data.count > cp0_regs[CP0_COUNT_REG]
-                || (cp0_regs[CP0_COUNT_REG] - r4300->cp0.q.first->data.count) < UINT32_C(0x80000000))
+        *cp0_next_interrupt = (r4300->cp0.q.first != NULL)
             ? r4300->cp0.q.first->data.count
+            : 0;
+
+        *cp0_cycle_count = (r4300->cp0.q.first != NULL)
+            ? (cp0_regs[CP0_COUNT_REG] - r4300->cp0.q.first->data.count)
             : 0;
 
         r4300->cp0.last_addr = dest;

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -965,7 +965,7 @@ DECLARE_INSTRUCTION(ERET)
 {
     DECLARE_R4300
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
-    unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
+    int* cp0_cycle_count = r4300_cp0_cycle_count(&r4300->cp0);
 
     cp0_update_count(r4300);
     if (cp0_regs[CP0_STATUS_REG] & CP0_STATUS_ERL)
@@ -981,7 +981,7 @@ DECLARE_INSTRUCTION(ERET)
     r4300->llbit = 0;
     r4300_check_interrupt(r4300, CP0_CAUSE_IP2, r4300->mi->regs[MI_INTR_REG] & r4300->mi->regs[MI_INTR_MASK_REG]); // ???
     r4300->cp0.last_addr = PCADDR;
-    if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
+    if (*cp0_cycle_count >= 0) { gen_interrupt(r4300); }
 }
 
 DECLARE_INSTRUCTION(SYNC)
@@ -1212,7 +1212,7 @@ DECLARE_INSTRUCTION(MTC0)
 {
     DECLARE_R4300
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
-    unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&r4300->cp0);
+    int* cp0_cycle_count = r4300_cp0_cycle_count(&r4300->cp0);
 
     switch(rfs)
     {
@@ -1248,10 +1248,9 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_COUNT_REG:
         cp0_update_count(r4300);
         r4300->cp0.interrupt_unsafe_state |= INTR_UNSAFE_R4300;
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
+        if (*cp0_cycle_count >= 0) { gen_interrupt(r4300); }
         r4300->cp0.interrupt_unsafe_state &= ~INTR_UNSAFE_R4300;
         translate_event_queue(&r4300->cp0, rrt32);
-        cp0_regs[CP0_COUNT_REG] = rrt32;
         break;
     case CP0_ENTRYHI_REG:
         cp0_regs[CP0_ENTRYHI_REG] = rrt32 & UINT32_C(0xFFFFE0FF);
@@ -1259,7 +1258,15 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_COMPARE_REG:
         cp0_update_count(r4300);
         remove_event(&r4300->cp0.q, COMPARE_INT);
+
+        /* Add count_per_op to avoid wrong event order in case CP0_COUNT_REG == CP0_COMPARE_REG */
+        cp0_regs[CP0_COUNT_REG] += r4300->cp0.count_per_op;
+        *cp0_cycle_count += r4300->cp0.count_per_op;
         add_interrupt_event_count(&r4300->cp0, COMPARE_INT, rrt32);
+        cp0_regs[CP0_COUNT_REG] -= r4300->cp0.count_per_op;
+
+        /* Update next interrupt in case first event is COMPARE_INT */
+        *cp0_cycle_count = cp0_regs[CP0_COUNT_REG] - r4300->cp0.q.first->data.count;
         cp0_regs[CP0_COMPARE_REG] = rrt32;
         cp0_regs[CP0_CAUSE_REG] &= ~CP0_CAUSE_IP7;
         break;
@@ -1272,7 +1279,7 @@ DECLARE_INSTRUCTION(MTC0)
         ADD_TO_PC(1);
         r4300_check_interrupt(r4300, CP0_CAUSE_IP2, r4300->mi->regs[MI_INTR_REG] & r4300->mi->regs[MI_INTR_MASK_REG]); // ???
         r4300->cp0.interrupt_unsafe_state |= INTR_UNSAFE_R4300;
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) { gen_interrupt(r4300); }
+        if (*cp0_cycle_count >= 0) { gen_interrupt(r4300); }
         r4300->cp0.interrupt_unsafe_state &= ~INTR_UNSAFE_R4300;
         ADD_TO_PC(-1);
         break;

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -72,22 +72,24 @@ static void InterpretOpcode(struct r4300_core* r4300);
          cp0_update_count(r4300); \
       } \
       r4300->cp0.last_addr = r4300->interp_PC.addr; \
-      if (*r4300_cp0_next_interrupt(&r4300->cp0) <= r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]) gen_interrupt(r4300); \
+      if (*r4300_cp0_cycle_count(&r4300->cp0) >= 0) gen_interrupt(r4300); \
    } \
    static void name##_IDLE(struct r4300_core* r4300, uint32_t op) \
    { \
       uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0); \
+      int* cp0_cycle_count = r4300_cp0_cycle_count(&r4300->cp0); \
       const int take_jump = (condition); \
-      int skip; \
       if (cop1 && check_cop1_unusable(r4300)) return; \
       if (take_jump) \
       { \
          cp0_update_count(r4300); \
-         skip = *r4300_cp0_next_interrupt(&r4300->cp0) - cp0_regs[CP0_COUNT_REG]; \
-         if (skip > 3) cp0_regs[CP0_COUNT_REG] += (skip & UINT32_C(0xFFFFFFFC)); \
-         else name(r4300, op); \
+         if(*cp0_cycle_count < 0) \
+         { \
+             cp0_regs[CP0_COUNT_REG] -= *cp0_cycle_count; \
+             *cp0_cycle_count = 0; \
+         } \
       } \
-      else name(r4300, op); \
+      name(r4300, op); \
    }
 
 #define RD_OF(op)      (((op) >> 11) & 0x1F)

--- a/src/device/r4300/x86/assemble.h
+++ b/src/device/r4300/x86/assemble.h
@@ -177,9 +177,22 @@ static osal_inline void test_m32_imm32(unsigned int *m32, unsigned int imm32)
     put32(imm32);
 }
 
+static osal_inline void test_reg32_reg32(int reg1, int reg2)
+{
+    put8(0x85);
+    put8((reg2 << 3) | reg1 | 0xC0);
+}
+
 static osal_inline void add_m32_reg32(unsigned int *m32, int reg32)
 {
     put8(0x01);
+    put8((reg32 << 3) | 5);
+    put32((unsigned int)(m32));
+}
+
+static osal_inline void sub_m32_reg32(unsigned int *m32, int reg32)
+{
+    put8(0x29);
     put8((reg32 << 3) | 5);
     put32((unsigned int)(m32));
 }
@@ -279,6 +292,18 @@ static osal_inline void jl_rj(unsigned char saut)
 static osal_inline void jp_rj(unsigned char saut)
 {
     put8(0x7A);
+    put8(saut);
+}
+
+static osal_inline void jns_rj(unsigned char saut)
+{
+    put8(0x79);
+    put8(saut);
+}
+
+static osal_inline void js_rj(unsigned char saut)
+{
+    put8(0x78);
     put8(saut);
 }
 

--- a/src/device/r4300/x86_64/assemble.h
+++ b/src/device/r4300/x86_64/assemble.h
@@ -348,12 +348,28 @@ static osal_inline void test_m32rel_imm32(unsigned int *m32, unsigned int imm32)
     put32(imm32);
 }
 
+static osal_inline void test_reg32_reg32(unsigned int reg1, unsigned int reg2)
+{
+    put8(0x85);
+    put8(0xC0 | (reg2 << 3) | reg1);
+}
+
 static osal_inline void add_m32rel_xreg32(unsigned int *m32, int xreg32)
 {
     int offset = rel_r15_offset(m32, "add_m32rel_xreg32");
 
     put8(0x41 | ((xreg32 & 8) >> 1));
     put8(0x01);
+    put8(0x87 | ((xreg32 & 7) << 3));
+    put32(offset);
+}
+
+static osal_inline void sub_m32rel_xreg32(unsigned int *m32, int xreg32)
+{
+    int offset = rel_r15_offset(m32, "sub_m32rel_xreg32");
+
+    put8(0x41 | ((xreg32 & 8) >> 1));
+    put8(0x29);
     put8(0x87 | ((xreg32 & 7) << 3));
     put32(offset);
 }
@@ -428,6 +444,18 @@ static osal_inline void jae_rj(unsigned char saut)
 static osal_inline void jp_rj(unsigned char saut)
 {
     put8(0x7A);
+    put8(saut);
+}
+
+static osal_inline void jns_rj(unsigned char saut)
+{
+    put8(0x79);
+    put8(saut);
+}
+
+static osal_inline void js_rj(unsigned char saut)
+{
+    put8(0x78);
     put8(saut);
 }
 

--- a/src/device/rcp/ai/ai_controller.c
+++ b/src/device/rcp/ai/ai_controller.c
@@ -51,7 +51,7 @@ static uint32_t get_remaining_dma_length(struct ai_controller* ai)
         return 0;
 
     cp0_regs = r4300_cp0_regs(&ai->mi->r4300->cp0);
-    if (next_ai_event <= cp0_regs[CP0_COUNT_REG])
+    if ((int)(cp0_regs[CP0_COUNT_REG] - next_ai_event) >= 0)
         return 0;
 
     remaining_dma_duration = next_ai_event - cp0_regs[CP0_COUNT_REG];

--- a/src/device/rcp/mi/mi_controller.c
+++ b/src/device/rcp/mi/mi_controller.c
@@ -91,8 +91,7 @@ void write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
     struct mi_controller* mi = (struct mi_controller*)opaque;
     uint32_t reg = mi_reg(address);
 
-    uint32_t* cp0_regs = r4300_cp0_regs(&mi->r4300->cp0);
-    unsigned int* cp0_next_interrupt = r4300_cp0_next_interrupt(&mi->r4300->cp0);
+    int* cp0_cycle_count = r4300_cp0_cycle_count(&mi->r4300->cp0);
 
     switch(reg)
     {
@@ -107,7 +106,7 @@ void write_mi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 
         r4300_check_interrupt(mi->r4300, CP0_CAUSE_IP2, mi->regs[MI_INTR_REG] & mi->regs[MI_INTR_MASK_REG]);
         cp0_update_count(mi->r4300);
-        if (*cp0_next_interrupt <= cp0_regs[CP0_COUNT_REG]) gen_interrupt(mi->r4300);
+        if (*cp0_cycle_count >= 0) gen_interrupt(mi->r4300);
         break;
     }
 }

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -57,7 +57,7 @@ enum { GB_CART_FINGERPRINT_OFFSET = 0x134 };
 enum { DD_DISK_ID_OFFSET = 0x43670 };
 
 static const char* savestate_magic = "M64+SAVE";
-static const int savestate_latest_version = 0x00010500;  /* 1.5 */
+static const int savestate_latest_version = 0x00010600;  /* 1.6 */
 static const unsigned char pj64_magic[4] = { 0xC8, 0xA6, 0xD8, 0x23 };
 
 static savestates_job job = savestates_job_nothing;


### PR DESCRIPTION
@loganmc10 
I didn't realized it at first but https://github.com/mupen64plus/mupen64plus-core/pull/701 is breaking the new dynarec very badly.

The main limitation is that the number of cycles between current cycle count and next interrupt event cannot exceed 2^31

I reworked interrupt scheduling a bit:

- cp0_next_interrupt is now a negative number representing the
number of cycles left until next interrupt is taken.
Next interrupt is taken whether cp0_next_interrupt value is positive or null

- Special interrupt is now a fake interrupt which porpose is
to ensure the number of cycles between current cycle count
and next interrupt will never exceed 2^31

I still need to fix both dynarecs.
In the meantime this PR needs to be tested to see if there's no regression 
