### PR TITLE
Rework flashram implementation

### DIFF
--- a/src/device/cart/cart.c
+++ b/src/device/cart/cart.c
@@ -124,7 +124,7 @@ void init_cart(struct cart* cart,
 
     init_flashram(&cart->flashram,
         flashram_type,
-        flashram_storage, iflashram_storage, dram);
+        flashram_storage, iflashram_storage);
 
     init_sram(&cart->sram,
         sram_storage, isram_storage);
@@ -161,7 +161,7 @@ void read_cart_dom2(void* opaque, uint32_t address, uint32_t* value)
         }
 
         cart->use_flashram = 1;
-        read_flashram_status(&cart->flashram, address, value);
+        read_flashram(&cart->flashram, address, value);
     }
 }
 
@@ -182,7 +182,7 @@ void write_cart_dom2(void* opaque, uint32_t address, uint32_t value, uint32_t ma
         }
 
         cart->use_flashram = 1;
-        write_flashram_command(&cart->flashram, address, value, mask);
+        write_flashram(&cart->flashram, address, value, mask);
     }
 }
 

--- a/src/device/cart/flashram.c
+++ b/src/device/cart/flashram.c
@@ -36,89 +36,103 @@
 static void flashram_command(struct flashram* flashram, uint32_t command)
 {
     unsigned int i;
-    const uint8_t* dram = flashram->dram;
+    unsigned int offset;
     uint8_t* mem = flashram->istorage->data(flashram->storage);
 
     switch (command & 0xff000000)
     {
+    case 0x3c000000:
+        /* set chip erase mode */
+        flashram->mode = FLASHRAM_MODE_CHIP_ERASE;
+        break;
+
     case 0x4b000000:
-        flashram->erase_offset = (command & 0xffff) * 128;
+        /* set sector erase mode, set erase sector */
+        flashram->mode = FLASHRAM_MODE_SECTOR_ERASE;
+        flashram->erase_page = (command & 0xffff);
         break;
+
     case 0x78000000:
-        flashram->mode = FLASHRAM_MODE_ERASE;
-        flashram->status[0] = 0x11118008;
-        break;
-    case 0xa5000000:
-        flashram->erase_offset = (command & 0xffff) * 128;
-        flashram->status[0] = 0x11118004;
-        break;
-    case 0xb4000000:
-        flashram->mode = FLASHRAM_MODE_WRITE;
-        break;
-    case 0xd2000000:  // execute
-        switch (flashram->mode)
-        {
-        case FLASHRAM_MODE_NOPES:
-        case FLASHRAM_MODE_READ:
-            break;
-        case FLASHRAM_MODE_ERASE:
-        {
-            for (i = flashram->erase_offset; i < (flashram->erase_offset+128); ++i) {
-                mem[i^S8] = 0xff;
-            }
-            flashram->istorage->save(flashram->storage);
+        /* set erase busy flag */
+        flashram->status |= 0x02;
+
+        /* do chip/sector erase */
+        if (flashram->mode == FLASHRAM_MODE_SECTOR_ERASE) {
+            memset(mem + (flashram->erase_page & 0xff80) * 128, 0xff, 128*128);
         }
-        break;
-        case FLASHRAM_MODE_WRITE:
-        {
-            for (i = 0; i < 128; ++i) {
-                mem[(flashram->erase_offset+i)^S8] = dram[(flashram->write_pointer+i)^S8];
-            }
-            flashram->istorage->save(flashram->storage);
+        else if (flashram->mode == FLASHRAM_MODE_CHIP_ERASE){
+            memset(mem, 0xff, FLASHRAM_SIZE);
         }
-        break;
-        case FLASHRAM_MODE_STATUS:
-            break;
-        default:
-            DebugMessage(M64MSG_WARNING, "unknown flashram command with mode:%x", flashram->mode);
-            break;
+        else {
+            DebugMessage(M64MSG_WARNING, "Unexpected erase command (mode=%x)", flashram->mode);
         }
-        flashram->mode = FLASHRAM_MODE_NOPES;
-        break;
-    case 0xe1000000:
+        flashram->istorage->save(flashram->storage);
+
+        /* clear erase busy flag, set erase success flag, transition to status mode */
+        flashram->status &= ~UINT32_C(0x02);
+        flashram->status |= 0x08;
         flashram->mode = FLASHRAM_MODE_STATUS;
-        flashram->status[0] = 0x11118001;
         break;
+
+    case 0xa5000000:
+        /* set program busy flag */
+        flashram->status |= 0x01;
+
+        /* program selected page */
+        offset = (command & 0xffff) * 128;
+        for (i = 0; i < 128; ++i) {
+            mem[(offset+i)^S8] = flashram->page_buf[i];
+        }
+        flashram->istorage->save(flashram->storage);
+
+        /* clear program busy flag, set program success flag, transition to status mode */
+        flashram->status &= ~UINT32_C(0x01);
+        flashram->status |= 0x04;
+        flashram->mode = FLASHRAM_MODE_STATUS;
+        break;
+
+    case 0xb4000000:
+        /* set page program mode */
+        flashram->mode = FLASHRAM_MODE_PAGE_PROGRAM;
+        break;
+
+    case 0xd2000000:
+        /* set status mode */
+        flashram->mode = FLASHRAM_MODE_STATUS;
+        break;
+
+    case 0xe1000000:
+        /* set silicon_id mode */
+        flashram->mode = FLASHRAM_MODE_READ_SILICON_ID;
+        break;
+
     case 0xf0000000:
-        flashram->mode = FLASHRAM_MODE_READ;
-        flashram->status[0] = 0x11118004;
+        /* set read mode */
+        flashram->mode = FLASHRAM_MODE_READ_ARRAY;
         break;
-    case 0x00000000:
-        break;
+
     default:
         DebugMessage(M64MSG_WARNING, "unknown flashram command: %" PRIX32, command);
-        break;
     }
 }
 
 
 void init_flashram(struct flashram* flashram,
-                   uint32_t flashram_type,
-                   void* storage, const struct storage_backend_interface* istorage,
-                   const uint8_t* dram)
+                   uint32_t flashram_id,
+                   void* storage, const struct storage_backend_interface* istorage)
 {
-    flashram->status[1] = flashram_type;
+    flashram->silicon_id[0] = FLASHRAM_TYPE_ID;
+    flashram->silicon_id[1] = flashram_id;
     flashram->storage = storage;
     flashram->istorage = istorage;
-    flashram->dram = dram;
 }
 
 void poweron_flashram(struct flashram* flashram)
 {
-    flashram->mode = FLASHRAM_MODE_NOPES;
-    flashram->status[0] = 0;
-    flashram->erase_offset = 0;
-    flashram->write_pointer = 0;
+    flashram->mode = FLASHRAM_MODE_READ_ARRAY;
+    flashram->status = 0x00;
+    flashram->erase_page = 0;
+    memset(flashram->page_buf, 0xff, 128);
 }
 
 void format_flashram(uint8_t* flash)
@@ -126,18 +140,41 @@ void format_flashram(uint8_t* flash)
     memset(flash, 0xff, FLASHRAM_SIZE);
 }
 
-void read_flashram_status(void* opaque, uint32_t address, uint32_t* value)
+void read_flashram(void* opaque, uint32_t address, uint32_t* value)
 {
     struct flashram* flashram = (struct flashram*)opaque;
 
-    *value = flashram->status[0];
+    if ((address & 0x1ffff) == 0x00000 && flashram->mode == FLASHRAM_MODE_STATUS) {
+        /* read Status register */
+        *value = flashram->status;
+    }
+    else if ((address & 0x1ffff) == 0x0000 && flashram->mode == FLASHRAM_MODE_READ_ARRAY) {
+        /* flashram MMIO read are not supported except for the "dummy" read @0x0000 done before DMA.
+         * returns a "dummy" value. */
+        *value = 0;
+    }
+    else {
+        /* other accesses are not implemented */
+        DebugMessage(M64MSG_WARNING, "unknown Flashram read IO (mode=%x) @%08x", flashram->mode, address);
+    }
 }
 
-void write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+void write_flashram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
     struct flashram* flashram = (struct flashram*)opaque;
 
-    flashram_command(flashram, value & mask);
+    if ((address & 0x1ffff) == 0x00000 && flashram->mode == FLASHRAM_MODE_STATUS) {
+        /* clear/set Status register */
+        flashram->status = (value & mask) & 0xff;
+    }
+    else if ((address & 0x1ffff) == 0x10000) {
+        /* set command */
+        flashram_command(flashram, value & mask);
+    }
+    else {
+        /* other accesses are not implemented */
+        DebugMessage(M64MSG_WARNING, "unknown Flashram write IO (mode=%x) @%08x <- %08x & %08x", flashram->mode, address, value, mask);
+    }
 }
 
 
@@ -147,23 +184,34 @@ unsigned int flashram_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr,
     struct flashram* flashram = (struct flashram*)opaque;
     const uint8_t* mem = flashram->istorage->data(flashram->storage);
 
-    switch (flashram->mode)
-    {
-    case FLASHRAM_MODE_STATUS:
-        ((uint32_t*)dram)[dram_addr/4+0] = flashram->status[0];
-        ((uint32_t*)dram)[dram_addr/4+1] = flashram->status[1];
-        break;
+    if ((cart_addr & 0x1ffff) == 0x00000 && length == 8 && flashram->mode == FLASHRAM_MODE_READ_SILICON_ID) {
+        /* read Silicon ID using DMA */
+        ((uint32_t*)dram)[dram_addr/4+0] = flashram->silicon_id[0];
+        ((uint32_t*)dram)[dram_addr/4+1] = flashram->silicon_id[1];
+    }
+    else if ((cart_addr & 0x1ffff) < 0x10000 && flashram->mode == FLASHRAM_MODE_READ_ARRAY) {
 
-    case FLASHRAM_MODE_READ:
-        cart_addr = (cart_addr & 0xffff) * 2; // ???
+        /* adjust flashram address before starting DMA. */
+        if (flashram->silicon_id[1] == MX29L1100_ID
+            || flashram->silicon_id[1] == MX29L0000_ID
+            || flashram->silicon_id[1] == MX29L0001_ID) {
+            /* "old" flash needs special address adjusting */
+            cart_addr = (cart_addr & 0xffff) * 2;
+        }
+        else {
+            /* "new" flash doesn't require special address adjusting at DMA start. */
+            cart_addr &= 0xffff;
+        }
 
+        /* do actual DMA */
         for(i = 0; i < length; ++i) {
             dram[(dram_addr+i)^S8] = mem[(cart_addr+i)^S8];
         }
-        break;
-    default:
-        DebugMessage(M64MSG_WARNING, "unknown dma_read_flashram: %x", flashram->mode);
-        break;
+    }
+    else {
+        /* other accesses are not implemented */
+        DebugMessage(M64MSG_WARNING, "unknown Flashram DMA Write (mode=%x) @%08x <- %08x length=%08x",
+            flashram->mode, dram_addr, cart_addr, length);
     }
 
     return /* length / 8 */0x1000;
@@ -172,15 +220,18 @@ unsigned int flashram_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr,
 unsigned int flashram_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length)
 {
     struct flashram* flashram = (struct flashram*)opaque;
+    unsigned int i;
 
-    switch (flashram->mode)
-    {
-    case FLASHRAM_MODE_WRITE:
-        flashram->write_pointer = dram_addr;
-        break;
-    default:
-        DebugMessage(M64MSG_ERROR, "unknown dma_write_flashram: %x", flashram->mode);
-        break;
+    if ((cart_addr & 0x1ffff) == 0x00000 && length == 128 && flashram->mode == FLASHRAM_MODE_PAGE_PROGRAM) {
+        /* load page buf using DMA */
+        for(i = 0; i < length; ++i) {
+            flashram->page_buf[i] = dram[(dram_addr+i)^S8];
+        }
+    }
+    else {
+        /* other accesses are not implemented */
+        DebugMessage(M64MSG_WARNING, "unknown Flashram DMA Read (mode=%x) @%08x <- %08x length=%08x",
+            flashram->mode, cart_addr, dram_addr, length);
     }
 
     return /* length / 8 */0x1000;

--- a/src/device/cart/flashram.h
+++ b/src/device/cart/flashram.h
@@ -29,8 +29,12 @@ struct storage_backend_interface;
 
 enum { FLASHRAM_SIZE = 0x20000 };
 
-/* flashram manufacture and device code */
+enum { FLASHRAM_TYPE_ID = 0x11118001 };
+
+/* flashram manufacturer and device code */
 enum {
+    MX29L0000_ID = 0x00c20000,
+    MX29L0001_ID = 0x00c20001,
     MX29L1100_ID = 0x00c2001e,
     MX29L1101_ID = 0x00c2001d,
     MN63F8MPN_ID = 0x003200f1,
@@ -39,37 +43,37 @@ enum {
 
 enum flashram_mode
 {
-    FLASHRAM_MODE_NOPES = 0,
-    FLASHRAM_MODE_ERASE,
-    FLASHRAM_MODE_WRITE,
-    FLASHRAM_MODE_READ,
-    FLASHRAM_MODE_STATUS
+    FLASHRAM_MODE_READ_ARRAY,
+    FLASHRAM_MODE_READ_SILICON_ID,
+    FLASHRAM_MODE_STATUS,
+    FLASHRAM_MODE_SECTOR_ERASE,
+    FLASHRAM_MODE_CHIP_ERASE,
+    FLASHRAM_MODE_PAGE_PROGRAM
 };
 
 struct flashram
 {
+    uint8_t page_buf[128];
+    uint32_t silicon_id[2];
+    uint32_t status; // supposedly only 8-bit
+    uint16_t erase_page;
     enum flashram_mode mode;
-    uint32_t status[2];
-    unsigned int erase_offset;
-    unsigned int write_pointer;
 
     void* storage;
     const struct storage_backend_interface* istorage;
-    const uint8_t* dram;
 };
 
 void init_flashram(struct flashram* flashram,
-                   uint32_t flashram_type,
+                   uint32_t flashram_id,
                    void* storage,
-                   const struct storage_backend_interface* istorage,
-                   const uint8_t* dram);
+                   const struct storage_backend_interface* istorage);
 
 void poweron_flashram(struct flashram* flashram);
 
 void format_flashram(uint8_t* flash);
 
-void read_flashram_status(void* opaque, uint32_t address, uint32_t* value);
-void write_flashram_command(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+void read_flashram(void* opaque, uint32_t address, uint32_t* value);
+void write_flashram(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
 
 unsigned int flashram_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
 unsigned int flashram_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);


### PR DESCRIPTION
By combining the following sources :
- reverse engineering of Majoras Mask flashram functions [1]
- @sanni's cart reader [2]
- and MX29L1611 datasheet ("close enough" flash memory from Macronix)

I was able to figure a better model for flashram than what we currently
have. As this new modeling of flashram doesn't match one-to-one with
old model, meaning it may possibly "break" older savestate (in fact it may break if the savestate has been taken during some flashram operation, otherwise it should be relatively safe),
I had to bump savestate version.

[1] pending PR in https://github.com/n64decomp/majora/
[2] https://github.com/sanni/cartreader/blob/master/Cart_Reader/N64.ino


I've tested mostly Majora's Mask, Jet Force Gemini and Derby Stallion and it seems to work OK.
If you want to test also, **be sure to backup your fla saves first**, so that you won't loose them, in case of a bug...

cc: @sanni. This work may (or may not) interest you. Feel free to comment or give suggestions if you want :)