### PR TITLE
Disable FBInfo support for dynarecs

### DIFF
--- a/src/device/rcp/rdp/fb.c
+++ b/src/device/rcp/rdp/fb.c
@@ -185,7 +185,8 @@ void protect_framebuffers(struct fb* fb)
     struct mem_mapping fb_mapping = { 0, 0, M64P_MEM_RDRAM, { fb, RW(rdram_fb) } };
 
     /* check API support */
-    if (!(gfx.fBGetFrameBufferInfo && gfx.fBRead && gfx.fBWrite)) {
+    if (!(gfx.fBGetFrameBufferInfo && gfx.fBRead && gfx.fBWrite)
+        || fb->r4300->emumode == EMUMODE_DYNAREC /* Dynarecs currently miss some of the read/writes needed for FBInfo */) {
         return;
     }
 


### PR DESCRIPTION
Right now FBInfo doesn't work properly on either dynarec, see:

https://github.com/mupen64plus/mupen64plus-core/issues/493

https://github.com/mupen64plus/mupen64plus-core/issues/214

It's better to not advertise support for FBInfo at all if it isn't working, since plugins like GLideN64 have it enabled by default for certain games.

From my testing it works pretty reliably with the interpreters