### PR TITLE
Enable FBInfo for CPU-RDP rendering

### DIFF
--- a/src/device/rcp/rdp/rdp_core.c
+++ b/src/device/rcp/rdp/rdp_core.c
@@ -114,7 +114,9 @@ void write_dpc_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mas
         dp->dpc_regs[DPC_CURRENT_REG] = dp->dpc_regs[DPC_START_REG];
         break;
     case DPC_END_REG:
+        unprotect_framebuffers(&dp->fb);
         gfx.processRDPList();
+        protect_framebuffers(&dp->fb);
         signal_rcp_interrupt(dp->mi, MI_INTR_DP);
         break;
     }


### PR DESCRIPTION
Some games bypass the RSP, and use the CPU to send commands directly to the RDP. FlappyBird64 is an example. The current unprotect/protect FB code only occurs in RSP rendering, so FBInfo doesn't work with these types of games.

This change fixes that and allows FBInfo to work with FlappyBird64, which is required for it to render properly in GLideN64