### PR TITLE
[Disk] Make sure the wrong System Data is checked upon read of the System Area

### DIFF
--- a/src/device/dd/disk.c
+++ b/src/device/dd/disk.c
@@ -251,7 +251,7 @@ static uint8_t* get_sector_base_mame(const struct dd_disk* disk,
         + sector * sector_size;
 
     /* Access to protected LBA should return an error */
-    if (sector == 0)
+    if (sector == 0 && track < 12)
     {
         uint16_t lblock = offset / BLOCKSIZE(0);
         uint16_t lblock_sys = disk->offset_sys / BLOCKSIZE(0);
@@ -287,7 +287,7 @@ static uint8_t* get_sector_base_sdk(const struct dd_disk* disk,
     unsigned int offset = LBAToByte(sys_data, 0, lba) + sector * sector_size;
 
     /* Handle Errors for wrong System Data */
-    if (sector == 0)
+    if (sector == 0 && lba < 24)
     {
         uint16_t lblock = offset / BLOCKSIZE(0);
         uint16_t lblock_sys = disk->offset_sys / BLOCKSIZE(0);

--- a/src/device/dd/disk.c
+++ b/src/device/dd/disk.c
@@ -251,7 +251,7 @@ static uint8_t* get_sector_base_mame(const struct dd_disk* disk,
         + sector * sector_size;
 
     /* Access to protected LBA should return an error */
-    if (sector == 0 && track < 12)
+    if (sector == 0 && track < (SYSTEM_LBAS / 2))
     {
         uint16_t lblock = offset / BLOCKSIZE(0);
         uint16_t lblock_sys = disk->offset_sys / BLOCKSIZE(0);
@@ -287,7 +287,7 @@ static uint8_t* get_sector_base_sdk(const struct dd_disk* disk,
     unsigned int offset = LBAToByte(sys_data, 0, lba) + sector * sector_size;
 
     /* Handle Errors for wrong System Data */
-    if (sector == 0 && lba < 24)
+    if (sector == 0 && lba < SYSTEM_LBAS)
     {
         uint16_t lblock = offset / BLOCKSIZE(0);
         uint16_t lblock_sys = disk->offset_sys / BLOCKSIZE(0);


### PR DESCRIPTION
It only impacted SDK format but there were serious regressions where games just didn't work properly. It seems I didn't do proper testing. Now they do.

Basically when you run Mario Artist Paint Studio, and try to access 2D Paint mode (the first on the left) and it would return Error 23 (Unrecovered Read Error), which is definitely weird. Other games were also impacted in weird ways so that was pretty annoying.