### PR TITLE
Support FBWrites with a size of 3

### DIFF
--- a/src/device/rcp/rdp/fb.c
+++ b/src/device/rcp/rdp/fb.c
@@ -162,6 +162,16 @@ void write_rdram_fb(void* opaque, uint32_t address, uint32_t value, uint32_t mas
         size = 2;
         break;
 
+    case 0xffffff00:
+        addr += (0 ^ Sh16);
+        size = 3;
+        break;
+
+    case 0x00ffffff:
+        addr += (1 ^ Sh16);
+        size = 3;
+        break;
+
     case 0xffffffff:
         addr += 0;
         size = 4;


### PR DESCRIPTION
I noticed that Resident Evil 2 does this, triggering an "Unknown mask" warning