### PR TITLE
Save 64DD data to SRAM folder in a zip file on emulation end

### DIFF
--- a/src/backends/file_storage.h
+++ b/src/backends/file_storage.h
@@ -32,10 +32,19 @@ struct file_storage
     const char* filename;
 };
 
+struct file_storage_rom
+{
+    uint8_t* data;
+    size_t size;
+    const char* filename;
+    const char* saveto_filename;
+};
+
 
 int open_file_storage(struct file_storage* storage, size_t size, const char* filename);
-int open_rom_file_storage(struct file_storage* storage, const char* filename);
+int open_rom_file_storage(struct file_storage_rom* storage, const char* filename, const char* save_filename, unsigned int max_size_bytes);
 void close_file_storage(struct file_storage* storage);
+void close_rom_file_storage(struct file_storage_rom* storage);
 
 extern const struct storage_backend_interface g_ifile_storage;
 extern const struct storage_backend_interface g_ifile_storage_ro;

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -222,10 +222,6 @@ static void write_sector(struct dd_controller* dd)
 	for (i = 0; i < length; ++i) {
 		disk_mem[offset + i] = dd->ds_buf[i ^ 3];
     }
-
-#if 0 /* disabled for now, because it causes too much slowdowns */
-    dd->idisk->save(dd->disk);
-#endif
 }
 
 static void seek_track(struct dd_controller* dd)

--- a/src/osal/files.h
+++ b/src/osal/files.h
@@ -56,6 +56,7 @@ extern const char * osal_get_shared_filepath(const char *filename, const char *f
 extern const char * osal_get_user_configpath(void);
 extern const char * osal_get_user_datapath(void);
 extern const char * osal_get_user_cachepath(void);
+extern const char * get_filename_from_path(const char *path);
 
 #endif /* OSAL_FILES_H */
 

--- a/src/osal/files_macos.c
+++ b/src/osal/files_macos.c
@@ -32,6 +32,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <libgen.h>
 
 #include "api/callbacks.h"
 #include "api/m64p_types.h"
@@ -223,3 +224,7 @@ const char * osal_get_user_cachepath(void)
     return osal_get_user_configpath();
 }
 
+const char * get_filename_from_path(const char *path)
+{
+    return basename(path);
+}

--- a/src/osal/files_unix.c
+++ b/src/osal/files_unix.c
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <libgen.h>
 
 #include "api/callbacks.h"
 #include "api/m64p_types.h"
@@ -230,6 +231,11 @@ const char * osal_get_user_cachepath(void)
     if (rval < 3)
         DebugMessage(M64MSG_ERROR, "Failed to get cache directory; $HOME is undefined or invalid.");
     return NULL;
+}
+
+const char * get_filename_from_path(const char *path)
+{
+    return basename(path);
 }
 
 

--- a/src/osal/files_win32.c
+++ b/src/osal/files_win32.c
@@ -204,4 +204,14 @@ const char * osal_get_user_cachepath(void)
     return osal_get_user_configpath();
 }
 
+const char * get_filename_from_path(const char *path)
+{
+    char node[ _MAX_DRIVE ];
+    char dir[ _MAX_DIR ];
+    static char fname[ _MAX_FNAME ];
+    char ext[ _MAX_EXT ];
 
+    _splitpath( path, node, dir, fname, ext );
+
+    return fname;
+}


### PR DESCRIPTION
This adds support for saving and loading 64DD data from a compressed zip file instead of the original image. The compressed zip file is stored in the SRAM folder like other save data but only once emulation finishes. The save file will be extracted and loaded when emulation starts up again for a disk with the same file name.

I tried using bsdiff before compressing the file, but that turned out to be way too slow. Creating a patch for a ~60MB 64DD image in my relatively high end phone took about 2 minutes to run, so it did not seem like an acceptable option to use bsdiff.

Also, I did not test the ```get_filename_from_path``` function I added for windows or MacOs, I'm hopefully someone else can test that.