### PR TITLE
Implement PIF write flags properly

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -201,7 +201,8 @@ void init_device(struct device* dev,
         (uint8_t*)mem_base_u32(base, MM_PIF_MEM),
         jbds, ijbds,
         (uint8_t*)mem_base_u32(base, rom_base) + 0x40,
-        &dev->r4300);
+        &dev->r4300,
+        &dev->si);
 
     init_cart(&dev->cart,
             af_rtc_clock, iaf_rtc_clock,

--- a/src/device/pif/pif.h
+++ b/src/device/pif/pif.h
@@ -31,6 +31,7 @@
 
 struct joybus_device_interface;
 struct r4300_core;
+struct si_controller;
 
 enum { PIF_ROM_SIZE = 0x7c0 };
 enum { PIF_RAM_SIZE = 0x40 };
@@ -58,6 +59,7 @@ struct pif
     struct cic cic;
 
     struct r4300_core* r4300;
+    struct si_controller* si;
 };
 
 static osal_inline uint32_t pif_ram_address(uint32_t address)
@@ -71,7 +73,8 @@ void init_pif(struct pif* pif,
     void* jbds[PIF_CHANNELS_COUNT],
     const struct joybus_device_interface* ijbds[PIF_CHANNELS_COUNT],
     const uint8_t* ipl3,
-    struct r4300_core* r4300);
+    struct r4300_core* r4300,
+    struct si_controller* si);
 
 void poweron_pif(struct pif* pif);
 

--- a/src/device/rcp/si/si_controller.c
+++ b/src/device/rcp/si/si_controller.c
@@ -33,15 +33,6 @@
 #include "device/rdram/rdram.h"
 #include "osal/preproc.h"
 
-enum
-{
-    /* SI_STATUS - read */
-    SI_STATUS_DMA_BUSY  = 0x0001,
-    SI_STATUS_RD_BUSY   = 0x0002,
-    SI_STATUS_DMA_ERROR = 0x0008,
-    SI_STATUS_INTERRUPT = 0x1000,
-};
-
 static int validate_dma(struct si_controller* si, uint32_t reg)
 {
     if ((si->regs[reg] & 0x1fffffff) != 0x1fc007c0)
@@ -177,7 +168,7 @@ void si_end_of_dma_event(void* opaque)
 
     /* end DMA */
     si->dma_dir = SI_NO_DMA;
-    si->regs[SI_STATUS_REG] &= ~SI_STATUS_DMA_BUSY;
+    si->regs[SI_STATUS_REG] &= ~(SI_STATUS_DMA_BUSY | SI_STATUS_IO_BUSY);
 
     /* raise si interrupt */
     si->regs[SI_STATUS_REG] |= SI_STATUS_INTERRUPT;

--- a/src/device/rcp/si/si_controller.h
+++ b/src/device/rcp/si/si_controller.h
@@ -49,6 +49,15 @@ enum si_registers
     SI_REGS_COUNT
 };
 
+enum
+{
+    /* SI_STATUS - read */
+    SI_STATUS_DMA_BUSY  = 0x0001,
+    SI_STATUS_IO_BUSY   = 0x0002,
+    SI_STATUS_DMA_ERROR = 0x0008,
+    SI_STATUS_INTERRUPT = 0x1000,
+};
+
 struct si_controller
 {
     uint32_t regs[SI_REGS_COUNT];


### PR DESCRIPTION
Here is another DMA flag fix, similar to #721 . As is the case with that PR, I haven't actually come across a game that does a CPU write to PIF RAM, but the documentation is clear:

```dma_busy indicates a DMA is in progress (or an IO write operation)```

```dma_busy is set for all dma and io write operations```

```DMA and IO writes generate an si_interrupt upon completion to inform host software that the operation has concluded.```

I would really love to find a game that does this so I can verify this behaviour, I'll probably keep trying to find an example, unless somebody has a way to search through game ASM code for SW operations to the PIF RAM address.