### PR TITLE
Allow plugins to have a configuration GUI

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus-v2.0-Plugin-API.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-v2.0-Plugin-API.mediawiki
@@ -25,6 +25,14 @@ These functions are present in all of the plugins.
 <br />
 {| border="1"
 |Prototype
+|'''<tt>m64p_error PluginConfig(void)</tt>'''
+|-
+|Usage
+|This optional function opens a configuration GUI for the plugin
+|}
+<br />
+{| border="1"
+|Prototype
 |'''<tt>m64p_error PluginShutdown(void)</tt>'''
 |-
 |Requirements

--- a/src/api/m64p_common.h
+++ b/src/api/m64p_common.h
@@ -72,6 +72,17 @@ typedef m64p_error (*ptr_PluginStartup)(m64p_dynlib_handle, void *, void (*)(voi
 EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle, void *, void (*)(void *, int, const char *));
 #endif
 
+
+/* PluginConfig()
+ *
+ * This optional function opens a configuration GUI for the plugin
+ *
+*/
+typedef m64p_error (*ptr_PluginConfig)(void);
+#if defined(M64P_PLUGIN_PROTOTYPES) || defined(M64P_CORE_PROTOTYPES)
+EXPORT m64p_error CALL PluginConfig(void);
+#endif
+
 /* PluginShutdown()
  *
  * This function destroys data structures and releases memory allocated by


### PR DESCRIPTION
this patch modifies the spec to allow plugins to expose an optional `PluginConfig` function which can run a configuration GUI (like gliden64's glidenUI)