### PR TITLE
Just stop frontend from enabling cheats during netplay

### DIFF
--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -359,6 +359,8 @@ EXPORT m64p_error CALL CoreAddCheat(const char *CheatName, m64p_cheat_code *Code
 {
     if (!l_CoreInit)
         return M64ERR_NOT_INIT;
+    if (netplay_is_init())
+        return M64ERR_INVALID_STATE;
     if (CheatName == NULL || CodeList == NULL)
         return M64ERR_INPUT_ASSERT;
     if (strlen(CheatName) < 1 || NumCodes < 1)
@@ -374,6 +376,8 @@ EXPORT m64p_error CALL CoreCheatEnabled(const char *CheatName, int Enabled)
 {
     if (!l_CoreInit)
         return M64ERR_NOT_INIT;
+    if (netplay_is_init())
+        return M64ERR_INVALID_STATE;
     if (CheatName == NULL)
         return M64ERR_INPUT_ASSERT;
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -890,9 +890,6 @@ static void apply_speed_limiter(void)
 /* TODO: make a GameShark module and move that there */
 static void gs_apply_cheats(struct cheat_ctx* ctx)
 {
-    if (netplay_is_init())
-        return;
-
     struct r4300_core* r4300 = &g_dev.r4300;
 
     if (g_gs_vi_counter < 60)


### PR DESCRIPTION
The current code blocks all cheats during netplay. This also includes hacks from mupen64plus.ini . mupen64plus.ini currently includes a hack to fix Mario Kart multiplayer timing.

This revision just blocks the frontend from enabling cheats, but allows hacks included in mupen64plus.ini to be applied. This is OK since it won't cause desyncs (every client will apply the same hack).