### PR TITLE
BattleTanx (U) games need CountPerOp=3 to boot

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -1443,6 +1443,7 @@ RefMD5=A5EE8A6C34863E3D0EB8C06AE8668B30
 [3406A505C22BAC2F40D9BFC6FF08CF86]
 GoodName=BattleTanx (U) [!]
 CRC=6AA4DDE7 E3E2F4E7
+CountPerOp=3
 SaveType=None
 Mempak=Yes
 Players=4
@@ -1480,7 +1481,7 @@ Rumble=Yes
 [654557C316F901A2CA6F7F4B43343147]
 GoodName=BattleTanx - Global Assault (U) [!]
 CRC=75A4E247 6008963D
-CountPerOp=1
+CountPerOp=3
 Players=4
 SaveType=None
 Mempak=Yes


### PR DESCRIPTION
These games are very sensitive to interrupt timing, since https://github.com/mupen64plus/mupen64plus-core/commit/5a1491505f65f7bdef8930d03f9890f6d7992145 they aren't booting.

I don't think it's really the fault of that PR, it's just that the interrupt timing changed a bit and now these games don't like it.

For whatever reason, the (E) version doesn't have this issue