### PR TITLE
Don't check event count to test if event is pending

### DIFF
--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -210,23 +210,23 @@ void remove_interrupt_event(struct cp0* cp0)
         : 0;
 }
 
-unsigned int get_event(const struct interrupt_queue* q, int type)
+unsigned int* get_event(const struct interrupt_queue* q, int type)
 {
-    const struct node* e = q->first;
+    struct node* e = q->first;
 
     if (e == NULL) {
-        return 0;
+        return NULL;
     }
 
     if (e->data.type == type) {
-        return e->data.count;
+        return &e->data.count;
     }
 
     for (; e->next != NULL && e->next->data.type != type; e = e->next);
 
     return (e->next != NULL)
-        ? e->next->data.count
-        : 0;
+        ? &e->next->data.count
+        : NULL;
 }
 
 int get_next_event_type(const struct interrupt_queue* q)

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -39,7 +39,7 @@ void translate_event_queue(struct cp0* cp0, unsigned int base);
 void remove_event(struct interrupt_queue* q, int type);
 void add_interrupt_event_count(struct cp0* cp0, int type, unsigned int count);
 void add_interrupt_event(struct cp0* cp0, int type, unsigned int delay);
-unsigned int get_event(const struct interrupt_queue* q, int type);
+unsigned int* get_event(const struct interrupt_queue* q, int type);
 int get_next_event_type(const struct interrupt_queue* q);
 unsigned int add_random_interrupt_time(struct r4300_core* r4300);
 void remove_interrupt_event(struct cp0* cp0);

--- a/src/device/rcp/ai/ai_controller.c
+++ b/src/device/rcp/ai/ai_controller.c
@@ -38,7 +38,7 @@
 
 static uint32_t get_remaining_dma_length(struct ai_controller* ai)
 {
-    unsigned int next_ai_event;
+    unsigned int* next_ai_event;
     unsigned int remaining_dma_duration;
     const uint32_t* cp0_regs;
 
@@ -47,14 +47,14 @@ static uint32_t get_remaining_dma_length(struct ai_controller* ai)
 
     cp0_update_count(ai->mi->r4300);
     next_ai_event = get_event(&ai->mi->r4300->cp0.q, AI_INT);
-    if (next_ai_event == 0)
+    if (next_ai_event == NULL)
         return 0;
 
     cp0_regs = r4300_cp0_regs(&ai->mi->r4300->cp0);
-    if ((int)(cp0_regs[CP0_COUNT_REG] - next_ai_event) >= 0)
+    if ((int)(cp0_regs[CP0_COUNT_REG] - *next_ai_event) >= 0)
         return 0;
 
-    remaining_dma_duration = next_ai_event - cp0_regs[CP0_COUNT_REG];
+    remaining_dma_duration = *next_ai_event - cp0_regs[CP0_COUNT_REG];
 
     uint64_t dma_length = (uint64_t)remaining_dma_duration * ai->fifo[0].length / ai->fifo[0].duration;
     return dma_length&~7;

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -1890,7 +1890,11 @@ static int savestates_save_pj64(const struct device* dev,
     PUTARRAY(pj64_magic, curr, unsigned char, 4);
     PUTDATA(curr, unsigned int, SaveRDRAMSize);
     PUTARRAY(dev->cart.cart_rom.rom, curr, unsigned int, 0x40/4);
-    PUTDATA(curr, uint32_t, get_event(&dev->r4300.cp0.q, VI_INT) - cp0_regs[CP0_COUNT_REG]); // vi_timer
+    uint32_t* next_vi = get_event(&dev->r4300.cp0.q, VI_INT);
+    if (next_vi != NULL)
+        PUTDATA(curr, uint32_t, *next_vi - cp0_regs[CP0_COUNT_REG]); // vi_timer
+    else
+        PUTDATA(curr, uint32_t, 0 - cp0_regs[CP0_COUNT_REG]);
     PUTDATA(curr, uint32_t, *r4300_pc((struct r4300_core*)&dev->r4300));
     PUTARRAY(r4300_regs((struct r4300_core*)&dev->r4300), curr, int64_t, 32);
     const cp1_reg* cp1_regs = r4300_cp1_regs((struct cp1*)&dev->r4300.cp1);


### PR DESCRIPTION
Right now we use the "count" of the next event to check if that type of event is pending.

This could lead to the (admittedly rare) situation where the next event is scheduled at COUNT_REG 0, and get_event() would return the incorrect answer.