### PR TITLE
Makefile: add missing "

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -723,7 +723,7 @@ targets:
 	@echo "    WARNFLAGS=flag == compiler warning levels (default: -Wall)"
 	@echo "    PIC=(1|0)      == Force enable/disable of position independent code"
 	@echo "    OSD=(1|0)      == Enable/disable build of OpenGL On-screen display"
-	@echo "    NETPLAY=1      == Enable netplay functionality, requires SDL2_net
+	@echo "    NETPLAY=1      == Enable netplay functionality, requires SDL2_net"
 	@echo "    NEW_DYNAREC=1  == Replace dynamic recompiler with Ari64's experimental dynarec"
 	@echo "    OPENCV=1       == Enable OpenCV support"
 	@echo "    POSTFIX=name   == String added to the name of the the build (default: '')"


### PR DESCRIPTION
This patch fixes:
```
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
make: *** [Makefile:726: targets] Error 1
```
when running `make`