### PR TITLE
Disable FTZ (flush to zero) mode for SSE when FS bit is set

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -144,7 +144,7 @@ endif
 # base CFLAGS, LDLIBS, and LDFLAGS
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
-CFLAGS += -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -I../../src/asm_defines -DM64P_PARALLEL
+CFLAGS += -fno-strict-aliasing -fvisibility=hidden -I../../src -I../../src/asm_defines -DM64P_PARALLEL
 CXXFLAGS += -fvisibility-inlines-hidden
 LDLIBS +=  -lm
 

--- a/src/device/r4300/cp1.h
+++ b/src/device/r4300/cp1.h
@@ -51,6 +51,10 @@ struct cp1
      * using 32-bit stores. */
     uint32_t rounding_mode;
 
+#ifdef OSAL_SSE
+    uint32_t flush_mode;
+#endif
+
 #ifdef NEW_DYNAREC
 	/* New dynarec uses a different memory layout */
     struct new_dynarec_hot_state* new_dynarec_hot_state;

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -121,6 +121,13 @@ void poweron_r4300(struct r4300_core* r4300)
 
 void run_r4300(struct r4300_core* r4300)
 {
+#ifdef OSAL_SSE
+    //Save FTZ/DAZ mode
+    unsigned int daz = _MM_GET_DENORMALS_ZERO_MODE();
+    unsigned int ftz = _MM_GET_FLUSH_ZERO_MODE();
+    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_OFF);
+#endif
+
     *r4300_stop(r4300) = 0;
     g_rom_pause = 0;
 
@@ -195,6 +202,11 @@ void run_r4300(struct r4300_core* r4300)
 #if defined(COUNT_INSTR)
     if (r4300->emumode == EMUMODE_DYNAREC)
         instr_counters_print();
+#endif
+#ifdef OSAL_SSE
+    //Restore FTZ/DAZ mode
+    _MM_SET_DENORMALS_ZERO_MODE(daz);
+    _MM_SET_FLUSH_ZERO_MODE(ftz);
 #endif
 }
 

--- a/src/osal/preproc.h
+++ b/src/osal/preproc.h
@@ -42,6 +42,11 @@
   /* for isnan() */
   #include <float.h>
 
+#if defined(_M_X64) || (_M_IX86_FP > 0)
+  #include <immintrin.h>
+  #define OSAL_SSE
+#endif
+
 #else  /* Not WIN32 */
   /* for strcasecmp */
   #include <strings.h>
@@ -57,6 +62,11 @@
 
   /* string functions */
   #define osal_insensitive_strcmp(x, y) strcasecmp(x, y)
+
+#ifdef __SSE__
+  #include <immintrin.h>
+  #define OSAL_SSE
+#endif
 
 #endif
 


### PR DESCRIPTION
Fixes (only for SSE, not ARM) #724 

The c.eq functions are meant to compare 2 float (or double) values. Computers aren't very good at comparing floating numbers, and the emulator seems to return ```equal``` when the N64 expects the values to be ```not equal```.

Using memcmp seems to work properly, the emulator still passes the PeterLemon/krom N64 test ROM for CP1 C EQ functions, and Rayman/Donald Duck collision detection is fixed