### PR TITLE
Emulate RSP DMA FIFO queue

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -121,7 +121,8 @@ void init_device(struct device* dev,
         { &dev->dp,        rdp_interrupt_event         }, /* DP */
         { &dev->pif,       hw2_int_handler             }, /* HW2 */
         { dev,             nmi_int_handler             }, /* NMI */
-        { dev,             reset_hard_handler          }  /* reset_hard */
+        { dev,             reset_hard_handler          }, /* reset_hard */
+        { &dev->sp,        rsp_end_of_dma_event        }
     };
 
 #define R(x) read_ ## x

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -166,7 +166,7 @@ struct interrupt_handler
     void (*callback)(void*);
 };
 
-enum { CP0_INTERRUPT_HANDLERS_COUNT = 12 };
+enum { CP0_INTERRUPT_HANDLERS_COUNT = 13 };
 
 enum {
     INTR_UNSAFE_R4300 = 0x01,

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -638,6 +638,11 @@ void gen_interrupt(struct r4300_core* r4300)
             call_interrupt_handler(&r4300->cp0, 10);
             break;
 
+        case RSP_DMA_EVT:
+            remove_interrupt_event(&r4300->cp0);
+            call_interrupt_handler(&r4300->cp0, 12);
+            break;
+
         default:
             DebugMessage(M64MSG_ERROR, "Unknown interrupt queue event type %.8X.", r4300->cp0.q.first->data.type);
             remove_interrupt_event(&r4300->cp0);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -65,5 +65,6 @@ void nmi_int_handler(void* opaque);
 #define DP_INT      0x100
 #define HW2_INT     0x200
 #define NMI_INT     0x400
+#define RSP_DMA_EVT 0x800
 
 #endif /* M64P_DEVICE_R4300_INTERRUPT_H */

--- a/src/device/rcp/rsp/rsp_core.h
+++ b/src/device/rcp/rsp/rsp_core.h
@@ -75,6 +75,21 @@ enum sp_registers2
     SP_REGS2_COUNT
 };
 
+enum sp_dma_dir
+{
+    SP_DMA_READ,
+    SP_DMA_WRITE
+};
+
+enum { SP_DMA_FIFO_SIZE = 2} ;
+
+struct sp_dma
+{
+    uint32_t dir;
+    uint32_t length;
+    uint32_t memaddr;
+    uint32_t dramaddr;
+};
 
 struct rsp_core
 {
@@ -86,6 +101,7 @@ struct rsp_core
     struct mi_controller* mi;
     struct rdp_core* dp;
     struct ri_controller* ri;
+    struct sp_dma fifo[SP_DMA_FIFO_SIZE];
 };
 
 static osal_inline uint32_t rsp_mem_address(uint32_t address)
@@ -123,5 +139,6 @@ void write_rsp_regs2(void* opaque, uint32_t address, uint32_t value, uint32_t ma
 void do_SP_Task(struct rsp_core* sp);
 
 void rsp_interrupt_event(void* opaque);
+void rsp_end_of_dma_event(void* opaque);
 
 #endif

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -57,7 +57,7 @@ enum { GB_CART_FINGERPRINT_OFFSET = 0x134 };
 enum { DD_DISK_ID_OFFSET = 0x43670 };
 
 static const char* savestate_magic = "M64+SAVE";
-static const int savestate_latest_version = 0x00010600;  /* 1.6 */
+static const int savestate_latest_version = 0x00010700;  /* 1.7 */
 static const unsigned char pj64_magic[4] = { 0xC8, 0xA6, 0xD8, 0x23 };
 
 static savestates_job job = savestates_job_nothing;
@@ -839,6 +839,20 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
             curr += sizeof(uint32_t);
 #endif
         }
+
+        if (version >= 0x00010700)
+        {
+            dev->sp.fifo[0].dir = GETDATA(curr, uint32_t);
+            dev->sp.fifo[0].length = GETDATA(curr, uint32_t);
+            dev->sp.fifo[0].memaddr = GETDATA(curr, uint32_t);
+            dev->sp.fifo[0].dramaddr = GETDATA(curr, uint32_t);
+            dev->sp.fifo[1].dir = GETDATA(curr, uint32_t);
+            dev->sp.fifo[1].length = GETDATA(curr, uint32_t);
+            dev->sp.fifo[1].memaddr = GETDATA(curr, uint32_t);
+            dev->sp.fifo[1].dramaddr = GETDATA(curr, uint32_t);
+        }
+        else
+            memset(dev->sp.fifo, 0, SP_DMA_FIFO_SIZE*sizeof(struct sp_dma));
     }
     else
     {
@@ -1856,6 +1870,14 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
 #else
     PUTDATA(curr, uint32_t, 0);
 #endif
+    PUTDATA(curr, uint32_t, dev->sp.fifo[0].dir);
+    PUTDATA(curr, uint32_t, dev->sp.fifo[0].length);
+    PUTDATA(curr, uint32_t, dev->sp.fifo[0].memaddr);
+    PUTDATA(curr, uint32_t, dev->sp.fifo[0].dramaddr);
+    PUTDATA(curr, uint32_t, dev->sp.fifo[1].dir);
+    PUTDATA(curr, uint32_t, dev->sp.fifo[1].length);
+    PUTDATA(curr, uint32_t, dev->sp.fifo[1].memaddr);
+    PUTDATA(curr, uint32_t, dev->sp.fifo[1].dramaddr);
 
     init_work(&save->work, savestates_save_m64p_work);
     queue_work(&save->work);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/848146/75212444-3366f700-5744-11ea-8252-41063d61f488.png)

I modelled the FIFO queue after the AI FIFO queue. There is not actually an interrupt that happens at the end of the DMA, but I've used the interrupt/event queue to schedule the end of the DMA, since that is the most convenient way.

I haven't noticed any difference in any game, either an improvement or a regression. As suggested, most games just check DMA_BUSY to see if the DMA is complete, since we never set that bit in our current code, games probably just assume the DMA was _really fast_. This should get us a little closer to timing accuracy, since the games will wait a bit for the DMA to complete, like on a real N64