### PR TITLE
Mask DRAM address in PI DMA

### DIFF
--- a/src/device/rcp/pi/pi_controller.c
+++ b/src/device/rcp/pi/pi_controller.c
@@ -54,7 +54,7 @@ static void dma_pi_read(struct pi_controller* pi)
         return;
 
     uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] & ~UINT32_C(1);
-    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG];
+    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & 0xffffff;
     uint32_t length = (pi->regs[PI_RD_LEN_REG] & UINT32_C(0x00fffffe)) + 2;
     const uint8_t* dram = (uint8_t*)pi->ri->rdram->dram;
 
@@ -86,7 +86,7 @@ static void dma_pi_write(struct pi_controller* pi)
         return;
 
     uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] & ~UINT32_C(1);
-    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG];
+    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & 0xffffff;
     uint32_t length = (pi->regs[PI_WR_LEN_REG] & UINT32_C(0x00fffffe)) + 2;
     uint8_t* dram = (uint8_t*)pi->ri->rdram->dram;
 


### PR DESCRIPTION
Just like in the RSP DMA:

https://github.com/mupen64plus/mupen64plus-core/blob/master/src/device/rcp/rsp/rsp_core.c#L49

The dram address should be masked, I came across one of the PeterLemon test ROMs that attempts a PI DMA using an address that needs to be masked. I believe the reason for this is that the memory can be accessed via cached/un-cached paths, but the resulting address access should be the same