### PR TITLE
CountPerOp=1 for Top Gear Overdrive/Hyperbike

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -15675,6 +15675,7 @@ Players=2
 SaveType=None
 Mempak=Yes
 Rumble=Yes
+CountPerOp=1
 
 [0072538EF925645DB310F8E23A480B89]
 GoodName=Top Gear Hyper Bike (E) [!]
@@ -15683,6 +15684,7 @@ Players=2
 SaveType=None
 Mempak=Yes
 Rumble=Yes
+CountPerOp=1
 
 [561B438F6E8240BEF1DAEB36AAE72675]
 GoodName=Top Gear Hyper Bike (E) [b1]
@@ -15696,6 +15698,7 @@ Players=2
 SaveType=None
 Mempak=Yes
 Rumble=Yes
+CountPerOp=1
 
 [7258F4AB367B025C95A4F476C461E717]
 GoodName=Top Gear Hyper Bike (U) [!]
@@ -15704,6 +15707,7 @@ Players=2
 SaveType=None
 Mempak=Yes
 Rumble=Yes
+CountPerOp=1
 
 [6C65A252F227AEF18DF2DD3CE04CC821]
 GoodName=Top Gear Overdrive (E) [!]
@@ -15711,6 +15715,7 @@ CRC=D09BA538 1C1A5489
 Players=4
 SaveType=Eeprom 4KB
 Rumble=Yes
+CountPerOp=1
 
 [11D6FFF288DE1BD61CCBD7CCA0C4A97B]
 GoodName=Top Gear Overdrive (E) [h1C]
@@ -15723,6 +15728,7 @@ CRC=0578F24F 9175BF17
 Players=4
 SaveType=Eeprom 4KB
 Rumble=Yes
+CountPerOp=1
 
 [8C0F46FEF9A6034FCF0B7D6952FFEC53]
 GoodName=Top Gear Overdrive (J) [b1]
@@ -15735,6 +15741,7 @@ CRC=D741CD80 ACA9B912
 Players=4
 SaveType=Eeprom 4KB
 Rumble=Yes
+CountPerOp=1
 
 [773FD446DA7F4E392907505053BF2A42]
 GoodName=Top Gear Overdrive (U) [o1]


### PR DESCRIPTION
These games perform much better with CountPerOp=1, it becomes very apparent if you listen to the audio during a race in both games (very choppy with CountPerOp=2)

Both games by the same developer, they behave very similarly.