### PR TITLE
Clean up netplay linked list

### DIFF
--- a/src/main/netplay.c
+++ b/src/main/netplay.c
@@ -137,6 +137,18 @@ m64p_error netplay_stop()
         return M64ERR_INVALID_STATE;
     else
     {
+        for (int i = 0; i < 4; ++i)
+        {
+            struct netplay_event* current = l_cin_compats[i].event_first;
+            struct netplay_event* next;
+            while (current != NULL)
+            {
+                next = current->next;
+                free(current);
+                current = next;
+            }
+        }
+
         char output_data[5];
         output_data[0] = TCP_DISCONNECT_NOTICE;
         SDLNet_Write32(l_reg_id, &output_data[1]);


### PR DESCRIPTION
When I wrote the netplay code I neglected to clean up the linked list used to store the local input buffer.

This just frees any items in the linked list when netplay is closed