### PR TITLE
Allow frontends to manage SDL's lifetime

### DIFF
--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -51,6 +51,7 @@
 /* some local state variables */
 static int l_CoreInit = 0;
 static int l_ROMOpen = 0;
+static int l_CallerUsingSDL = 0;
 
 /* functions exported outside of libmupen64plus to front-end application */
 EXPORT m64p_error CALL CoreStartup(int APIVersion, const char *ConfigPath, const char *DataPath, void *Context,
@@ -59,6 +60,9 @@ EXPORT m64p_error CALL CoreStartup(int APIVersion, const char *ConfigPath, const
 {
     if (l_CoreInit)
         return M64ERR_ALREADY_INIT;
+
+    /* check wether the caller has already initialized SDL */
+    l_CallerUsingSDL = (SDL_WasInit(0) != 0);
 
     /* very first thing is to set the callback functions for debug info and state changing*/
     SetDebugCallback(DebugCallback, Context);
@@ -117,8 +121,9 @@ EXPORT m64p_error CALL CoreShutdown(void)
     workqueue_shutdown();
     savestates_deinit();
 
-    /* tell SDL to shut down */
-    SDL_Quit();
+    /* if the calling code is using SDL, don't shut it down */
+    if (!l_CallerUsingSDL)
+        SDL_Quit();
 
     /* deallocate base memory */
     release_mem_base(g_mem_base);


### PR DESCRIPTION
As already discussed at [mupen64plus-input-sdl#91](https://github.com/mupen64plus/mupen64plus-input-sdl/pull/91) it's currently not possible for the frontend to use SDL while Mupen64Plus is running. This is because `CoreShutdown` calls `SDL_Quit` resulting in segfaults if the frontend continues to call SDL functions.

SDL's documentation states that `SDL_InitSubsystem()` and `SDL_QuitSubsystem()` calls are reference counted (`SDL_Init()` is just an alias for `SDL_InitSubsystem()`). `SDL_Quit()` on the other hand does not care about the reference count and shuts everything down no matter what.

I added a check to `CoreShutdown` to only shutdown SDL if it wasn't already initialized at the time `CoreStartup()` was called. That way SDL cleanup is left to the frontend if it's using SDL. In any other case SDL is correctly shutdown by the core.