### PR TITLE
Allow 64DD disks to boot without N64 cart

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -32,6 +32,7 @@
 #include "rcp/rsp/rsp_core.h"
 #include "rcp/si/si_controller.h"
 #include "rcp/vi/vi_controller.h"
+#include "main/rom.h"
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof((x)[0]))
 
@@ -190,19 +191,10 @@ void init_device(struct device* dev,
     init_si(&dev->si, si_dma_duration, &dev->mi, &dev->pif, &dev->ri);
     init_vi(&dev->vi, vi_clock, expected_refresh_rate, &dev->mi, &dev->dp);
 
-    /* FIXME: should boot on cart, unless only a disk is present, but having no cart is not yet supported by ui/core,
-     * so use another way of selecting boot device:
-     * use CART unless DD is plugged and the plugged CART is not a combo media (cart+disk).
-     */
-    uint8_t media = *((uint8_t*)mem_base_u32(base, MM_CART_ROM) + (0x3b ^ S8));
-    uint32_t rom_base = (dd_rom_size > 0 && media != 'C')
-        ? MM_DD_ROM
-        : MM_CART_ROM;
-
     init_pif(&dev->pif,
         (uint8_t*)mem_base_u32(base, MM_PIF_MEM),
         jbds, ijbds,
-        (uint8_t*)mem_base_u32(base, rom_base) + 0x40,
+        (uint8_t*)mem_base_u32(base, g_rom_base) + 0x40,
         &dev->r4300,
         &dev->si);
 

--- a/src/device/pif/bootrom_hle.c
+++ b/src/device/pif/bootrom_hle.c
@@ -33,6 +33,7 @@
 #include "device/rcp/si/si_controller.h"
 #include "device/rcp/vi/vi_controller.h"
 #include "main/rom.h"
+#include "main/main.h"
 
 static unsigned int get_tv_type(void)
 {
@@ -109,7 +110,7 @@ void pif_bootrom_hle_execute(struct r4300_core* r4300)
     /* configure ROM access
      * XXX: we skip the first temporary configuration */
     uint32_t rom_base = (rom_type == 0) ? MM_CART_ROM : MM_DD_ROM;
-    r4300_read_aligned_word(r4300, R4300_KSEG1 + rom_base, &bsd_dom1_config);
+    r4300_read_aligned_word(r4300, R4300_KSEG1 + g_rom_base, &bsd_dom1_config);
     r4300_write_aligned_word(r4300, R4300_KSEG1 + MM_PI_REGS + 4*PI_BSD_DOM1_LAT_REG, (bsd_dom1_config      ) & 0xff, ~UINT32_C(0));
     r4300_write_aligned_word(r4300, R4300_KSEG1 + MM_PI_REGS + 4*PI_BSD_DOM1_PWD_REG, (bsd_dom1_config >>  8) & 0xff, ~UINT32_C(0));
     r4300_write_aligned_word(r4300, R4300_KSEG1 + MM_PI_REGS + 4*PI_BSD_DOM1_PGS_REG, (bsd_dom1_config >> 16) & 0x0f, ~UINT32_C(0));

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1421,7 +1421,24 @@ m64p_error main_run(void)
     load_dd_rom((uint8_t*)mem_base_u32(g_mem_base, MM_DD_ROM), &dd_rom_size);
     if (dd_rom_size > 0) {
         dd_rtc_iclock = &g_iclock_ctime_plus_delta;
-        load_dd_disk(&dd_disk, &dd_idisk);
+
+        if (ROM_PARAMS.is_dd_disk)
+        {
+            dd_disk.data = g_dd_disk;
+            dd_disk.size = g_dd_disk_size;
+
+            // TODO, split load_dd_disk into seperate functions,
+            // and use one of those here!
+            dd_idisk = &g_ifile_storage_dd_sdk_dump;
+            uint8_t* buffer = malloc(MAME_FORMAT_DUMP_SIZE);
+            dd_convert_to_mame(buffer, dd_disk.data);
+            dd_disk.data = buffer;
+            dd_disk.size = MAME_FORMAT_DUMP_SIZE;
+        }
+        else
+        {
+            load_dd_disk(&dd_disk, &dd_idisk);
+        }
     }
 
     /* setup pif channel devices */

--- a/src/main/rom.h
+++ b/src/main/rom.h
@@ -42,6 +42,10 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size);
 m64p_error close_rom(void);
 
 extern int g_rom_size;
+extern int g_rom_base;
+
+extern void* g_dd_disk;
+extern int g_dd_disk_size;
 
 typedef struct _rom_params
 {
@@ -51,6 +55,7 @@ typedef struct _rom_params
    unsigned char countperop;
    int disableextramem;
    unsigned int sidmaduration;
+   unsigned int is_dd_disk;
 } rom_params;
 
 extern m64p_rom_header   ROM_HEADER;

--- a/src/plugin/plugin.c
+++ b/src/plugin/plugin.c
@@ -228,25 +228,8 @@ static m64p_error plugin_connect_gfx(m64p_dynlib_handle plugin_handle)
 
 static m64p_error plugin_start_gfx(void)
 {
-    uint8_t media = *((uint8_t*)mem_base_u32(g_mem_base, MM_CART_ROM) + (0x3b ^ S8));
-
-    /* Here we feed 64DD IPL ROM header to GFX plugin if 64DD is present.
-     * We use g_media_loader.get_dd_rom to detect 64DD presence
-     * instead of g_dev because the latter is not yet initialized at plugin_start time */
-    /* XXX: Not sure it is the best way to convey which game is being played to the GFX plugin
-     * as 64DD IPL is the same for all 64DD games... */
-    char* dd_ipl_rom_filename = (g_media_loader.get_dd_rom == NULL)
-        ? NULL
-        : g_media_loader.get_dd_rom(g_media_loader.cb_data);
-
-    uint32_t rom_base = (dd_ipl_rom_filename != NULL && strlen(dd_ipl_rom_filename) != 0 && media != 'C')
-        ? MM_DD_ROM
-        : MM_CART_ROM;
-
-    free(dd_ipl_rom_filename);
-
     /* fill in the GFX_INFO data structure */
-    gfx_info.HEADER = (unsigned char *)mem_base_u32(g_mem_base, rom_base);
+    gfx_info.HEADER = (unsigned char *)mem_base_u32(g_mem_base, g_rom_base);
     gfx_info.RDRAM = (unsigned char *)mem_base_u32(g_mem_base, MM_RDRAM_DRAM);
     gfx_info.DMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM);
     gfx_info.IMEM = (unsigned char *)mem_base_u32(g_mem_base, MM_RSP_MEM + 0x1000);


### PR DESCRIPTION
this PR is still WIP,

the main goal is to allow 64DD games to boot without requiring a N64 cart ROM.

I opened this PR early because I wanted some feedback on the changes I've made so far (mainly in `open_rom` & `main_run`)

the main things TODO are:
* rework `is_dd_rom`
* split `load_dd_disk` into separate functions,

note that this already functions as-is on `ndd` roms 

cc @bsmiles32 