### PR TITLE
Removed "not officially supported" for ARM

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -121,7 +121,6 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
         CFLAGS += -mfpu=vfp -mfloat-abi=softfp
       endif
     endif
-    $(warning Architecture "$(HOST_CPU)" not officially supported.)
   endif
 endif
 ifneq ("$(filter mips,$(HOST_CPU))","")


### PR DESCRIPTION
I think we can safely remove this warning now - ARM is a well established target for mupen64plus. i note the same warning isn't there for aarch64.