### PR TITLE
Remove CountPerOp=1 for Dino Planet

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -3680,7 +3680,6 @@ GoodName=Dinosaur Planet (Dec 2000 Beta)
 CRC=906C3F77 CE495EA1
 Players=1
 SaveType=Flash RAM
-CountPerOp=1
 
 [0E0E920AB13EF13508F5A98CC4CD2FF8]
 GoodName=Disney's Donald Duck - Goin' Quackers (U) [!]


### PR DESCRIPTION
Makes it hard to hit enemies