### PR TITLE
storage backend save method nows know about modified byte range

### DIFF
--- a/src/backends/api/storage_backend.h
+++ b/src/backends/api/storage_backend.h
@@ -37,7 +37,7 @@ struct storage_backend_interface
 
     /* Notify the storage backend that data should be persisted
      */
-    void (*save)(void* storage);
+    void (*save)(void* storage, size_t start, size_t size);
 };
 
 #endif

--- a/src/backends/file_storage.h
+++ b/src/backends/file_storage.h
@@ -30,6 +30,7 @@ struct file_storage
     uint8_t* data;
     size_t size;
     const char* filename;
+    int first_access;
 };
 
 

--- a/src/device/cart/eeprom.c
+++ b/src/device/cart/eeprom.c
@@ -72,7 +72,7 @@ void eeprom_write_block(struct eeprom* eeprom,
     if (address < eeprom->istorage->size(eeprom->storage))
     {
         memcpy(eeprom->istorage->data(eeprom->storage) + address, data, EEPROM_BLOCK_SIZE);
-        eeprom->istorage->save(eeprom->storage);
+        eeprom->istorage->save(eeprom->storage, address, EEPROM_BLOCK_SIZE);
         *status = 0x00;
     }
     else

--- a/src/device/cart/sram.c
+++ b/src/device/cart/sram.c
@@ -54,7 +54,7 @@ unsigned int sram_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr
         mem[(cart_addr+i)^S8] = dram[(dram_addr+i)^S8];
     }
 
-    sram->istorage->save(sram->storage);
+    sram->istorage->save(sram->storage, cart_addr, length);
 
     return /* length / 8 */0x1000;
 }
@@ -93,5 +93,5 @@ void write_sram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 
     masked_write((uint32_t*)(mem + address), value, mask);
 
-    sram->istorage->save(sram->storage);
+    sram->istorage->save(sram->storage, address, sizeof(value));
 }

--- a/src/device/controllers/paks/mempak.c
+++ b/src/device/controllers/paks/mempak.c
@@ -100,7 +100,7 @@ static void write_mempak(void* pak, uint16_t address, const uint8_t* data, size_
     if (address < 0x8000)
     {
         memcpy(mpk->istorage->data(mpk->storage) + address, data, size);
-        mpk->istorage->save(mpk->storage);
+        mpk->istorage->save(mpk->storage, address, size);
     }
     else
     {

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -192,9 +192,7 @@ static void write_sector(struct dd_controller* dd)
 		disk_sec[i] = dd->ds_buf[i ^ 3];
     }
 
-#if 0 /* disabled for now, because it causes too much slowdowns */
-    dd->idisk->save(dd->disk);
-#endif
+    //dd->idisk->save(dd->disk, disk_sec - dd->idisk->data(dd->disk), length);
 }
 
 void dd_update_bm(void* opaque)

--- a/src/device/dd/disk.c
+++ b/src/device/dd/disk.c
@@ -39,14 +39,14 @@ static size_t storage_disk_size(const void* storage)
     return disk->istorage->size(disk->storage);
 }
 
-static void storage_disk_save(void* storage)
+static void storage_disk_save(void* storage, size_t start, size_t size)
 {
     struct dd_disk* disk = (struct dd_disk*)storage;
 
     // XXX: you have now access to all disk members
     // and can handle the various format specificities here
 
-    disk->istorage->save(disk->storage);
+    disk->istorage->save(disk->storage, start, size);
 }
 
 const struct storage_backend_interface g_istorage_disk =

--- a/src/device/gb/gb_cart.c
+++ b/src/device/gb/gb_cart.c
@@ -135,7 +135,7 @@ static void write_ram(void* ram_storage, const struct storage_backend_interface*
             dst[i] &= mask;
         }
     }
-    iram_storage->save(ram_storage);
+    iram_storage->save(ram_storage, address, size);
 }
 
 

--- a/src/main/util.h
+++ b/src/main/util.h
@@ -58,8 +58,14 @@ file_status_t read_from_file(const char *filename, void *data, size_t size);
 /** write_to_file
  *    opens a file and writes the specified number of bytes.
  *    returns zero on success, nonzero on failure
- */ 
+ */
 file_status_t write_to_file(const char *filename, const void *data, size_t size);
+
+/** write_chunk_to_file
+ *    opens a file, seek to offset and writes the specified number of bytes.
+ *    returns zero on success, nonzero on failure
+ */
+file_status_t write_chunk_to_file(const char *filename, const void *data, size_t size, size_t offset);
 
 /** load_file
  *    load the file content into a newly allocated buffer.

--- a/src/osal/files.h
+++ b/src/osal/files.h
@@ -8,7 +8,7 @@
  *   the Free Software Foundation; either version 2 of the License, or     *
  *   (at your option) any later version.                                   *
  *                                                                         *
- *   This program is distributed in the hope that it will be useful,       * 
+ *   This program is distributed in the hope that it will be useful,       *
  *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
  *   GNU General Public License for more details.                          *
@@ -18,7 +18,7 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-                       
+
 /* This file contains the declarations for OS-dependent file handling
  * functions
  */

--- a/src/osal/files_unix.c
+++ b/src/osal/files_unix.c
@@ -8,7 +8,7 @@
  *   the Free Software Foundation; either version 2 of the License, or     *
  *   (at your option) any later version.                                   *
  *                                                                         *
- *   This program is distributed in the hope that it will be useful,       * 
+ *   This program is distributed in the hope that it will be useful,       *
  *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
  *   GNU General Public License for more details.                          *
@@ -18,7 +18,7 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-                       
+
 /* This file contains the definitions for the unix-specific file handling
  * functions
  */
@@ -173,7 +173,7 @@ const char * osal_get_user_configpath(void)
 {
     static char retpath[PATH_MAX];
     int rval;
-    
+
     /* first, try the XDG_CONFIG_HOME environment variable */
     rval = get_xdg_dir(retpath, "XDG_CONFIG_HOME", "mupen64plus/");
     if (rval == 0)
@@ -194,7 +194,7 @@ const char * osal_get_user_datapath(void)
 {
     static char retpath[PATH_MAX];
     int rval;
-    
+
     /* first, try the XDG_DATA_HOME environment variable */
     rval = get_xdg_dir(retpath, "XDG_DATA_HOME", "mupen64plus/");
     if (rval == 0)
@@ -215,7 +215,7 @@ const char * osal_get_user_cachepath(void)
 {
     static char retpath[PATH_MAX];
     int rval;
-    
+
     /* first, try the XDG_CACHE_HOME environment variable */
     rval = get_xdg_dir(retpath, "XDG_CACHE_HOME", "mupen64plus/");
     if (rval == 0)

--- a/src/osal/files_win32.c
+++ b/src/osal/files_win32.c
@@ -8,7 +8,7 @@
  *   the Free Software Foundation; either version 2 of the License, or     *
  *   (at your option) any later version.                                   *
  *                                                                         *
- *   This program is distributed in the hope that it will be useful,       * 
+ *   This program is distributed in the hope that it will be useful,       *
  *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
  *   GNU General Public License for more details.                          *
@@ -18,7 +18,7 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-                       
+
 /* This file contains the definitions for the unix-specific file handling
  * functions
  */


### PR DESCRIPTION
This features allows to notify storage backends about the range of modified bytes, and in turn allow them to not have to do a full data write every time save method is called, reducing the saving bandwidth requirement.
This was needed to handle 64DD saves which are several order of magnitude bigger than existing saves.

See https://github.com/bsmiles32/mupen64plus-core/tree/wip_64dd_save for possible usage of this feature.

I'd like to have this merge quickly (in the next few days), so please test and voice your concerns if any.

cc : @richard42, @loganmc10, @fzurita 