### PR TITLE
Proper handling of divide by zero

### DIFF
--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -815,10 +815,22 @@ DECLARE_INSTRUCTION(DIV)
     DECLARE_R4300
     if (rrt32)
     {
-        *r4300_mult_lo(r4300) = SE32(rrs32 / rrt32);
-        *r4300_mult_hi(r4300) = SE32(rrs32 % rrt32);
+        if (rrs32 == INT32_MIN && rrt32 == -1)
+        {
+            *r4300_mult_lo(r4300) = SE32(rrs32);
+            *r4300_mult_hi(r4300) = 0;
+        }
+        else
+        {
+            *r4300_mult_lo(r4300) = SE32(rrs32 / rrt32);
+            *r4300_mult_hi(r4300) = SE32(rrs32 % rrt32);
+        }
     }
-    else { DebugMessage(M64MSG_ERROR, "DIV: divide by 0"); }
+    else
+    {
+        *r4300_mult_lo(r4300) = rrs32 < 0 ? 1 : -1;
+        *r4300_mult_hi(r4300) = SE32(rrs32);
+    }
     ADD_TO_PC(1);
 }
 
@@ -830,7 +842,11 @@ DECLARE_INSTRUCTION(DIVU)
         *r4300_mult_lo(r4300) = SE32((uint32_t) rrs32 / (uint32_t) rrt32);
         *r4300_mult_hi(r4300) = SE32((uint32_t) rrs32 % (uint32_t) rrt32);
     }
-    else { DebugMessage(M64MSG_ERROR, "DIVU: divide by 0"); }
+    else
+    {
+        *r4300_mult_lo(r4300) = -1;
+        *r4300_mult_hi(r4300) = SE32(rrs32);
+    }
     ADD_TO_PC(1);
 }
 
@@ -839,10 +855,22 @@ DECLARE_INSTRUCTION(DDIV)
     DECLARE_R4300
     if (rrt)
     {
-        *r4300_mult_lo(r4300) = rrs / rrt;
-        *r4300_mult_hi(r4300) = rrs % rrt;
+        if (rrs == INT64_MIN && rrt == -1)
+        {
+            *r4300_mult_lo(r4300) = rrs;
+            *r4300_mult_hi(r4300) = 0;
+        }
+        else
+        {
+            *r4300_mult_lo(r4300) = rrs / rrt;
+            *r4300_mult_hi(r4300) = rrs % rrt;
+        }
     }
-    else { DebugMessage(M64MSG_ERROR, "DDIV: divide by 0"); }
+    else
+    {
+        *r4300_mult_lo(r4300) = rrs < 0 ? 1 : -1;
+        *r4300_mult_hi(r4300) = rrs;
+    }
     ADD_TO_PC(1);
 }
 
@@ -854,7 +882,11 @@ DECLARE_INSTRUCTION(DDIVU)
         *r4300_mult_lo(r4300) = (uint64_t) rrs / (uint64_t) rrt;
         *r4300_mult_hi(r4300) = (uint64_t) rrs % (uint64_t) rrt;
     }
-    else { DebugMessage(M64MSG_ERROR, "DDIVU: divide by 0"); }
+    else
+    {
+        *r4300_mult_lo(r4300) = -1;
+        *r4300_mult_hi(r4300) = rrs;
+    }
     ADD_TO_PC(1);
 }
 


### PR DESCRIPTION
I was testing these test ROMs:

https://github.com/PeterLemon/N64/tree/master/CPUTest

We pass all the CPU tests except for division.

I took this implementation from https://github.com/n64dev/cen64/pull/79. So credit to @sp1187 for this code.

After this PR, all the division test ROMs pass. The only commercial game that I know of that consistently tries to do division by zero is Toy Story 2 (it currently spits out a bunch of "DIV by zero" warnings). I tested that game and it still seems to work fine.

```rrs32 == INT32_MIN && rrt32 == -1``` is a special case, the result of that equation is actually an integer overflow, which was crashing the emulator, so it needs to be dealt with in an if statement, same as the cen64 implementation.