### PR TITLE
CountPerOp=1 for Smash

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -11268,6 +11268,7 @@ Status=3
 Players=4
 SaveType=SRAM
 Rumble=Yes
+CountPerOp=1
 
 [B2DF29627E0219A9C14605F46803C94C]
 GoodName=Nintendo All-Star! Dairantou Smash Brothers (J) [b1]
@@ -13890,6 +13891,15 @@ SaveType=None
 GoodName=Sitero Demo by Renderman (PD)
 CRC=9A6CF2F5 D5F365EE
 
+[5AAC6E652C5CF1E37A466AC0073E88CA]
+GoodName=SmashRemix0.9.4
+CRC=1B5AAD82 368B88C1
+Status=3
+Players=4
+SaveType=SRAM
+Rumble=Yes
+CountPerOp=1
+
 [B8D4B92E66A312708626B3216DE07A3A]
 GoodName=Snobow Kids (J) [!]
 CRC=84FC04FF B1253CE9
@@ -15062,6 +15072,7 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
+CountPerOp=1
 
 [7F18A06BB16A507E23F9DD636B7046A6]
 GoodName=Super Smash Bros. (A) [f1]
@@ -15082,6 +15093,7 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
+CountPerOp=1
 
 [4D37726FDFEC039CB36E2AAE65B9727D]
 GoodName=Super Smash Bros. (E) (M3) [b1]
@@ -15100,6 +15112,7 @@ Status=3
 SaveType=SRAM
 Players=4
 Rumble=Yes
+CountPerOp=1
 
 [508BE860974B75470851A2D25C0FCB36]
 GoodName=Super Smash Bros. (U) [b1]


### PR DESCRIPTION
See a discussion here for the benefits of CountPerOp=1 for Smash: http://forum.pj64-emu.com/showthread.php?t=8856

It decreases input latency and I guess puts it more in line with a console, Smash players are really serious about input latency.

Also included Smash Remix (https://github.com/JSsixtyfour/smashremix/releases) in the INI file