### PR TITLE
Add fixed count factor overclock

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -83,6 +83,7 @@ void init_device(struct device* dev,
     /* r4300 */
     unsigned int emumode,
     unsigned int count_per_op,
+    unsigned int enable_overclock,
     int no_compiled_jump,
     int randomize_interrupt,
     uint32_t start_address,
@@ -177,7 +178,7 @@ void init_device(struct device* dev,
     init_rdram(&dev->rdram, mem_base_u32(base, MM_RDRAM_DRAM), dram_size, &dev->r4300);
 
     init_r4300(&dev->r4300, &dev->mem, &dev->mi, &dev->rdram, interrupt_handlers,
-            emumode, count_per_op, no_compiled_jump, randomize_interrupt, start_address);
+            emumode, count_per_op, enable_overclock, no_compiled_jump, randomize_interrupt, start_address);
     init_rdp(&dev->dp, &dev->sp, &dev->mi, &dev->mem, &dev->rdram, &dev->r4300);
     init_rsp(&dev->sp, mem_base_u32(base, MM_RSP_MEM), &dev->mi, &dev->dp, &dev->ri);
     init_ai(&dev->ai, &dev->mi, &dev->ri, &dev->vi, aout, iaout);

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -118,6 +118,7 @@ void init_device(struct device* dev,
     /* r4300 */
     unsigned int emumode,
     unsigned int count_per_op,
+    unsigned int enable_overclock,
     int no_compiled_jump,
     int randomize_interrupt,
     uint32_t start_address,

--- a/src/device/r4300/cp0.c
+++ b/src/device/r4300/cp0.c
@@ -36,9 +36,10 @@
 #endif
 
 /* global functions */
-void init_cp0(struct cp0* cp0, unsigned int count_per_op, struct new_dynarec_hot_state* new_dynarec_hot_state, const struct interrupt_handler* interrupt_handlers)
+void init_cp0(struct cp0* cp0, unsigned int count_per_op, unsigned int enable_overclock, struct new_dynarec_hot_state* new_dynarec_hot_state, const struct interrupt_handler* interrupt_handlers)
 {
     cp0->count_per_op = count_per_op;
+    cp0->enable_overclock = enable_overclock;
 #ifdef NEW_DYNAREC
     cp0->new_dynarec_hot_state = new_dynarec_hot_state;
 #endif
@@ -138,7 +139,13 @@ void cp0_update_count(struct r4300_core* r4300)
     if (r4300->emumode != EMUMODE_DYNAREC)
     {
 #endif
-        uint32_t count = ((*r4300_pc(r4300) - cp0->last_addr) >> 2) * cp0->count_per_op;
+        uint32_t count;
+        if (!cp0->enable_overclock) {
+            count = ((*r4300_pc(r4300) - cp0->last_addr) >> 2) * cp0->count_per_op;
+        }
+        else {
+            count = 2;
+        }
         cp0_regs[CP0_COUNT_REG] += count;
         *r4300_cp0_cycle_count(cp0) += count;
         cp0->last_addr = *r4300_pc(r4300);

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -200,6 +200,7 @@ struct cp0
 
     uint32_t last_addr;
     unsigned int count_per_op;
+    unsigned int enable_overclock;
 
     struct tlb tlb;
 };
@@ -214,7 +215,7 @@ struct cp0
     offsetof(struct new_dynarec_hot_state, cp0_regs))
 #endif
 
-void init_cp0(struct cp0* cp0, unsigned int count_per_op, struct new_dynarec_hot_state* new_dynarec_hot_state, const struct interrupt_handler* interrupt_handlers);
+void init_cp0(struct cp0* cp0, unsigned int count_per_op, unsigned int enable_overclock, struct new_dynarec_hot_state* new_dynarec_hot_state, const struct interrupt_handler* interrupt_handlers);
 void poweron_cp0(struct cp0* cp0);
 
 uint32_t* r4300_cp0_regs(struct cp0* cp0);

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -5668,7 +5668,11 @@ static void do_cc(int i,signed char i_regmap[],int *adj,int addr,int taken,int i
     emit_jmp(0);
   }
   else if(*adj==0||invert) {
-    emit_addimm_and_set_flags(CLOCK_DIVIDER*(count+2),HOST_CCREG);
+    if(!g_dev.r4300.cp0.enable_overclock) {
+      emit_addimm_and_set_flags(CLOCK_DIVIDER*(count+2),HOST_CCREG);
+    } else {
+      emit_addimm_and_set_flags(2,HOST_CCREG);
+    }
     jaddr=(intptr_t)out;
     emit_jns(0);
   }

--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -41,7 +41,7 @@
 #include <time.h>
 
 void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers,
-    unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int randomize_interrupt, uint32_t start_address)
+    unsigned int emumode, unsigned int count_per_op, unsigned int enable_overclock, int no_compiled_jump, int randomize_interrupt, uint32_t start_address)
 {
     struct new_dynarec_hot_state* new_dynarec_hot_state =
 #ifdef NEW_DYNAREC
@@ -51,7 +51,7 @@ void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controll
 #endif
 
     r4300->emumode = emumode;
-    init_cp0(&r4300->cp0, count_per_op, new_dynarec_hot_state, interrupt_handlers);
+    init_cp0(&r4300->cp0, count_per_op, enable_overclock, new_dynarec_hot_state, interrupt_handlers);
     init_cp1(&r4300->cp1, new_dynarec_hot_state);
 
 #ifndef NEW_DYNAREC

--- a/src/device/r4300/r4300_core.h
+++ b/src/device/r4300/r4300_core.h
@@ -211,7 +211,7 @@ struct r4300_core
     offsetof(struct new_dynarec_hot_state, regs))
 #endif
 
-void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, int no_compiled_jump, int randomize_interrupt, uint32_t start_address);
+void init_r4300(struct r4300_core* r4300, struct memory* mem, struct mi_controller* mi, struct rdram* rdram, const struct interrupt_handler* interrupt_handlers, unsigned int emumode, unsigned int count_per_op, unsigned int enable_overclock, int no_compiled_jump, int randomize_interrupt, uint32_t start_address);
 void poweron_r4300(struct r4300_core* r4300);
 
 void run_r4300(struct r4300_core* r4300);

--- a/src/device/r4300/x86/dynarec.c
+++ b/src/device/r4300/x86/dynarec.c
@@ -123,11 +123,18 @@ static void gencheck_cop1_unusable(struct r4300_core* r4300)
 static void gencp0_update_count(struct r4300_core* r4300, unsigned int addr)
 {
 #if !defined(COMPARE_CORE) && !defined(DBG)
-    mov_reg32_imm32(EAX, addr);
-    sub_reg32_m32(EAX, (unsigned int*)(&r4300->cp0.last_addr));
-    shr_reg32_imm8(EAX, 2);
-    mov_reg32_m32(EDX, &r4300->cp0.count_per_op);
-    mul_reg32(EDX);
+    if (!r4300->cp0.enable_overclock)
+    {
+        mov_reg32_imm32(EAX, addr);
+        sub_reg32_m32(EAX, (unsigned int*)(&r4300->cp0.last_addr));
+        shr_reg32_imm8(EAX, 2);
+        mov_reg32_m32(EDX, &r4300->cp0.count_per_op);
+        mul_reg32(EDX);
+    }
+    else
+    {
+        mov_reg32_imm32(EAX, 2);
+    }
     add_m32_reg32((unsigned int*)(&r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]), EAX);
     add_m32_reg32((unsigned int*)r4300_cp0_cycle_count(&r4300->cp0), EAX);
 #else

--- a/src/device/r4300/x86_64/dynarec.c
+++ b/src/device/r4300/x86_64/dynarec.c
@@ -134,11 +134,18 @@ static void gencheck_cop1_unusable(struct r4300_core* r4300)
 static void gencp0_update_count(struct r4300_core* r4300, unsigned int addr)
 {
 #if !defined(COMPARE_CORE) && !defined(DBG)
-    mov_reg32_imm32(EAX, addr);
-    sub_xreg32_m32rel(EAX, (unsigned int*)(&r4300->cp0.last_addr));
-    shr_reg32_imm8(EAX, 2);
-    mov_xreg32_m32rel(EDX, (void*)&r4300->cp0.count_per_op);
-    mul_reg32(EDX);
+    if (!r4300->cp0.enable_overclock)
+    {
+        mov_reg32_imm32(EAX, addr);
+        sub_xreg32_m32rel(EAX, (unsigned int*)(&r4300->cp0.last_addr));
+        shr_reg32_imm8(EAX, 2);
+        mov_xreg32_m32rel(EDX, (void*)&r4300->cp0.count_per_op);
+        mul_reg32(EDX);
+    }
+    else
+    {
+        mov_reg32_imm32(EAX, 2);
+    }
     add_m32rel_xreg32((unsigned int*)(&r4300_cp0_regs(&r4300->cp0)[CP0_COUNT_REG]), EAX);
     add_m32rel_xreg32((unsigned int*)(r4300_cp0_cycle_count(&r4300->cp0)), EAX);
 #else

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -308,6 +308,7 @@ int main_set_core_defaults(void)
     ConfigSetDefaultString(g_CoreConfig, "SaveSRAMPath", "", "Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used");
     ConfigSetDefaultString(g_CoreConfig, "SharedDataPath", "", "Path to a directory to search when looking for shared data files");
     ConfigSetDefaultInt(g_CoreConfig, "CountPerOp", 0, "Force number of cycles per emulated instruction");
+    ConfigSetDefaultInt(g_CoreConfig, "EnableOverclock", 0, "Override cycle calculation with fixed count factor (overclock)");
     ConfigSetDefaultBool(g_CoreConfig, "RandomizeInterrupt", 1, "Randomize PI/SI Interrupt Timing");
     ConfigSetDefaultInt(g_CoreConfig, "SiDmaDuration", -1, "Duration of SI DMA (-1: use per game settings)");
     ConfigSetDefaultString(g_CoreConfig, "GbCameraVideoCaptureBackend1", DEFAULT_VIDEO_CAPTURE_BACKEND, "Gameboy Camera Video Capture backend");
@@ -1304,6 +1305,7 @@ m64p_error main_run(void)
     size_t i, k;
     size_t rdram_size;
     uint32_t count_per_op;
+    uint32_t enable_overclock;
     uint32_t emumode;
     uint32_t disable_extra_mem;
     int32_t si_dma_duration;
@@ -1338,6 +1340,7 @@ m64p_error main_run(void)
     //We disable any randomness for netplay
     randomize_interrupt = !netplay_is_init() ? ConfigGetParamBool(g_CoreConfig, "RandomizeInterrupt") : 0;
     count_per_op = ConfigGetParamInt(g_CoreConfig, "CountPerOp");
+    enable_overclock = ConfigGetParamInt(g_CoreConfig, "EnableOverclock");
 
     if (ROM_PARAMS.disableextramem)
         disable_extra_mem = ROM_PARAMS.disableextramem;
@@ -1355,7 +1358,7 @@ m64p_error main_run(void)
         si_dma_duration = ROM_PARAMS.sidmaduration;
 
     //During netplay, player 1 is the source of truth for these settings
-    netplay_sync_settings(&count_per_op, &disable_extra_mem, &si_dma_duration, &emumode, &no_compiled_jump);
+    netplay_sync_settings(&count_per_op, &enable_overclock, &disable_extra_mem, &si_dma_duration, &emumode, &no_compiled_jump);
 
     cheat_add_hacks(&g_cheat_ctx, ROM_PARAMS.cheats);
 
@@ -1573,6 +1576,7 @@ m64p_error main_run(void)
                 g_mem_base,
                 emumode,
                 count_per_op,
+                enable_overclock,
                 no_compiled_jump,
                 randomize_interrupt,
                 g_start_address,

--- a/src/main/netplay.c
+++ b/src/main/netplay.c
@@ -483,23 +483,24 @@ file_status_t netplay_read_storage(const char *filename, void *data, size_t size
     return ret;
 }
 
-void netplay_sync_settings(uint32_t *count_per_op, uint32_t *disable_extra_mem, int32_t *si_dma_duration, uint32_t *emumode, int32_t *no_compiled_jump)
+void netplay_sync_settings(uint32_t *count_per_op, uint32_t *enable_overclock, uint32_t *disable_extra_mem, int32_t *si_dma_duration, uint32_t *emumode, int32_t *no_compiled_jump)
 {
     if (!netplay_is_init())
         return;
 
-    char output_data[21];
+    char output_data[25];
     uint8_t request;
     if (l_netplay_control[0] != -1) //player 1 is the source of truth for settings
     {
         request = TCP_SEND_SETTINGS;
         memcpy(&output_data[0], &request, 1);
         SDLNet_Write32(*count_per_op, &output_data[1]);
-        SDLNet_Write32(*disable_extra_mem, &output_data[5]);
-        SDLNet_Write32(*si_dma_duration, &output_data[9]);
-        SDLNet_Write32(*emumode, &output_data[13]);
-        SDLNet_Write32(*no_compiled_jump, &output_data[17]);
-        SDLNet_TCP_Send(l_tcpSocket, &output_data[0], 21);
+        SDLNet_Write32(*enable_overclock, &output_data[5]);
+        SDLNet_Write32(*disable_extra_mem, &output_data[9]);
+        SDLNet_Write32(*si_dma_duration, &output_data[14]);
+        SDLNet_Write32(*emumode, &output_data[17]);
+        SDLNet_Write32(*no_compiled_jump, &output_data[21]);
+        SDLNet_TCP_Send(l_tcpSocket, &output_data[0], 25);
     }
     else
     {
@@ -510,10 +511,11 @@ void netplay_sync_settings(uint32_t *count_per_op, uint32_t *disable_extra_mem, 
         while (recv < 20)
             recv += SDLNet_TCP_Recv(l_tcpSocket, &output_data[recv], 20 - recv);
         *count_per_op = SDLNet_Read32(&output_data[0]);
-        *disable_extra_mem = SDLNet_Read32(&output_data[4]);
-        *si_dma_duration = SDLNet_Read32(&output_data[8]);
-        *emumode = SDLNet_Read32(&output_data[12]);
-        *no_compiled_jump = SDLNet_Read32(&output_data[16]);
+        *enable_overclock = SDLNet_Read32(&output_data[4]);
+        *disable_extra_mem = SDLNet_Read32(&output_data[8]);
+        *si_dma_duration = SDLNet_Read32(&output_data[12]);
+        *emumode = SDLNet_Read32(&output_data[16]);
+        *no_compiled_jump = SDLNet_Read32(&output_data[20]);
     }
 }
 

--- a/src/main/netplay.h
+++ b/src/main/netplay.h
@@ -47,7 +47,7 @@ void netplay_set_controller(uint8_t player);
 int netplay_is_init();
 int netplay_get_controller(uint8_t player);
 file_status_t netplay_read_storage(const char *filename, void *data, size_t size);
-void netplay_sync_settings(uint32_t *count_per_op, uint32_t *disable_extra_mem, int32_t *si_dma_duration, uint32_t *emumode, int32_t *no_compiled_jump);
+void netplay_sync_settings(uint32_t *count_per_op, uint32_t *enable_overclock, uint32_t *disable_extra_mem, int32_t *si_dma_duration, uint32_t *emumode, int32_t *no_compiled_jump);
 void netplay_check_sync(struct cp0* cp0);
 int netplay_next_controller();
 void netplay_read_registration(struct controller_input_compat* cin_compats);


### PR DESCRIPTION
This hack applies a constant for count register calculation (all core), much like the [recently added overclock to the libretro fork](https://github.com/libretro/mupen64plus-libretro-nx/pull/236).

This improves performance in many titles such as GoldenEye, Perfect Dark, Conker's Bad Fur Day, Indiana Jones, Re-Volt.

The overclock is mostly untested apart from the mentioned titles.