### PR TITLE
build: Allow out of tree builds.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -139,17 +139,17 @@ ifeq ("$(CPU)","NONE")
   $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif
 
-# base CFLAGS, LDLIBS, and LDFLAGS
-OPTFLAGS ?= -O3 -flto
-WARNFLAGS ?= -Wall
-CFLAGS += -fno-strict-aliasing -fvisibility=hidden -I../../src -I../../src/asm_defines -DM64P_PARALLEL
-CXXFLAGS += -fvisibility-inlines-hidden
-LDLIBS +=  -lm
-
 # directory paths
 SRCDIR = ../../src
 OBJDIR = _obj$(POSTFIX)
 SUBDIR = ../../subprojects
+
+# base CFLAGS, LDLIBS, and LDFLAGS
+OPTFLAGS ?= -O3 -flto
+WARNFLAGS ?= -Wall
+CFLAGS += -fno-strict-aliasing -fvisibility=hidden -I$(SRCDIR) -I$(SRCDIR)/asm_defines -DM64P_PARALLEL
+CXXFLAGS += -fvisibility-inlines-hidden
+LDLIBS +=  -lm
 
 # Since we are building a shared library, we must compile with -fPIC on some architectures
 # On 32-bit x86 systems we do not want to use -fPIC because we don't have to and it has a big performance penalty on this arch
@@ -192,7 +192,7 @@ ifeq ($(OS), LINUX)
   LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-dynamic -Wl,-soname,$(SONAME)
   LDLIBS += -ldl
   # only export api symbols
-  LDFLAGS += -Wl,-version-script,../../src/api/api_export.ver
+  LDFLAGS += -Wl,-version-script,$(SRCDIR)/api/api_export.ver
   ifeq ($(ARCH_DETECTED), 64BITS)
     ASFLAGS = -f elf64
   else
@@ -228,7 +228,7 @@ ifeq ($(OS), MINGW)
   TARGET = mupen64plus$(POSTFIX).dll
   LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-all-symbols
   # only export api symbols
-  LDFLAGS += -Wl,-version-script,../../src/api/api_export.ver
+  LDFLAGS += -Wl,-version-script,$(SRCDIR)/api/api_export.ver
   LDLIBS += -lpthread
   ifeq ($(ARCH_DETECTED), 64BITS)
     ASFLAGS = -f win64 -d WIN64
@@ -242,7 +242,7 @@ ifeq ($(PIC), 1)
 endif
 
 # assembler also needs base include directories
-ASFLAGS += -I../../src/ -I../../src/asm_defines/
+ASFLAGS += -I$(SRCDIR) -I$(SRCDIR)/asm_defines/
 
 ifeq ($(CPU_ENDIANNESS), BIG)
   CFLAGS += -DM64P_BIG_ENDIAN
@@ -751,9 +751,9 @@ install: $(TARGET)
 	$(INSTALL) -d "$(DESTDIR)$(LIBDIR)"
 	$(INSTALL) -m 0644 $(INSTALL_STRIP_FLAG) $(TARGET) "$(DESTDIR)$(LIBDIR)"
 	$(INSTALL) -d "$(DESTDIR)$(SHAREDIR)"
-	$(INSTALL) -m 0644 ../../data/* "$(DESTDIR)$(SHAREDIR)"
+	$(INSTALL) -m 0644 $(SRCDIR)/../data/* "$(DESTDIR)$(SHAREDIR)"
 	$(INSTALL) -d "$(DESTDIR)$(INCDIR)"
-	$(INSTALL) -m 0644 ../../src/api/m64p_*.h "$(DESTDIR)$(INCDIR)"
+	$(INSTALL) -m 0644 $(SRCDIR)/api/m64p_*.h "$(DESTDIR)$(INCDIR)"
 	-$(LDCONFIG) "$(DESTDIR)$(LIBDIR)"
 	if [ ! -e "$(DESTDIR)$(LIBDIR)/$(SONAME)" ]; then ln -sf "$(TARGET)" "$(DESTDIR)$(LIBDIR)/$(SONAME)"; fi
 
@@ -781,8 +781,8 @@ $(ASM_DEFINES_OBJ): $(SRCDIR)/asm_defines/asm_defines.c
 
 # Script hackery for generating ASM include files for the new dynarec assembly code
 $(SRCDIR)/asm_defines/asm_defines_gas.h: $(SRCDIR)/asm_defines/asm_defines_nasm.h
-$(SRCDIR)/asm_defines/asm_defines_nasm.h: $(ASM_DEFINES_OBJ) ../../tools/gen_asm_script.sh
-	sh ../../tools/gen_asm_script.sh "$(SRCDIR)/asm_defines" "$(ASM_DEFINES_OBJ)"
+$(SRCDIR)/asm_defines/asm_defines_nasm.h: $(ASM_DEFINES_OBJ) $(SRCDIR)/../tools/gen_asm_script.sh
+	sh $(SRCDIR)/../tools/gen_asm_script.sh "$(SRCDIR)/asm_defines" "$(ASM_DEFINES_OBJ)"
 
 # standard build rules
 $(OBJDIR)/%.o: $(SRCDIR)/%.asm $(SRCDIR)/asm_defines/asm_defines_nasm.h


### PR DESCRIPTION
This allows building the project out of tree.

Example:
```
mkdir /tmp/build
cd /tmp/build
make install -f /path/to/mupen64plus-core/projects/unix/Makefile \
  SRCDIR=/path/to/mupen64plus-core/src \
  SUBDIR=/path/to/mupen64plus-core/subdir
```