### PR TITLE
Update linkage_arm64.S

### DIFF
--- a/src/device/r4300/new_dynarec/arm64/linkage_arm64.S
+++ b/src/device/r4300/new_dynarec/arm64/linkage_arm64.S
@@ -18,6 +18,26 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifdef LEADING_UNDERSCORE
+
+#define GLOBAL_FUNCTION(name)  \
+	.globl _##name;            \
+	.type _##name, %function;  \
+	_##name
+
+#define LOCAL_FUNCTION(name)  \
+	.type _##name, %function; \
+	_##name
+
+#define GLOBAL_VARIABLE(name, size_) \
+	.global _##name;                 \
+	.type   _##name, %object;        \
+	.size   _##name, size_
+
+#define EXTERN_SYMBOL(name) _##name
+
+#else
+
 #define GLOBAL_FUNCTION(name)  \
     .globl name;               \
     .hidden name;              \
@@ -34,6 +54,10 @@
     .hidden name;                    \
     .type   name, %object;           \
     .size   name, size_
+
+#define EXTERN_SYMBOL(name) name
+
+#endif
 
 .macro movl Wn, imm
     movz    \Wn, (\imm >> 16) & 0xFFFF, lsl 16
@@ -74,117 +98,117 @@ fp_memory_map          = offsetof_struct_new_dynarec_hot_state_memory_map
 TEXT_SECTION
     
 GLOBAL_FUNCTION(jump_vaddr_x0):
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x1):
     mov    w0, w1
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x2):
     mov    w0, w2
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x3):
     mov    w0, w3
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x4):
     mov    w0, w4
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x5):
     mov    w0, w5
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x6):
     mov    w0, w6
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x8):
     mov    w0, w8
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
 
 GLOBAL_FUNCTION(jump_vaddr_x9):
     mov    w0, w9
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x10):
     mov    w0, w10
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x11):
     mov    w0, w11
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x12):
     mov    w0, w12
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x13):
     mov    w0, w13
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x14):
     mov    w0, w14
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x15):
     mov    w0, w15
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x16):
     mov    w0, w16
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x17):
     mov    w0, w17
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x18):
     brk 0  /*trampoline jumps uses x18*/
     mov    w0, w18
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x19):
     mov    w0, w19
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x20):
     brk    0 /*address in cycle count*/
     mov    w0, w20
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x21):
     mov    w0, w21
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x22):
     mov    w0, w22
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x23):
     mov    w0, w23
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x24):
     mov    w0, w24
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x25):
     mov    w0, w25
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x26):
     mov    w0, w26
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x27):
     mov    w0, w27
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x28):
     mov    w0, w28
-    b      jump_vaddr
+    b      EXTERN_SYMBOL(jump_vaddr)
     
 GLOBAL_FUNCTION(jump_vaddr_x7):
     mov    w0, w7
@@ -194,20 +218,20 @@ GLOBAL_FUNCTION(jump_vaddr):
     ldr    w18, [x29, #fp_next_interrupt]
     add    w20, w18, w20 /* Count */
     str    w20, [x29, #fp_cp0_regs+36] /* Count */
-    bl     get_addr_ht
+    bl     EXTERN_SYMBOL(get_addr_ht)
     ldr    w20, [x29, #fp_cycle_count]
     br     x0
     
 GLOBAL_FUNCTION(verify_code):
     /* x0 = head */
     mov    x21, x30 /* Save link register */
-    bl     verify_dirty
+    bl     EXTERN_SYMBOL(verify_dirty)
     tst    x0, x0
     b.ne   .D1
     mov    x30, x21 /* Restore link register */
     ret
 .D1:
-    bl     get_addr
+    bl     EXTERN_SYMBOL(get_addr)
     br     x0
     
 GLOBAL_FUNCTION(cc_interrupt):
@@ -224,7 +248,7 @@ GLOBAL_FUNCTION(cc_interrupt):
     tst    w22, w22
     b.ne   .E4
 .E1:
-    bl     dynarec_gen_interrupt
+    bl     EXTERN_SYMBOL(dynarec_gen_interrupt)
     mov    x30, x20 /* Restore link register */
     ldr    w20, [x29, #fp_cp0_regs+36] /* Count */
     ldr    w0, [x29, #fp_next_interrupt]
@@ -238,7 +262,7 @@ GLOBAL_FUNCTION(cc_interrupt):
     ret
 .E2:
     ldr    w0, [x29, #fp_pcaddr]
-    bl     get_addr_ht
+    bl     EXTERN_SYMBOL(get_addr_ht)
     br     x0
 .E3:
     add    x16, x29, #saved_context
@@ -258,7 +282,7 @@ GLOBAL_FUNCTION(cc_interrupt):
     tst    w22, #1
     b.eq   .E6
     add    w0, w21, w23
-    bl     clean_blocks
+    bl     EXTERN_SYMBOL(clean_blocks)
 .E6:
     lsr    w22, w22, #1
     add    w23, w23, #1
@@ -268,7 +292,7 @@ GLOBAL_FUNCTION(cc_interrupt):
     
 GLOBAL_FUNCTION(do_interrupt):
     ldr    w0, [x29, #fp_pcaddr]
-    bl     get_addr_ht
+    bl     EXTERN_SYMBOL(get_addr_ht)
     ldr    w1, [x29, #fp_next_interrupt]
     ldr    w20, [x29, #fp_cp0_regs+36] /* Count */
     sub    w20, w20, w1
@@ -285,7 +309,7 @@ GLOBAL_FUNCTION(fp_exception):
     str    w1, [x29, #fp_cp0_regs+48] /* Status */
     str    w2, [x29, #fp_cp0_regs+52] /* Cause */
     add    w0, w3, #0x180
-    bl     get_addr_ht
+    bl     EXTERN_SYMBOL(get_addr_ht)
     br     x0
     
 GLOBAL_FUNCTION(fp_exception_ds):
@@ -304,7 +328,7 @@ GLOBAL_FUNCTION(jump_eret):
     add    w20, w0, w20
     str    w1, [x29, #fp_cp0_regs+48] /* Status */
     str    w20, [x29, #fp_cp0_regs+36] /* Count */
-    bl     new_dynarec_check_interrupt
+    bl     EXTERN_SYMBOL(new_dynarec_check_interrupt)
     ldr    w1, [x29, #fp_next_interrupt]
     ldr    w0, [x29, #fp_cp0_regs+56] /* EPC */
     subs   w20, w20, w1
@@ -334,21 +358,21 @@ GLOBAL_FUNCTION(jump_eret):
 .E10:
     subs   w3, w3, #1
     adc    w1, w1, w1
-    bl     get_addr_32
+    bl     EXTERN_SYMBOL(get_addr_32)
     br     x0
 .E11:
     str    w0, [x29, #fp_pcaddr]
-    bl     cc_interrupt
+    bl     EXTERN_SYMBOL(cc_interrupt)
     ldr    w0, [x29, #fp_pcaddr]
     b      .E8
     
 GLOBAL_FUNCTION(new_dyna_start):
-    adrp   x16, g_dev
-    add    x16, x16, :lo12:g_dev
+    adrp   x16, EXTERN_SYMBOL(g_dev)
+    add    x16, x16, :lo12:EXTERN_SYMBOL(g_dev)
     movl   x1, (device_r4300_new_dynarec_hot_state_dynarec_local + saved_context)
     add    x16, x16, x1
-    adrp   x1, base_addr_rx
-    add    x1, x1, :lo12:base_addr_rx
+    adrp   x1, EXTERN_SYMBOL(base_addr_rx)
+    add    x1, x1, :lo12:EXTERN_SYMBOL(base_addr_rx)
     mov    w0, #0xa4000000
     stp    x19,x20,[x16,#0]
     stp    x21,x22,[x16,#16]
@@ -359,7 +383,7 @@ GLOBAL_FUNCTION(new_dyna_start):
     sub    x29, x16, #saved_context
     ldr    x19, [x1]
     add    w0, w0, #0x40
-    bl     new_recompile_block
+    bl     EXTERN_SYMBOL(new_recompile_block)
     ldr    w0, [x29, #fp_next_interrupt]
     ldr    w20, [x29, #fp_cp0_regs+36] /* Count */
     sub    w20, w20, w0


### PR DESCRIPTION
Add support for underscores in symbol names.

This is based off of my work on https://github.com/OpenEmu/Mupen64Plus-Core/commit/decfb5dd0526e76d7f545a65818fff0bacfe3f98 and https://github.com/OpenEmu/Mupen64Plus-Core/commit/7c5a3eb76de013afaf21e9a0bd5378ad2fc57af0

This is needed for Darwin/macOS and, I believe, Windows. (To get it to compile on Mac, you will need to use gas-preprocessor, but the current version doesn't like the adrp/add used by this file.)
To enable, pass `-DLEADING_UNDERSCORE` to the compiler/preprocessor/assembler.