### PR TITLE
NOT mempak checksum when pak is not present

### DIFF
--- a/src/device/controllers/game_controller.c
+++ b/src/device/controllers/game_controller.c
@@ -120,6 +120,7 @@ static void pak_read_block(struct game_controller* cont,
         cont->ipak->read(cont->pak, address, data, PAK_CHUNK_SIZE);
         *dcrc = pak_data_crc(data, PAK_CHUNK_SIZE);
     } else {
+        //NOT the CRC value when pak is not present
         *dcrc = ~pak_data_crc(data, PAK_CHUNK_SIZE);
     }
 }

--- a/src/device/controllers/game_controller.c
+++ b/src/device/controllers/game_controller.c
@@ -118,9 +118,10 @@ static void pak_read_block(struct game_controller* cont,
 
     if (cont->ipak != NULL) {
         cont->ipak->read(cont->pak, address, data, PAK_CHUNK_SIZE);
+        *dcrc = pak_data_crc(data, PAK_CHUNK_SIZE);
+    } else {
+        *dcrc = ~pak_data_crc(data, PAK_CHUNK_SIZE);
     }
-
-    *dcrc = pak_data_crc(data, PAK_CHUNK_SIZE);
 }
 
 static void pak_write_block(struct game_controller* cont,
@@ -133,9 +134,10 @@ static void pak_write_block(struct game_controller* cont,
 
     if (cont->ipak != NULL) {
         cont->ipak->write(cont->pak, address, data, PAK_CHUNK_SIZE);
+        *dcrc = pak_data_crc(data, PAK_CHUNK_SIZE);
+    } else {
+        *dcrc = ~pak_data_crc(data, PAK_CHUNK_SIZE);
     }
-
-    *dcrc = pak_data_crc(data, PAK_CHUNK_SIZE);
 }
 
 


### PR DESCRIPTION
I was troubleshooting an issue with netplay raw input, and came across this discrepancy in the way mempak CRCs are calculated.

From http://hcs64.com/files/n64-hw.dox
> when something is not plugged into the
      mempack port, then the CRC is calculated the same way except the final
      8-bit result is NOT'd. You might wonder why there would even be a CRC
      when reading from the mempack port and nothing is plugged in.  Well
      basically when nothing is plugged in, data is still read, but it is not
      valid data. This data is usually all 0's. The data CRC algo is still
      calculated but the result is of course NOT'd to let you know that the
      data is erronous.

I have verified this behaviour against a "raw" controller using Raphnet's plugin