### PR TITLE
CountPerOp=1 for Battle for Naboo

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -14620,6 +14620,7 @@ CRC=EAE6ACE2 020B4384
 Players=1
 SaveType=Eeprom 4KB
 Rumble=Yes
+CountPerOp=1
 
 [3CB88B934572E7520F35E5458798775B]
 GoodName=Star Wars Episode I - Battle for Naboo (U) [!]
@@ -14627,6 +14628,7 @@ CRC=3D02989B D4A381E2
 Players=1
 SaveType=Eeprom 4KB
 Rumble=Yes
+CountPerOp=1
 
 [B4724120C269A1DC86991D34B1561F3D]
 GoodName=Star Wars Episode I - Battle for Naboo (U) [b1]


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-core/issues/570

I went to play this game today, it froze (sound but a black screen) just when about to start the first level. Settings CountPerOp=1 fixed the issue, it also happens to fix https://github.com/mupen64plus/mupen64plus-core/issues/570, which is an old reported issue