### PR TITLE
Adjust DD DMA timing

### DIFF
--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -623,14 +623,14 @@ unsigned int dd_dom_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_ad
     else {
         DebugMessage(M64MSG_ERROR, "Unknown DD dma read dram=%08x  cart=%08x length=%08x",
             dram_addr, cart_addr, length);
-        return (length * 63) / 25;
+        return (length * 63) / 50;
     }
 
     for (i = 0; i < length; ++i) {
         mem[(cart_addr + i) ^ S8] = dram[(dram_addr + i) ^ S8];
     }
 
-    return (length * 63) / 25;
+    return (length * 63) / 50;
 }
 
 unsigned int dd_dom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length)
@@ -658,16 +658,16 @@ unsigned int dd_dom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, u
             DebugMessage(M64MSG_ERROR, "Unknown DD dma write dram=%08x  cart=%08x length=%08x",
                 dram_addr, cart_addr, length);
 
-            return (length * 63) / 25;
+            return (length * 63) / 50;
         }
 
-        cycles = (length * 63) / 25;
+        cycles = (length * 63) / 50;
     }
     else {
         /* DD ROM */
         cart_addr = (cart_addr - MM_DD_ROM);
         mem = (const uint8_t*)dd->rom;
-        cycles = (length * 63) / 25;
+        cycles = (length * 63) / 50;
     }
 
     for (i = 0; i < length; ++i) {


### PR DESCRIPTION
I believe the formula for DD DMA timing (length * 63 / 25) was taken from MAME:
https://github.com/mamedev/mame/blob/master/src/mame/machine/n64.cpp#L1573

They say "Measured as between 2.53 cycles per byte and 2.55 cycles per byte". 63/25 is 2.52.

We time our interrupts using the COUNT register, which increments at 1/2 the clock speed. To me this means we should be using 63/50.

This change allows F-Zero DD expansion to boot, before it was just sitting on the "DD Loading" screen. The only other game I have tested it the "Dawn to Dusk" Zelda OoT homebrew that was recently released.

The rest of the DD games should be tested to make sure there aren't regressions, I haven't found a really good way to boot them because of the requirement for a cartridge ROM. Maybe someone that knows how to get all those games booted can give this PR a try? I wouldn't merge this until the rest of the DD games can be tested for regressions