### PR TITLE
CountPerOp=3 for Wave Race 64 - Shindou Edition

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -17116,6 +17116,7 @@ Mempak=Yes
 GoodName=Wave Race 64 - Shindou Edition (J) (V1.2) [!]
 CRC=535DF3E2 609789F1
 Players=2
+CountPerOp=3
 SaveType=Eeprom 4KB
 Mempak=Yes
 Rumble=Yes


### PR DESCRIPTION
See https://github.com/loganmc10/m64p/issues/57. CountPerOp=3 is needed for the game to get past the Nintendo logo