### PR TITLE
Use cheat code to allow Rat Attack to boot

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -12964,6 +12964,8 @@ CRC=20FD0BF1 F5CF1D87
 Players=4
 SaveType=None
 Mempak=Yes
+; Allows the game to boot
+Cheat0=F117DAEC 8014,F117DAEE A1D0
 
 [E0BB65C30C1185FD9997020A1994B07E]
 GoodName=Rat Attack (E) (M6) [f1] (NTSC)
@@ -12981,6 +12983,8 @@ CRC=0304C48E AC4001B8
 Players=4
 SaveType=None
 Mempak=Yes
+; Allows the game to boot
+Cheat0=F117E34C 8014,F117E34E A8F0
 
 [5DBBFD5ACE8222FA8FE51BE113453C13]
 GoodName=Rayman 2 - The Great Escape (E) (M5) [!]


### PR DESCRIPTION
Thanks to @m4xw for helping me track down the correct memory addresses.

Obviously not the correct fix, but at least this won't dirty up the main emulation code. Tested with the U and E versions