### PR TITLE
Change some DD logging to only happen in verbose mode

### DIFF
--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -188,7 +188,7 @@ static void read_C2(struct dd_controller* dd)
     size_t length = zone_sec_size[dd->bm_zone];
     size_t offset = 0x40 * (dd->regs[DD_ASIC_CUR_SECTOR] - SECTORS_PER_BLOCK);
 
-    DebugMessage(M64MSG_INFO, "read C2: length=%08x, offset=%08x",
+    DebugMessage(M64MSG_VERBOSE, "read C2: length=%08x, offset=%08x",
             (uint32_t)length, (uint32_t)offset);
 
     for (i = 0; i < length; ++i) {
@@ -413,7 +413,7 @@ void read_dd_regs(void* opaque, uint32_t address, uint32_t* value)
     }
 
     *value = dd->regs[reg];
-    DebugMessage(M64MSG_INFO, "DD REG: %08X -> %08x", address, *value);
+    DebugMessage(M64MSG_VERBOSE, "DD REG: %08X -> %08x", address, *value);
 
     /* post read update. Not part of the returned value */
     switch(reg)
@@ -442,7 +442,7 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 
     assert(mask == ~UINT32_C(0));
 
-    DebugMessage(M64MSG_INFO, "DD REG: %08X <- %08x", address, value);
+    DebugMessage(M64MSG_VERBOSE, "DD REG: %08X <- %08x", address, value);
 
     switch (reg)
     {
@@ -481,7 +481,7 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 
         /* Set Disk type */
         case 0x0b:
-            DebugMessage(M64MSG_INFO, "Setting disk type %u", (dd->regs[DD_ASIC_DATA] >> 16) & 0xf);
+            DebugMessage(M64MSG_VERBOSE, "Setting disk type %u", (dd->regs[DD_ASIC_DATA] >> 16) & 0xf);
             break;
 
         /* Read RTC in ASIC_DATA (BCD format) */
@@ -599,12 +599,12 @@ void read_dd_rom(void* opaque, uint32_t address, uint32_t* value)
 
     *value = dd->rom[addr];
 
-    DebugMessage(M64MSG_INFO, "DD ROM: %08X -> %08x", address, *value);
+    DebugMessage(M64MSG_VERBOSE, "DD ROM: %08X -> %08x", address, *value);
 }
 
 void write_dd_rom(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
-    DebugMessage(M64MSG_WARNING, "DD ROM: %08X <- %08x & %08x", address, value, mask);
+    DebugMessage(M64MSG_VERBOSE, "DD ROM: %08X <- %08x & %08x", address, value, mask);
 }
 
 unsigned int dd_dom_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length)
@@ -613,7 +613,7 @@ unsigned int dd_dom_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_ad
     uint8_t* mem;
     size_t i;
 
-    DebugMessage(M64MSG_INFO, "DD DMA read dram=%08x  cart=%08x length=%08x",
+    DebugMessage(M64MSG_VERBOSE, "DD DMA read dram=%08x  cart=%08x length=%08x",
             dram_addr, cart_addr, length);
 
     if (cart_addr == MM_DD_DS_BUFFER) {
@@ -640,7 +640,7 @@ unsigned int dd_dom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, u
     const uint8_t* mem;
     size_t i;
 
-    DebugMessage(M64MSG_INFO, "DD DMA write dram=%08x  cart=%08x length=%08x",
+    DebugMessage(M64MSG_VERBOSE, "DD DMA write dram=%08x  cart=%08x length=%08x",
             dram_addr, cart_addr, length);
 
     if (cart_addr < MM_DD_ROM) {


### PR DESCRIPTION
Excessive logging can really kill performance (depending on the frontend).

The DD controller is currently printing out a lot of logs just for things like DMA reads and writes. This converts the logs to "verbose" mode, so they'll only print out if you have verbose mode enabled