### PR TITLE
New Database fixes

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -35,8 +35,19 @@ Mempak=Yes
 Rumble=Yes
 Transferpak=No
 
+[39ABE0C383A44C464B408BE3E1D6766E]
+GoodName=007 - The World is Not Enough (U) (v2) (Beta) [!]
+CRC=7BD65F9E 76B6A083
+Players=4
+SaveType=None
+Status=1
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
+
 [12BD3FAFB4E064B6B0C07B7EE156243B]
-GoodName=007 - The World is Not Enough (U) (Beta) [!]
+GoodName=007 - The World is Not Enough (U) (v21) (Beta) [!]
 CRC=A92E0966 341C3912
 Players=4
 SaveType=None
@@ -219,8 +230,9 @@ CRC=4C304819 2CBE7573
 RefMD5=8BEC4EDFA1446859DA896E4EBAE8F925
 
 [0A5ACFEA0C7CF68AE25202040D5AD1EB]
-GoodName=40 Winks (E) (M3) (Prototype)
+GoodName=40 Winks (E) (M3) (Prototype) (1999-10-07) [!]
 CRC=ABA51D09 C668BAD9
+SaveType=None
 Biopak=No
 Mempak=Yes
 Rumble=Yes
@@ -662,14 +674,24 @@ Rumble=No
 Transferpak=No
 
 [CD24763BECFA1D0053E5438B0EF5E75E]
-GoodName=Aidyn Chronicles - The First Mage (U) (Beta) (2000-02-10)
+GoodName=Aidyn Chronicles - The First Mage (U) (Beta) (2000-02-10) [!]
 CRC=40066883 9375D98F
-RefMD5=AF149336B3DDB899598E7BE8740D7DC6
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [CC6EAE9ED582044CC27945684FD396CD]
-GoodName=Aidyn Chronicles - The First Mage (U) (Beta) (2000-05-09)
+GoodName=Aidyn Chronicles - The First Mage (U) (Beta) (2000-05-09) [!]
 CRC=FC8BED44 D640D904
-RefMD5=AF149336B3DDB899598E7BE8740D7DC6
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [E8891F8F498A615A6CBAF75B7DDC9FA6]
 GoodName=Airboarder 64 (E) [!]
@@ -2664,7 +2686,7 @@ GoodName=CZN Module Player (PD)
 CRC=5B9D65DF A18AB4AE
 
 [29B79BF5812E5F9E5ECEF073D59F8915]
-GoodName=California Speed (E) (Prototype)
+GoodName=California Speed (E) (Prototype) [!]
 CRC=CA2A7444 71DAB71C
 SaveType=None
 Players=2
@@ -3492,12 +3514,16 @@ Rumble=Yes
 Transferpak=No
 
 [70E9EB9BF2F7BC76CA38CE450BA01C2E]
-GoodName=Conker's Bad Fur Day (U) (Debug Version) [f1] (Decrypted)
+GoodName=Conker's Bad Fur Day (U) (Debug Version) (Decrypted) [!]
 CRC=8BC3A47A 74221294
-RefMD5=00E2920665F2329B95797A7EAABC2390
+Players=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [13ECBAEEF7111D5343D73A80E03E353A]
-GoodName=Conker's Bad Fur Day (U) (Demo) (V_ECTS_Decrypted)
+GoodName=Conker's Bad Fur Day (U) (ECTS 2000 Demo) [!]
 CRC=A08D0F77 6F82E38C
 Players=4
 Biopak=No
@@ -3864,7 +3890,7 @@ RefMD5=772FA166E5DB51EFFC77FB8D832AC4D2
 Transferpak=Yes
 
 [1051E1402EE110F3C5E372C9E1C5B338]
-GoodName=Derby Stallion 64 (J) (Beta)
+GoodName=Derby Stallion 64 (J) (Beta) [!]
 CRC=96BA4EFB C9988E4E
 Players=4
 SaveType=Flash RAM
@@ -3975,16 +4001,34 @@ CRC=33487563 AC0AE62A
 RefMD5=54BE265E7B2C28AB92BF1A4130ACB5A2
 
 [820929EBBE6FD332AC1720F94B745A8B]
-GoodName=Die Hard 64 (U) (Prototype) (Level 1)
+GoodName=Die Hard 64 (U) (Prototype) (Level 1) [!]
 CRC=870611BA D8B1226C
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [3D1E03B097F2124F8F713013D8219291]
-GoodName=Die Hard 64 (U) (Prototype) (Level 2)
+GoodName=Die Hard 64 (U) (Prototype) (Level 2) [!]
 CRC=08D49262 03763D39
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [1B28C4CA21648D318BC6DD3EF27BB1FA]
-GoodName=Die Hard 64 (U) (Prototype) (Level 3)
+GoodName=Die Hard 64 (U) (Prototype) (Level 3) [!]
 CRC=A1F51C25 16D61291
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [0F0B7B78B345FBF2581D834CB4A81245]
 GoodName=Diddy Kong Racing (E) (M3) (V1.0) [!]
@@ -4837,12 +4881,24 @@ GoodName=Dragon King by CrowTRobo (PD)
 CRC=19E0E54C CB721FD2
 
 [770D0D2BB08235613569667A284BCA2C]
-GoodName=Dragon Sword 64 (E) (Prototype)
+GoodName=Dragon Sword 64 (E) (Prototype) [!]
 CRC=40DFEDA0 3AA09CB2
+Players=2
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [64011DD56FF84CF9EB46153E7AECCD26]
-GoodName=Dragon Sword 64 (U) (Prototype) (1999-08-25)
-CRC=AE6b1E11 B7CBD69E
+GoodName=Dragon Sword 64 (U) (Prototype) (1999-08-25) [!]
+CRC=AE6B1E11 B7CBD69E
+Players=2
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [F120FADB52B414EB4FB7D13092AC3CDB]
 GoodName=Dual Heroes (E) [!]
@@ -4994,9 +5050,14 @@ Rumble=Yes
 Transferpak=No
 
 [BB2472B3F8A41FBF3AEC3CCEF7EA8C78]
-GoodName=Duke Nukem 64 (E) (Beta)
+GoodName=Duke Nukem 64 (E) (Beta) [!]
 CRC=FF14C1DA 167FDE92
-RefMD5=8657CBA95C409B74C1F5632CBC36643F
+Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [A6AC9D140112BD7A3AA8A5ABA79EBD88]
 GoodName=Duke Nukem 64 (E) [b1]
@@ -5009,7 +5070,7 @@ CRC=57BFF74D DE747743
 RefMD5=8657CBA95C409B74C1F5632CBC36643F
 
 [E2E79C7167BDB26E176D220904739C91]
-GoodName=Duke Nukem 64 (F)
+GoodName=Duke Nukem 64 (F) [!]
 CRC=1E12883D D3B92718
 Players=4
 SaveType=None
@@ -6205,6 +6266,16 @@ RefMD5=360DC6BE6D06DCA12E53C077AC0D2571
 GoodName=Fractal Zoomer Demo by RedboX (PD)
 CRC=30E6FE79 3EEA5386
 
+[19D8CC329244F73F9A0E0750E3688D58]
+GoodName=Freak Boy (Unk) (Proto) [!]
+CRC=4471C13E CE7F44A9
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
+
 [7C87831B28D5E49F4EC2BDAE9D01F3B9]
 GoodName=Freekworld BBS Intro by Rene (PD) [a1]
 CRC=714001E3 2EB04B67
@@ -6228,23 +6299,27 @@ CRC=CEE5C8CD D3D85466
 [097189B4C9BF6775E4685951B6E66F24]
 GoodName=Frogger 2 (U) (Prototype 1) [!]
 CRC=AD19A172 9004666A
+Players=1
+SaveType=None
 Biopak=No
-Mempak=Yes
-Rumble=No
-Transferpak=No
-
-[CB2C9C6104C3EF69A1CF979525F2F73D]
-GoodName=Frogger 2 (U) (Prototype 2) [!]
-CRC=E8E5B179 44AA30E8
-Biopak=No
-Mempak=Yes
+Mempak=No
 Rumble=No
 Transferpak=No
 
 [27F61A55E27EA7F1EDE4CA11966ACC7C]
+GoodName=Frogger 2 (U) (Prototype 2) [!]
+CRC=E8E5B179 44AA30E8
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
+
+[CB2C9C6104C3EF69A1CF979525F2F73D]
 GoodName=Frogger 2 (U) (Alpha) [o1]
 CRC=E8E5B179 44AA30E8
-RefMD5=CB2C9C6104C3EF69A1CF979525F2F73D
+RefMD5=27F61A55E27EA7F1EDE4CA11966ACC7C
 
 [FA6CE44ECF86DEC0AFA321D82CD3ED6E]
 GoodName=Frogger 2 (U) (Alpha) [o2]
@@ -6334,6 +6409,17 @@ GoodName=GT 64 - Championship Edition (U) [!]
 CRC=C49ADCA2 F1501B62
 Players=2
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
+CountPerOp=1
+
+[4690CAB33D0BC10B62D62CECDCAA50A1]
+GoodName=GT 64 - Championship Edition (U) (Beta) (1998-05-25) [!]
+CRC=99D5CF89 03AA0071
+Players=2
+SaveType=Eeprom 4KB
 Biopak=No
 Mempak=Yes
 Rumble=Yes
@@ -6631,6 +6717,16 @@ RefMD5=2F2163C53DB135792331DF00398B3F87
 GoodName=Glover (Prototype)
 CRC=254CC736 6F5C721B
 
+[232B6106F3A1761D92268EBE8A25188E]
+GoodName=Glover (Beta) (1998-07-16) [!]
+CRC=25414DCA FD553293
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
+
 [87AA5740DFF79291EE97832DA1F86205]
 GoodName=Glover (U) [!]
 CRC=8E6E01FF CCB4F948
@@ -6657,12 +6753,24 @@ CRC=51938192 BD4A98A1
 RefMD5=87AA5740DFF79291EE97832DA1F86205
 
 [4E15D92CCA23E1A01BB65246431B5C5A]
-GoodName=Glover 2 - Unreleased Beta Version (New Build) (Prototype)
+GoodName=Glover 2 (Prototype 1) [!]
 CRC=8E9F21D2 DC19C5AB
+Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A8567DDABD3672FFF18BC5DF933CF8C7]
-GoodName=Glover 2 (Prototype)
+GoodName=Glover 2 (Prototype 2) [!]
 CRC=B7F40BCF 553556A5
+Players=1
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [29BC5C1A24D3979D376AD421000AC9CB]
 GoodName=Goemon's Great Adventure (U) [!]
@@ -7173,7 +7281,7 @@ CRC=277B129D DD3879FF
 RefMD5=80CC112F62E9A8581A1BB6A1D1E1488B
 
 [988F5ABD96259196343659E913666820]
-GoodName=Holy Magic Century (F)
+GoodName=Holy Magic Century (F) [!]
 CRC=B35FEBB0 7427B204
 Players=1
 SaveType=None
@@ -7565,7 +7673,7 @@ Rumble=Yes
 Transferpak=No
 
 [63D7AB29BA3DFC5D5B12C1D9C5832355]
-GoodName=Indiana Jones and the Infernal Machine (E) (Unreleased)
+GoodName=Indiana Jones and the Infernal Machine (E) (Unreleased) [!]
 CRC=3A6F8C6B 2897BAEB
 Players=1
 SaveType=Eeprom 4KB
@@ -8826,45 +8934,6 @@ GoodName=Last Legion UX (J) [b2]
 CRC=7F304099 52CF5276
 RefMD5=EB11FC0797AE1107201C4601FEE5471A
 
-[0C13E0449A28EA5B925CDB8AF8D29768]
-GoodName=Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!]
-CRC=F7F52DB8 2195E636
-Players=1
-SaveType=SRAM
-Status=4
-Biopak=No
-Mempak=No
-Rumble=Yes
-Transferpak=No
-; End Credits Fix
-Cheat0=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
-
-[33FB7852C180B18EA0B9620B630F413F]
-GoodName=Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!]
-CRC=F611F4BA C584135C
-Players=1
-SaveType=SRAM
-Status=4
-Biopak=No
-Mempak=No
-Rumble=Yes
-Transferpak=No
-; End Credits Fix
-Cheat0=D109A834 0320,8109A834 0000,D109A836 F809,8109A836 0000
-
-[69895C5C78442260F6EAFB2506DC482A]
-GoodName=Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!]
-CRC=F43B45BA 2F0E9B6F
-Players=1
-SaveType=SRAM
-Status=4
-Biopak=No
-Mempak=No
-Rumble=Yes
-Transferpak=No
-; End Credits Fix
-Cheat0=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
-
 [13FAB67E603B002CEAF0EEA84130E973]
 GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!]
 CRC=E97955C6 BC338D38
@@ -8923,9 +8992,15 @@ Rumble=Yes
 Transferpak=No
 
 [71FBAE5D2B27926EA54E92CE2FC91622]
-GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) (Debug Version)
+GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) (Debug Version) [!]
 CRC=9FC385E5 3ECC05C7
-RefMD5=BECCFDED43A2F159D03555027462A950
+Players=1
+SaveType=Flash RAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [609B47B79DA21F3DF9B31D06C95C09A1]
 GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (VC) [!]
@@ -8997,9 +9072,16 @@ RefMD5=2A0A8ACB61538235BC1094D297FB6556
 [8F281800FBA5DDCB1D2B377731FC0215]
 GoodName=Legend of Zelda, The - Majora's Mask - Preview Demo (U) [!]
 CRC=BF799345 39FF7A02
+Players=1
+SaveType=Flash RAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [AC0751DBC23AB2EC0C3144203ACA0003]
-GoodName=Legend of Zelda, The - Majora's Mask (U) (GC)
+GoodName=Legend of Zelda, The - Majora's Mask (U) (GC) [!]
 CRC=B443EB08 4DB31193
 Players=1
 SaveType=Flash RAM
@@ -9020,49 +9102,12 @@ Mempak=No
 Rumble=Yes
 Transferpak=No
 
-[9F04C8E68534B870F707C247FA4B50FC]
-GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!]
-CRC=EC7011B7 7616D72B
+[3C10B67A76616AE2C162DEF7528724CF]
+GoodName=Legend of Zelda, The - Ocarina of Time (E) (M3) (GC) (Debug Version) [!]
+CRC=871E1C92 509D8A96
+Status=4
 Players=1
 SaveType=SRAM
-Status=4
-Biopak=No
-Mempak=No
-Rumble=Yes
-Transferpak=No
-
-[A04EBD753276C52E95E25AF7683DA32D]
-GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell]
-CRC=EC7011B7 7616D72B
-RefMD5=9F04C8E68534B870F707C247FA4B50FC
-
-[D48CFE3FBF77D5335731509BFDE10D47]
-GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi]
-CRC=EC7011B7 7616D72B
-RefMD5=9F04C8E68534B870F707C247FA4B50FC
-
-[BF0622C4C479E8FF5983DB3786F84293]
-GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [f1]
-CRC=9FD0987D 7EAE10D8
-RefMD5=9F04C8E68534B870F707C247FA4B50FC
-
-[1BF5F42B98C3E97948F01155F12E2D88]
-GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!]
-CRC=D43DA81F 021E1E19
-Players=1
-SaveType=SRAM
-Status=4
-Biopak=No
-Mempak=No
-Rumble=Yes
-Transferpak=No
-
-[2258052847BDD056C8406A9EF6427F13]
-GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!]
-CRC=693BA2AE B7F14E9F
-Players=1
-SaveType=SRAM
-Status=4
 Biopak=No
 Mempak=No
 Rumble=Yes
@@ -9429,9 +9474,15 @@ CRC=917D18F6 69BC5453
 RefMD5=DA35577FE54579F6A266931CC75F512D
 
 [8CA71E87DE4CE5E9F6EC916202A623E9]
-GoodName=Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version)
+GoodName=Legend of Zelda, The - Ocarina of Time - Master Quest (U) (Debug Version) [!]
 CRC=917D18F6 69BC5453
-RefMD5=DA35577FE54579F6A266931CC75F512D
+Status=4
+Players=1
+SaveType=SRAM
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [0AB48B2D44A74B3BB2D384F6170C2742]
 GoodName=Legend of Zelda, The - Ocarina of Time (Ch) (iQue) [!]
@@ -9675,8 +9726,14 @@ GoodName=MMR by Count0 (PD)
 CRC=9E6581AB 57CC8CED
 
 [9C6CF9D3CB5852439DE4EF4A399253B9]
-GoodName=Mini Racers (U) (Prototype)
+GoodName=Mini Racers (U) (Prototype) [!]
 CRC=21548CA9 9059F32C
+Players=4
+SaveType=SRAM
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [0054B7FC0C2ACBED650EFE727CDBA472]
 GoodName=MRC - Multi Racing Championship (E) (M3) [!]
@@ -10011,7 +10068,12 @@ CountPerOp=1
 [5F3D42D5F96191F3CE50D70E0E42127A]
 GoodName=Madden NFL 99 (Beta) (1998-08-05) [!]
 CRC=76F8FB3 509A2054
-RefMD5=507CEAB72EF2A1BF145BF190F5CE1C80
+Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [20E51B27E8098A9D101B44689014C281]
 GoodName=Magical Tetris Challenge (E) [!]
@@ -10831,6 +10893,7 @@ Transferpak=No
 GoodName=Mega Man 64 (U) (Beta) [!]
 CRC=27C985A8 ED7CE5C6
 Players=1
+SaveType=SRAM
 Biopak=No
 Mempak=No
 Rumble=Yes
@@ -11718,7 +11781,12 @@ RefMD5=3DCB15043063BD656A0223C519218CFB
 
 [B6A7B85C123DF4E0B9CC118578DBC9A2]
 GoodName=Mortal Kombat Trilogy (U) (Beta) (1996-05-13) [!]
-RefMD5=9B7F29AAB911D6753F2011C48DA752BF
+Players=2
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [08BEA3310E778A6584EB64CD3F15F86E]
 GoodName=Ms. Pac-Man - Maze Madness (U) [!]
@@ -15134,13 +15202,30 @@ GoodName=Robot Ponkotsu 64 - 7tsu no Umi no Caramel (J) [f1] (PAL)
 CRC=7F564549 ED60C5E6
 RefMD5=444F70A655AC89CA900F6FAFAF926B16
 
-[27C6F780F9032A531E9A322969CD9159]
-GoodName=Robotech - Crystal Dreams (Beta)
-CRC=75A0B893 4CA321B5
+[E40BA4761CE977F3FB02151354812D99]
+GoodName=Robotech - Crystal Dreams (Prototype 1) [!]
+CRC=A6B25452 2AF73110
+Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [B39592C6C9A3121258BDB62485956880]
-GoodName=Robotech - Crystal Dreams (Beta) [a1]
+GoodName=Robotech - Crystal Dreams (Prototype 2) [!]
 CRC=75A0B893 4CA321B5
+Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
+
+[27C6F780F9032A531E9A322969CD9159]
+GoodName=Robotech - Crystal Dreams (Prototype 2) [a1]
+CRC=75A0B893 4CA321B5
+RefMD5=B39592C6C9A3121258BDB62485956880
 
 [2ABCD1AD41B3356FBC1018ECB121283E]
 GoodName=Robotron 64 (E) [!]
@@ -16673,8 +16758,14 @@ CRC=4D486681 AB7D9245
 RefMD5=591CF8E672C9CC0FE9C871CC56DCC854
 
 [4076973CFDA277FC876E9F066CC73DEB]
-GoodName=Star Wars - Shadows of the Empire (U) (Prototype)
+GoodName=Star Wars - Shadows of the Empire (U) (Prototype) [!]
 CRC=FB315F95 7786CBFB
+Players=1
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [5CCE8AD5F86E8A373A7525DC4C7E6705]
 GoodName=Star Wars - Shadows of the Empire (U) (V1.0) [!]
@@ -16889,7 +16980,7 @@ CRC=B722133E 5EECEC4D
 RefMD5=1EE8800A4003E7F9688C5A35F929D01B
 
 [3EB732A8D004263AD8EB0DA59A29582A]
-GoodName=StarCraft 64 (Beta)
+GoodName=StarCraft 64 (Beta) [!]
 CRC=BC9B2CC3 4ED04DA5
 Status=1
 Players=2
@@ -16936,8 +17027,14 @@ CRC=C7501968 06533B11
 RefMD5=72B60FAC5EE257FA387B43C57632D50C
 
 [356A5D3D59E0ADEF6EFAE6096FC20F77]
-GoodName=StarCraft 64 (G) (Prototype)
+GoodName=StarCraft 64 (G) (Prototype) [!]
 CRC=FD6907F0 83CBC160
+Players=2
+SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [559F71B861F639B6376D891E3023414B]
 GoodName=StarCraft 64 (U) [!]
@@ -17489,7 +17586,12 @@ Transferpak=No
 [1170033980ADC1981505CF958F35F1EB]
 GoodName=Superman (U) (M3) (Beta) [!]
 CRC=944FAFC4 B288266A
-RefMD5=3F64B4F72E61225EF3AE93976C9BFC7C
+Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
+;Rumble=Yes
+Transferpak=No
 
 [04A6F25CB0F2084E631B3B7FFF76BEFD]
 GoodName=Superman (U) (M3) [T+Ita100_Cattivik66]
@@ -17571,12 +17673,24 @@ CRC=35E811F3 99792724
 RefMD5=26F4CA20F7B9C88199AC046C57E282B4
 
 [FC32007BA03FF2510020E979C7BDAD4F]
-GoodName=Sydney 2000 (E) (Prototype)
+GoodName=Sydney 2000 (E) (Prototype) [!]
 CRC=ECBD95DD 1FAB637D
+Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [2EEA8D20BEF26F88A5E82FDD39F87E75]
-GoodName=Sydney 2000 (U) (Prototype)
+GoodName=Sydney 2000 (U) (Prototype) [!]
 CRC=80A78080 5F9F8833
+Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [4BC1D3074FA3A3DCAF1F16888B82A966]
 GoodName=T-Shirt Demo by Neptune and Steve (POM '98) (PD) [b1]
@@ -17613,14 +17727,24 @@ GoodName=TRSI Intro by Ayatollah (POM '99) (PD)
 CRC=2DD07E20 24D40CD6
 
 [CECAB8DF02C02F38C9CF1BDD57B1DA00]
-GoodName=Tamiya Racing 64 (U) (Prototype)
+GoodName=Tamiya Racing 64 (U) (Prototype) [!]
 CRC=37955E65 C6F2B7B3
+Players=4
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [192B715E8BC5972A4986DF21DC8BF357]
 GoodName=Taz Express (E) (M6) [!]
 CRC=AEBCDD54 15FF834A
 Players=1
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [53DFA593019BDA070DD3CD5FC5B58436]
 GoodName=Taz Express (E) (M6) [f1] (NTSC)
@@ -17633,13 +17757,20 @@ CRC=00BC1D78 00709D53
 RefMD5=192B715E8BC5972A4986DF21DC8BF357
 
 [7A94F94485BD28F0D6D67257050B26D4]
-GoodName=Taz Express (U) (Prototype)
+GoodName=Taz Express (U) (Prototype) [!]
 CRC=6C2C6C49 9BE5CA66
+Players=1
+SaveType=None
+Biopak=No
+Mempak=Yes
+;Rumble=Yes
+Transferpak=No
 
 [7F244AFF8D729417E32B6A5B299AFDA5]
 GoodName=Telefoot Soccer 2000 (F) [!]
 CRC=D9042FBB FCFF997C
 Players=4
+SaveType=None
 Biopak=No
 Mempak=Yes
 Rumble=Yes
@@ -17896,8 +18027,14 @@ CRC=9BF2A817 EE20252A
 RefMD5=A63A9AF85BE8BB47C1741B8A37115354
 
 [99F95AD4A3B0C78B6F58A0FC3AD22DB6]
-GoodName=Tommy Thunder (U) (Prototype)
+GoodName=Tommy Thunder (U) (Prototype) [!]
 CRC=21260D94 06AE1DFE
+Players=1
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [3D3573A855835A98DE29D598C35590E0]
 GoodName=Tonic Trouble (E) (M5) [!]
@@ -17937,6 +18074,16 @@ RefMD5=7D3E935156844DE0002DB875E1076A5C
 [C9E9C4A18B1540C6B4111331D7C663B8]
 GoodName=Tony Hawk's Pro Skater (E) [!]
 CRC=9F8926A5 0587B409
+Players=2
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
+
+[035C0700406197104D977C379E410CB7]
+GoodName=Tony Hawk's Pro Skater (U) (Beta) [!]
+CRC=1762C9FF E221BFE3
 Players=2
 SaveType=None
 Biopak=No
@@ -17989,8 +18136,28 @@ Mempak=Yes
 Rumble=Yes
 Transferpak=No
 
+[317A4E89618B8B7955632C5F70177690]
+GoodName=Tony Hawk's Pro Skater 2 (U) (Alpha) (2001-04-20) [!]
+CRC=404E8D71 7A07DD64
+Players=2
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
+
+[6440A67E2C27BD9ADEDFC60939C2BF1B]
+GoodName=Tony Hawk's Pro Skater 2 (U) (Later, v012) (Beta) [!]
+CRC=E7641245 DB045341
+Players=2
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
+
 [9D4891BF26881C4541171B0235015FD4]
-GoodName=Tony Hawk's Pro Skater 3 (U)
+GoodName=Tony Hawk's Pro Skater 3 (U) [!]
 CRC=1A7F70B5 00B7B9FD
 Players=2
 SaveType=None
@@ -18000,13 +18167,19 @@ Rumble=Yes
 Transferpak=No
 
 [B6FD2A048D1F4F324CEBC97BA09872BB]
-GoodName=Toon Panic (J) (Prototype)
+GoodName=Toon Panic (J) (Prototype) [!]
 CRC=9A746EBF 2802EA99
+Players=4
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [B60D26C2C2242BFF61F76469FC272D2A]
-GoodName=Top Gear Hyper Bike (Beta)
+GoodName=Top Gear Hyper Bike (Beta) [!]
 CRC=75FBDE20 A3189B31
-Players=2
+Players=4
 SaveType=None
 Biopak=No
 Mempak=Yes
@@ -18176,7 +18349,7 @@ CRC=62269B3D FE11B1E8
 RefMD5=6F7030284B6BC84A49E07DA864526B52
 
 [C33CD926E1E71F39F7238AF7B9E0DC5C]
-GoodName=Top Gear Rally 2 (Beta)
+GoodName=Top Gear Rally 2 (Beta) [!]
 CRC=EFDF9140 A4168D6B
 Players=4
 SaveType=None
@@ -18665,9 +18838,14 @@ Rumble=Yes
 Transferpak=No
 
 [03D17AA3DC7663502017D3CC5A19AA8B]
-GoodName=Turok 3 - Shadow of Oblivion (E) (Beta) (2000-05-31)
+GoodName=Turok 3 - Shadow of Oblivion (E) (Beta) (2000-05-31) [!]
 CRC=D124DBB7 7C9FF5E5
-RefMD5=279EC83BD60A3CCE69A1DB22B0A5C318
+Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
+;Rumble=Yes
+Transferpak=No
 
 [69CE88C46A7C829C6F54004DE93EFCEF]
 GoodName=Turok 3 - Shadow of Oblivion (E) (Beta) (2000-06-06)
@@ -18933,6 +19111,16 @@ CRC=A38F7AA6 03A48A45
 [CF17AF84662E1457E61AD54575D50D20]
 GoodName=View N64 Test Program (PD)
 CRC=34B493C9 07654185
+
+[B7425D12935662E480268B48055F2E6C]
+GoodName=Viewpoint 2064 (J) (Prototype) [!]
+CRC=5D40ED2C 10D6ABCF
+Players=1
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [DF011E19F41B1B19C21F1E77E13780B7]
 GoodName=Vigilante 8 (E) [!]
@@ -19986,8 +20174,14 @@ CRC=F4520439 753A6281
 RefMD5=F85F2A2B6CA64898F0ADD2A78CCDCCF3
 
 [B867880C96C9E8D3130DDE5526C95439]
-GoodName=Wildwaters (U) (Prototype)
+GoodName=Wildwaters (U) (Prototype) [!]
 CRC=A04237B9 68F62C72
+Players=2
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [EE3D3550ACC463CA57408BF14E541F68]
 GoodName=WinBack (J) (V1.0) [!]
@@ -20734,4 +20928,91 @@ Biopak=No
 Mempak=No
 Rumble=Yes
 Transferpak=No
+
+[9F04C8E68534B870F707C247FA4B50FC]
+GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!]
+CRC=EC7011B7 7616D72B
+Players=1
+SaveType=SRAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
+
+[A04EBD753276C52E95E25AF7683DA32D]
+GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell]
+CRC=EC7011B7 7616D72B
+RefMD5=9F04C8E68534B870F707C247FA4B50FC
+
+[D48CFE3FBF77D5335731509BFDE10D47]
+GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi]
+CRC=EC7011B7 7616D72B
+RefMD5=9F04C8E68534B870F707C247FA4B50FC
+
+[BF0622C4C479E8FF5983DB3786F84293]
+GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [f1]
+CRC=9FD0987D 7EAE10D8
+RefMD5=9F04C8E68534B870F707C247FA4B50FC
+
+[1BF5F42B98C3E97948F01155F12E2D88]
+GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!]
+CRC=D43DA81F 021E1E19
+Players=1
+SaveType=SRAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
+
+[2258052847BDD056C8406A9EF6427F13]
+GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!]
+CRC=693BA2AE B7F14E9F
+Players=1
+SaveType=SRAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
+
+[0C13E0449A28EA5B925CDB8AF8D29768]
+GoodName=Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!]
+CRC=F7F52DB8 2195E636
+Players=1
+SaveType=SRAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
+; End Credits Fix
+Cheat0=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
+
+[33FB7852C180B18EA0B9620B630F413F]
+GoodName=Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!]
+CRC=F611F4BA C584135C
+Players=1
+SaveType=SRAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
+; End Credits Fix
+Cheat0=D109A834 0320,8109A834 0000,D109A836 F809,8109A836 0000
+
+[69895C5C78442260F6EAFB2506DC482A]
+GoodName=Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!]
+CRC=F43B45BA 2F0E9B6F
+Players=1
+SaveType=SRAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
+; End Credits Fix
+Cheat0=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
 

--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -16,29 +16,35 @@ CountPerOp=1
 [34AB1DEA3111A233A8B5C5679DE22E83]
 GoodName=007 - The World is Not Enough (E) (M3) [!]
 CRC=3B941695 F90A5EEB
-SaveType=None
-Mempak=Yes
-Status=1
-Rumble=Yes
 Players=4
+SaveType=None
+Status=1
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [9D58996A8AA91263B5CD45C385F45FE4]
 GoodName=007 - The World is Not Enough (U) [!]
 CRC=033F4C13 319EE7A7
-SaveType=None
-Mempak=Yes
-Status=1
-Rumble=Yes
 Players=4
+SaveType=None
+Status=1
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [12BD3FAFB4E064B6B0C07B7EE156243B]
 GoodName=007 - The World is Not Enough (U) (Beta) [!]
 CRC=A92E0966 341C3912
-SaveType=None
-Mempak=Yes
-Status=1
-Rumble=Yes
 Players=4
+SaveType=None
+Status=1
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [0846FFFDA3081821EA0DCBB7D4DEAAA3]
 GoodName=007 - The World is Not Enough (U) [t1]
@@ -53,10 +59,13 @@ RefMD5=9D58996A8AA91263B5CD45C385F45FE4
 [632C98CF281CDA776E66685B278A4FA6]
 GoodName=1080 Snowboarding (E) (M4) [!]
 CRC=58FD3F25 D92EAA8D
+Players=2
 SaveType=SRAM
 Status=2
-Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [4E08D29B094C13C030AC73A1DA2F8CD2]
 GoodName=1080 Snowboarding (E) (M4) [b1]
@@ -81,10 +90,13 @@ RefMD5=632C98CF281CDA776E66685B278A4FA6
 [FA27089C425DBAB99F19245C5C997613]
 GoodName=1080 Snowboarding (JU) (M2) [!]
 CRC=1FBAF161 2C1C54F1
+Players=2
 SaveType=SRAM
 Status=2
-Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E428181D573E25DCC0DC7F9F3BF4D1E1]
 GoodName=1080 Snowboarding (JU) (M2) [b1]
@@ -209,8 +221,10 @@ RefMD5=8BEC4EDFA1446859DA896E4EBAE8F925
 [0A5ACFEA0C7CF68AE25202040D5AD1EB]
 GoodName=40 Winks (E) (M3) (Prototype)
 CRC=ABA51D09 C668BAD9
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [66335F4DC6AB27034398BC26F263B897]
 GoodName=64 Hanafuda - Tenshi no Yakusoku (J) [!]
@@ -224,8 +238,10 @@ GoodName=64 Oozumou (J) [!]
 CRC=9C961069 F5EA488D
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 Status=5
 CountPerOp=1
 
@@ -249,8 +265,10 @@ GoodName=64 Oozumou 2 (J) [!]
 CRC=85C18B16 DF9622AF
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 Status=5
 
 [6B947F654775CF5DACD1E5D53D577DA7]
@@ -258,7 +276,10 @@ GoodName=64 Trump Collection - Alice no Wakuwaku Trump World (J) [!]
 CRC=7A6081FC FF8F7A78
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 Status=5
 
 [2C6FDCF4A6A6614D09224EFAA55FB531]
@@ -272,7 +293,10 @@ CRC=B98BA456 5B2B76AF
 Players=4
 Status=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [11B20CFE8E3ECCC680AA8157A7906D6D]
@@ -327,7 +351,10 @@ CRC=8CC182A6 C2D0CAB0
 Players=4
 Status=1
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [D9FE93EBA610E60F8F5D9880E52DB056]
 GoodName=Absolute Crap #2 by Lem (PD)
@@ -390,8 +417,11 @@ GoodName=AeroFighters Assault (E) (M3) [!]
 CRC=62F6BE95 F102D6D6
 Players=2
 SaveType=Eeprom 4KB
-Rumble=Yes
 Status=3
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [915E7762364C2449AAEBC4CA5278D1E8]
 GoodName=AeroFighters Assault (E) (M3) [f1] (NTSC)
@@ -408,8 +438,11 @@ GoodName=AeroFighters Assault (U) [!]
 CRC=1B598BF1 ECA29B45
 Players=2
 SaveType=Eeprom 4KB
-Rumble=Yes
 Status=3
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [CF5FF92EED5FD3C714BC3C4D15C47AE3]
 GoodName=AeroFighters Assault (U) [b1]
@@ -451,8 +484,11 @@ GoodName=AeroGauge (E) (M3) [!]
 CRC=D83045C8 F29D3A36
 Players=2
 SaveType=Eeprom 4KB
-Mempak=Yes
 Status=4
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [FD979768AC0EC6CBBCA8C5339D62BB05]
 GoodName=AeroGauge (E) (M3) [f1] (NTSC)
@@ -474,8 +510,11 @@ GoodName=AeroGauge (J) (V1.0) (Kiosk Demo) [!]
 CRC=B00903C9 3916C146
 Players=2
 SaveType=Eeprom 4KB
-Mempak=Yes
 Status=4
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [6A52188E8A7D008F1921AA8A6D40A74C]
 GoodName=AeroGauge (J) (V1.0) (Kiosk Demo) [b1]
@@ -502,8 +541,11 @@ GoodName=AeroGauge (J) (V1.1) [!]
 CRC=80F41131 384645F6
 Players=2
 SaveType=Eeprom 4KB
-Mempak=Yes
 Status=4
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [CC8C56B4E37BC5A501087E7CE8C12CC5]
 GoodName=AeroGauge (J) (V1.1) [b1]
@@ -550,8 +592,11 @@ GoodName=AeroGauge (U) [!]
 CRC=AEBE463E CC71464B
 Players=2
 SaveType=Eeprom 4KB
-Mempak=Yes
 Status=4
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [B8BA26F0C27253B80E5C7D96B0FB66AB]
 GoodName=AeroGauge (U) [T+Ita0.01_Cattivik66]
@@ -583,16 +628,22 @@ GoodName=Aidyn Chronicles - The First Mage (E) [!]
 CRC=2DC4FFCC C8FF5A21
 Players=1
 SaveType=None
-Mempak=Yes
 Status=3
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [AF149336B3DDB899598E7BE8740D7DC6]
 GoodName=Aidyn Chronicles - The First Mage (U) (V1.0) [!]
 CRC=E6A95A4F BAD2EA23
 Players=1
 SaveType=None
-Mempak=Yes
 Status=3
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [31448B07CBC932018870F71D1254E317]
 GoodName=Aidyn Chronicles - The First Mage (U) (V1.0) [o1]
@@ -602,7 +653,13 @@ RefMD5=AF149336B3DDB899598E7BE8740D7DC6
 [E8CDDF0C52B72453D52DA385322DFE15]
 GoodName=Aidyn Chronicles - The First Mage (U) (V1.1) [!]
 CRC=112051D2 68BEF8AC
-RefMD5=AF149336B3DDB899598E7BE8740D7DC6
+Players=1
+SaveType=None
+Status=3
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [CD24763BECFA1D0053E5438B0EF5E75E]
 GoodName=Aidyn Chronicles - The First Mage (U) (Beta) (2000-02-10)
@@ -619,9 +676,11 @@ GoodName=Airboarder 64 (E) [!]
 CRC=27C425D0 8C2D99C1
 Players=2
 SaveType=Eeprom 4KB
-Mempak=Yes
 Status=4
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [DCFB92A4B106FE61E54579B1D3B7336E]
@@ -639,9 +698,11 @@ GoodName=Airboarder 64 (J) [!]
 CRC=6C45B60C DCE50E30
 Players=2
 Status=4
-Rumble=Yes
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [F558165311C9CDCA73FB089E298F2056]
@@ -709,14 +770,20 @@ GoodName=Akumajou Dracula Mokushiroku - Real Action Adventure (J) [!]
 CRC=B6951A94 63C849AF
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [47EA239717C4D225C9D0E9FD37B9FCB3]
 GoodName=Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J) [!]
 CRC=A5533106 B9F25E5B
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [ECD127A57E25CE8514307BB47ECC1E95]
 GoodName=Alienstyle Intro by Renderman (PD) [a1]
@@ -740,6 +807,10 @@ CRC=DFD784AD AE426603
 Players=4
 SaveType=Eeprom 4KB
 Status=4
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [4DC614B1022252F41E4E182249FA7BAA]
 GoodName=All Star Tennis '99 (E) (M5) [f1] (NTSC)
@@ -767,6 +838,10 @@ CRC=E185E291 4E50766D
 Players=4
 SaveType=Eeprom 4KB
 Status=4
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A90FE01FDAFFB70DD123C0BA04589FAA]
 GoodName=All Star Tennis '99 (U) [T+Bra1.0_Guto]
@@ -793,18 +868,22 @@ GoodName=All-Star Baseball '99 (E) [!]
 CRC=D9EDD54D 6BB8E274
 Players=4
 SaveType=None
+Status=3
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=3
+Transferpak=No
 
 [78551D23F230B58B9F449CDB4A285761]
 GoodName=All-Star Baseball '99 (U) [!]
 CRC=C43E23A7 40B1681A
 Players=4
 SaveType=None
-Mempak=Yes
 Status=3
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [045E0B801F70ADE69981FCBB2EDE5376]
 GoodName=All-Star Baseball '99 (U) [f1] (PAL)
@@ -821,9 +900,11 @@ GoodName=All-Star Baseball 2000 (E) [!]
 CRC=A19F8089 77884B51
 Players=4
 SaveType=None
+Status=0
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=0
+Transferpak=No
 
 [E4076E07DBDA9CEAB5EDCEF4D4648EAB]
 GoodName=All-Star Baseball 2000 (E) [f1] (NTSC)
@@ -835,8 +916,10 @@ GoodName=All-Star Baseball 2000 (U) [!]
 CRC=5E547A4D 90E60795
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5D29C01B96A738C3EB68254EF40552F3]
 GoodName=All-Star Baseball 2000 (U) [f1] (PAL)
@@ -858,8 +941,10 @@ GoodName=All-Star Baseball 2001 (U) [!]
 CRC=5446C6EF E18E47BB
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [CD04ABC5979F22EF5D6FDC4DCFAA4D50]
 GoodName=All-Star Baseball 2001 (U) [f1] (PAL)
@@ -896,9 +981,11 @@ GoodName=Armorines - Project S.W.A.R.M. (E) [!]
 CRC=3CC77150 21CDB987
 Players=4
 SaveType=None
+Status=5
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=5
+Transferpak=No
 
 [0B5F909546DE5A414F2281AD0C83D9F9]
 GoodName=Armorines - Project S.W.A.R.M. (E) [f1] (NTSC)
@@ -910,9 +997,11 @@ GoodName=Armorines - Project S.W.A.R.M. (G) [!]
 CRC=C0F6DB17 80E0D532
 Players=4
 SaveType=None
+Status=5
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=5
+Transferpak=No
 
 [43C23D76E4B6B1CBFCE446DFADFB0396]
 GoodName=Armorines - Project S.W.A.R.M. (G) [f1] (NTSC)
@@ -924,9 +1013,11 @@ GoodName=Armorines - Project S.W.A.R.M. (U) [!]
 CRC=1FB5D932 3BA9481B
 Players=4
 SaveType=None
+Status=5
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=5
+Transferpak=No
 
 [4C15C85280DFB003C3BE6506B217B775]
 GoodName=Armorines - Project S.W.A.R.M. (U) [f1] (PAL)
@@ -943,28 +1034,34 @@ GoodName=Army Men - Air Combat (U) [!]
 CRC=4C52BBB2 CEAB0F6B
 Players=4
 SaveType=None
+Status=3
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=3
+Transferpak=No
 
 [53E2872612760133AB7B2CC2E22B847C]
 GoodName=Army Men - Sarge's Heroes (E) (M3) [!]
 CRC=B210DF19 98B58D1A
-CountPerOp=1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [B8085C2EDB1C6D23E52ED8C06D92B4F8]
 GoodName=Army Men - Sarge's Heroes (U) [!]
 CRC=862C0657 8DFD896D
-CountPerOp=1
-SaveType=None
-Mempak=Yes
 Players=4
-Rumble=Yes
+SaveType=None
 Status=4
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [906D5A77188A0DC90EBF294EF8A3915E]
 GoodName=Army Men - Sarge's Heroes (U) [b1]
@@ -994,12 +1091,14 @@ RefMD5=B8085C2EDB1C6D23E52ED8C06D92B4F8
 [6EEA5C4A6256092ED8F9BA8861C689C6]
 GoodName=Army Men - Sarge's Heroes 2 (U) [!]
 CRC=B20F73B6 2975FC34
-CountPerOp=1
 Players=4
 SaveType=None
+Status=3
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=3
+Transferpak=No
+CountPerOp=1
 
 [F818FB61331122D455692C00EDB2A2FF]
 GoodName=Army Men - Sarge's Heroes 2 (U) [t1]
@@ -1011,9 +1110,11 @@ GoodName=Asteroids Hyper 64 (U) [!]
 CRC=D1F7D8AB 293B0446
 Players=4
 SaveType=None
-Mempak=Yes
 Status=3
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [94751FE93510EBA2D42D82269B224CF8]
 GoodName=Asteroids Hyper 64 (U) [o1]
@@ -1048,9 +1149,11 @@ GoodName=Automobili Lamborghini (E) [!]
 CRC=FC7797BF 4A95E83C
 Players=4
 SaveType=None
+Status=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=4
+Transferpak=No
 
 [DE4631D6419B7361DE9C4A5472964D21]
 GoodName=Automobili Lamborghini (E) [o1]
@@ -1062,9 +1165,11 @@ GoodName=Automobili Lamborghini (U) [!]
 CRC=41B25DC4 1B726786
 Players=5
 SaveType=None
+Status=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Status=4
+Transferpak=No
 
 [E86A022815D0B7E65FD5557F0B3451D4]
 GoodName=Automobili Lamborghini (U) [T+Ita_cattivik66][b3]
@@ -1184,7 +1289,10 @@ GoodName=Baku Bomberman (J) [!]
 CRC=E340A49C 74318D41
 SaveType=Eeprom 4KB
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [70415D917D5B7BEEFEDAFDB65CD64D43]
 GoodName=Baku Bomberman (J) [b1]
@@ -1206,14 +1314,20 @@ GoodName=Baku Bomberman 2 (J) [!]
 CRC=E73C7C4F AF93B838
 SaveType=Eeprom 4KB
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [8107825AC2A522057422463ED81E276B]
 GoodName=Bakuretsu Muteki Bangai-O (J) [!]
 CRC=DF98B95D 58840978
+SaveType=Eeprom 4KB
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [A78517540876AE94C2027FE260633CA8]
 GoodName=Bakuretsu Muteki Bangai-O (J) [f1] (PAL)
@@ -1228,8 +1342,12 @@ RefMD5=8107825AC2A522057422463ED81E276B
 [09FD63AFA1156405E618752FC583DF93]
 GoodName=Bakushou Jinsei 64 - Mezase! Resort Ou (J) [!]
 CRC=88CF980A 8ED52EB5
+SaveType=None
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [E16CFE9268E472A7814C58783AE7D3A2]
 GoodName=Bakushou Jinsei 64 - Mezase! Resort Ou (J) [h1C]
@@ -1241,7 +1359,10 @@ GoodName=Banjo to Kazooie no Daibouken (J) [!]
 CRC=5168D520 CA5FCD0D
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [7FDAFD3252C0F59FFBA59CD42729D959]
 GoodName=Banjo to Kazooie no Daibouken (J) [f1]
@@ -1263,14 +1384,20 @@ GoodName=Banjo to Kazooie no Daibouken 2 (J) [!]
 CRC=514B6900 B4B19881
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [06A43BACF5C0687F596DF9B018CA6D7F]
 GoodName=Banjo-Kazooie (E) (M3) [!]
 CRC=733FCCB1 444892F9
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [5FC8116DAFDEC73DE9C5CCC2D8E14B4F]
 GoodName=Banjo-Kazooie (E) (M3) [f1]
@@ -1287,7 +1414,10 @@ GoodName=Banjo-Kazooie (U) (V1.0) [!]
 CRC=A4BF9306 BF0CDFD1
 SaveType=Eeprom 4KB
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [8E870036E7A40BA42803C333A412EFE7]
 GoodName=Banjo-Kazooie (U) (V1.0) [b1]
@@ -1337,42 +1467,62 @@ RefMD5=B29599651A13F681C9923D69354BF4A3
 [B11F476D4BC8E039355241E871DC08CF]
 GoodName=Banjo-Kazooie (U) (V1.1) [!]
 CRC=CD7559AC B26CF5AE
-RefMD5=B29599651A13F681C9923D69354BF4A3
+SaveType=Eeprom 4KB
+Players=1
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [61B5C5C3E5E1A81E5D37072C01B39B76]
 GoodName=Banjo-Tooie (A) [!]
 CRC=155B7CDF F0DA7325
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [8B2E56F18421A67BCA861427453A1E19]
 GoodName=Banjo-Tooie (E) (M4) [!]
 CRC=C9176D39 EA4779D1
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [40E98FAA24AC3EBE1D25CB5E5DDF49E4]
 GoodName=Banjo-Tooie (U) [!]
 CRC=C2E9AA9A 475D70AA
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [BF3E84CDD01CAC05987FD8DA5191534B]
 GoodName=Bass Hunter 64 (E) [!]
 CRC=B088FBB4 441E4B1D
 Players=1
 SaveType=Eeprom 4KB
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [2C618F6C69C3B4803F08762A03835139]
 GoodName=Bass Rush - ECOGEAR PowerWorm Championship (J) [!]
 CRC=D76333AC 0CB6219D
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [B1AB1D5B3B92B0ACA380D0291DA0689E]
@@ -1390,9 +1540,11 @@ GoodName=Bassmasters 2000 (U) [!]
 CRC=BCFACCAA B814D8EF
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=1
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [D8903586B5E479E6C4937879650D0D2D]
 GoodName=Bassmasters 2000 (U) [b1]
@@ -1409,7 +1561,10 @@ GoodName=Batman Beyond - Return of the Joker (U) [!]
 CRC=204489C1 1286CF2B
 Players=1
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E4498D8FE11A6E0CC0737D89361DE097]
 GoodName=Batman Beyond - Return of the Joker (U) [o1]
@@ -1428,7 +1583,10 @@ GoodName=Batman of the Future - Return of the Joker (E) (M3) [!]
 CRC=259F7F84 7C9EED26
 Players=1
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [F5C9B6E4DB938258EA277670B6D37F16]
 GoodName=Batman of the Future - Return of the Joker (E) (M3) [b1]
@@ -1443,11 +1601,13 @@ RefMD5=A5EE8A6C34863E3D0EB8C06AE8668B30
 [3406A505C22BAC2F40D9BFC6FF08CF86]
 GoodName=BattleTanx (U) [!]
 CRC=6AA4DDE7 E3E2F4E7
-CountPerOp=3
 SaveType=None
-Mempak=Yes
 Players=4
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=3
 
 [94A7605A28861C43F636AE0FF7F25F2E]
 GoodName=BattleTanx (U) [b1]
@@ -1472,20 +1632,24 @@ RefMD5=3406A505C22BAC2F40D9BFC6FF08CF86
 [D6E667FE10AFE8F7116888EFDE98AE0E]
 GoodName=BattleTanx - Global Assault (E) (M3) [!]
 CRC=0CAD17E6 71A5B797
-CountPerOp=1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [654557C316F901A2CA6F7F4B43343147]
 GoodName=BattleTanx - Global Assault (U) [!]
 CRC=75A4E247 6008963D
-CountPerOp=3
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=3
 
 [DC5AAE1CADF43DF43184D2935C32C26C]
 GoodName=BattleTanx - Global Assault (U) [f1] (Country Check)
@@ -1502,17 +1666,21 @@ GoodName=Battlezone - Rise of the Black Dogs (U) [!]
 CRC=55D4C4CE 7753C78A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [A94135D163E6091C960ADC918C1FB8A7]
 GoodName=Beetle Adventure Racing! (E) (M3) [!]
 CRC=A1B64A61 D014940B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=3
 Rumble=Yes
+Transferpak=No
+CountPerOp=3
 
 [9D5A1B779F8B43E63E8CE8427675A7EF]
 GoodName=Beetle Adventure Racing! (E) (M3) [h1C]
@@ -1529,9 +1697,11 @@ GoodName=Beetle Adventure Racing! (J) [!]
 CRC=9C7318D2 24AE0DC1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=3
 Rumble=Yes
+Transferpak=No
+CountPerOp=3
 
 [E126B84FA242916289D04D68C0E20BFE]
 GoodName=Beetle Adventure Racing! (J) [b1]
@@ -1542,10 +1712,12 @@ RefMD5=5FFD43089B7334072B2B74421618D973
 GoodName=Beetle Adventure Racing! (U) (M3) [!]
 CRC=EDF419A8 BF1904CC
 SaveType=None
-Mempak=Yes
 Players=4
-CountPerOp=3
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=3
 
 [D11BC38F26EA2835FBF017FE9BD404FE]
 GoodName=Beetle Adventure Racing! (U) (M3) [b1]
@@ -1589,8 +1761,10 @@ GoodName=Big Mountain 2000 (U) [!]
 CRC=08FFA4B7 01F453B6
 SaveType=Eeprom 4KB
 Players=2
-Rumble=Yes
+Biopak=No
 Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [CFE3E75B8B4C75F231CBBD9C99804EC3]
 GoodName=Big Mountain 2000 (U) [t1]
@@ -1633,8 +1807,10 @@ GoodName=Bio F.R.E.A.K.S. (E) [!]
 CRC=AB7C101D EC58C8B0
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [0F412C4CDE69AE41B89D390731D34F71]
 GoodName=Bio F.R.E.A.K.S. (E) [b1]
@@ -1646,8 +1822,10 @@ GoodName=Bio F.R.E.A.K.S. (U) [!]
 CRC=08123595 0510F1DE
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [801ECC49DAF04FBA099C6F75A06F0454]
 GoodName=Bio F.R.E.A.K.S. (U) [b1]
@@ -1679,8 +1857,11 @@ GoodName=Biohazard 2 (J) [!]
 CRC=7EAE2488 9D40A35A
 SaveType=SRAM
 Players=1
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [13D7834291A311077B84B9A2816AF6FC]
 GoodName=Birthday Demo for Steve by Nep (PD) [b1]
@@ -1695,7 +1876,10 @@ GoodName=Blast Corps (E) (M2) [!]
 CRC=7C64E6DB 55B924DB
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [7C9C000B61BF0BCF81AFD4E583EC9B2A]
 GoodName=Blast Corps (E) (M2) [b1]
@@ -1712,7 +1896,10 @@ GoodName=Blast Corps (U) (V1.0) [!]
 CRC=7C647C25 D9D901E6
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [000E40366ECE225565D3EC83BE7D97A4]
 GoodName=Blast Corps (U) (V1.0) [b1]
@@ -1729,14 +1916,20 @@ GoodName=Blast Corps (U) (V1.1) [!]
 CRC=7C647E65 1948D305
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [16B82D53D7F038A8FE67A78027720516]
 GoodName=Blast Dozer (J) [!]
 CRC=65234451 EBD3346F
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [FA3A5597012B710C844682DA586A62C9]
 GoodName=Blast Dozer (J) [b1]
@@ -1748,16 +1941,20 @@ GoodName=Blues Brothers 2000 (E) (M6) [!]
 CRC=D571C883 822D3FCF
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [997FD8F79CD6F3CD1C1C1FD21E358717]
 GoodName=Blues Brothers 2000 (U) [!]
 CRC=7CD08B12 1153FF89
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [96D5910A6FFD3EE53638251ACE86E0CB]
 GoodName=Blues Brothers 2000 (U) [f1] (PAL-NTSC)
@@ -1779,8 +1976,11 @@ GoodName=Body Harvest (E) (M3) [!]
 CRC=0B58B8CD B7B291D2
 SaveType=Eeprom 4KB
 Players=1
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [0EF2448C243F86C4C9F194F49CFD8352]
 GoodName=Body Harvest (E) (M3) [f1] (NTSC)
@@ -1792,8 +1992,11 @@ GoodName=Body Harvest (U) [!]
 CRC=5326696F FE9A99C3
 Players=1
 SaveType=Eeprom 4KB
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [77554810629D4EF4D93519745FA6066B]
 GoodName=Body Harvest (U) [b1]
@@ -1819,7 +2022,11 @@ RefMD5=3B8585ED03E8DDB89D7DE456317545E7
 GoodName=Bokujou Monogatari 2 (J) (V1.0) [!]
 CRC=B3D451C6 E1CB58E2
 Players=1
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [C902BB7203C6C77DDA16ABCDF8995E32]
@@ -1830,19 +2037,34 @@ RefMD5=1CF31E7F6E0DEB2C18C39DDD4EED9E51
 [E627B898A7692C08B595A8D2178E34A0]
 GoodName=Bokujou Monogatari 2 (J) (V1.1) [!]
 CRC=7365D8F8 9ED9326F
-RefMD5=1CF31E7F6E0DEB2C18C39DDD4EED9E51
+Players=1
+SaveType=SRAM
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
+CountPerOp=1
 
 [24E3EE6A54278DB65C463804F2BB6223]
 GoodName=Bokujou Monogatari 2 (J) (V1.2) [!]
 CRC=736657F6 3C88A702
-RefMD5=1CF31E7F6E0DEB2C18C39DDD4EED9E51
+Players=1
+SaveType=SRAM
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
+CountPerOp=1
 
 [B68F49AA8F6F7499184AC6B7B8570F2B]
 GoodName=Bomberman 64 (E) [!]
 CRC=5A160336 BC7B37B0
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [B9E6A38B28108E4D6E6A0A47BF981747]
 GoodName=Bomberman 64 (E) [b1]
@@ -1869,7 +2091,10 @@ GoodName=Bomberman 64 (U) [!]
 CRC=F568D51E 7E49BA1E
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [BB4C5769EED69362F1A90A2BE19998D6]
 GoodName=Bomberman 64 (U) [b1]
@@ -1895,14 +2120,21 @@ RefMD5=08E491F87445C6E5C168D982FC665D5F
 GoodName=Bomberman 64 - Arcade Edition (J) [!]
 CRC=DF6FF0F4 29D14238
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [AEC1FDB0F1CAAD86C9F457989A4CE482]
 GoodName=Bomberman 64 - The Second Attack! (U) [!]
 CRC=237E73B4 D63B6B37
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9058970DDF26431A4DAF353C2EEA86AB]
 GoodName=Bomberman 64 - The Second Attack! (U) [t1][f1] (PAL-NTSC)
@@ -1914,7 +2146,10 @@ GoodName=Bomberman Hero (E) [!]
 CRC=D85C4E29 88E276AF
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [EA6D0EBD673A66C395569A2A230AEA6F]
 GoodName=Bomberman Hero (E) [b1]
@@ -1941,7 +2176,10 @@ GoodName=Bomberman Hero (U) [!]
 CRC=4446FDD6 E3788208
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [5642E51D746F603DFE5A71C5CBDB5C73]
 GoodName=Bomberman Hero (U) [b1]
@@ -1968,7 +2206,10 @@ GoodName=Bomberman Hero - Mirian Oujo wo Sukue! (J) [!]
 CRC=67FF12CC 76BF0212
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E7D3A4A73D373DA534A025E99B4D0EEF]
 GoodName=Bomberman Hero - Mirian Oujo wo Sukue! (J) [b1]
@@ -2028,8 +2269,11 @@ CRC=2D15DC8C D3BBDB52
 GoodName=Bottom of the 9th (U) [!]
 CRC=D72FD14D 1FED32C4
 SaveType=None
-Mempak=Yes
 Players=2
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [6E207C47FAAD2A4F64AE721A3A8F6161]
 GoodName=Bottom of the 9th (U) [b1]
@@ -2041,7 +2285,10 @@ GoodName=Brunswick Circuit Pro Bowling (U) [!]
 CRC=1E22CF2E 42AAC813
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [14D070077D70C94CBB1413C7641E7272]
 GoodName=Brunswick Circuit Pro Bowling (U) [b1]
@@ -2063,24 +2310,30 @@ GoodName=Buck Bumble (E) (M5) [!]
 CRC=D5B2339C CABCCAED
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AEE981977D8F069003574CD10A268D47]
 GoodName=Buck Bumble (J) [!]
 CRC=D7C762B6 F83D9642
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [41417FCE2B37EAAE787C5A845A0015C4]
 GoodName=Buck Bumble (U) [!]
 CRC=85AE781A C756F05D
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [01933A0CBBDE1D4EB4C58CC6C6C27633]
 GoodName=Buck Bumble (U) [b1][t1]
@@ -2107,8 +2360,10 @@ GoodName=Bug's Life, A (E) [!]
 CRC=8F12C096 45DC17E1
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [5BF0F2351AEE577A8345D6E13D197E06]
@@ -2120,9 +2375,11 @@ RefMD5=ED3E962653A1CD56AAB175DEEE6EE52A
 GoodName=Bug's Life, A (F) [!]
 CRC=2B38AEC0 6350B810
 SaveType=None
+Players=1
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Players=1
+Transferpak=No
 CountPerOp=1
 
 [504C92A5978B7EAE7A3FD30645E06D39]
@@ -2135,8 +2392,10 @@ GoodName=Bug's Life, A (G) [!]
 CRC=DFF227D9 0D4D8169
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [919E5D60A7F9A79D89AC179123D47EEE]
@@ -2149,8 +2408,10 @@ GoodName=Bug's Life, A (I) [!]
 CRC=F63B89CE 4582D57D
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [7FD6BFFB80F920E01EF869829D485EA3]
@@ -2158,8 +2419,10 @@ GoodName=Bug's Life, A (U) [!]
 CRC=82DC04FD CF2D82F4
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [14ACC20454B0C2789C9F7EF7A556231A]
@@ -2192,8 +2455,10 @@ GoodName=Bust-A-Move '99 (U) [!]
 CRC=4222D89F AFE0B637
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [B292B14BBC7FFCC2A741FE87A80B8D4D]
 GoodName=Bust-A-Move '99 (U) [b1]
@@ -2210,7 +2475,10 @@ GoodName=Bust-A-Move 2 - Arcade Edition (E) [!]
 CRC=CEDCDE1E 513A0502
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [AE0693C8D73E5A1407A2EDF41F1164A9]
 GoodName=Bust-A-Move 2 - Arcade Edition (E) [b1]
@@ -2222,7 +2490,10 @@ GoodName=Bust-A-Move 2 - Arcade Edition (U) [!]
 CRC=8A86F073 CD45E54B
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [84DD20F80DB23CB49BFE98639BE6CD71]
 GoodName=Bust-A-Move 2 - Arcade Edition (U) [b1]
@@ -2249,8 +2520,10 @@ GoodName=Bust-A-Move 3 DX (E) [!]
 CRC=E328B4FA 004A28E1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [16D7676C2394E422076F7CB855DE901B]
 GoodName=Bust-A-Move 3 DX (E) [b1]
@@ -2394,19 +2667,23 @@ CRC=5B9D65DF A18AB4AE
 GoodName=California Speed (E) (Prototype)
 CRC=CA2A7444 71DAB71C
 SaveType=None
-Mempak=Yes
 Players=2
-CountPerOp=1
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [965AD2FA317F0644E49A89A3219719CB]
 GoodName=California Speed (U) [!]
 CRC=AC16400E CF5D071A
 SaveType=None
-Mempak=Yes
 Players=2
-CountPerOp=1
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [C95353C14C4AE3DC95D1D91D6566EF92]
 GoodName=California Speed (U) [f1] (Country Check)
@@ -2428,8 +2705,10 @@ GoodName=Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ger) [!]
 CRC=580162EC E3108BF1
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [A5DB496C328C36682EB770CEFE6C2064]
@@ -2442,8 +2721,10 @@ GoodName=Carmageddon 64 (E) (M4) (Eng-Spa-Fre-Ita) [!]
 CRC=E48E01F5 E6E51F9B
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [D5271DB3CBE6B24099DCC6878C137FF7]
@@ -2466,8 +2747,10 @@ GoodName=Carmageddon 64 (U) [!]
 CRC=F00F2D4E 340FAAF4
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [57146B6CD8EE7D96B01A811F98A1AC61]
@@ -2475,7 +2758,10 @@ GoodName=Castlevania (E) (M3) [!]
 CRC=64F1B7CA 71A23755
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [DE30F7C3D077778380E2B3D507EFE2D3]
 GoodName=Castlevania (E) (M3) [b1]
@@ -2492,7 +2778,10 @@ GoodName=Castlevania (U) (V1.0) [!]
 CRC=F35D5F95 8AFE3D69
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [C19E5A3FCDF52C7292097F215DDC428A]
 GoodName=Castlevania (U) (V1.0) [b1]
@@ -2539,21 +2828,30 @@ GoodName=Castlevania (U) (V1.1) [!]
 CRC=F35D5335 B7667CB7
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [06B58673F7D31C56F8FE8186E86F6BD6]
 GoodName=Castlevania (U) (V1.2) [!]
 CRC=4BCDFF47 AAA3AF8F
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [78D5F8A98A5ED21D0817856BCD2AD750]
 GoodName=Castlevania - Legacy of Darkness (E) (M3) [!]
 CRC=A2C54BE7 6719CBB2
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [3152B82C03FC7B928D3D5C43F95AEF51]
 GoodName=Castlevania - Legacy of Darkness (E) (M3) [h1C]
@@ -2570,7 +2868,10 @@ GoodName=Castlevania - Legacy of Darkness (U) [!]
 CRC=1CC06338 87388926
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [5F73634C622ABEDF6204CB801872C79C]
 GoodName=Castlevania - Legacy of Darkness (U) [b1]
@@ -2596,7 +2897,10 @@ RefMD5=25258460F98F567497B24844ABE3A05B
 GoodName=Centre Court Tennis (E) [!]
 CRC=DCCF2134 9DD63578
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [F52661EF93B9FD4DF16F1F113082AEAA]
 GoodName=Centre Court Tennis (E) [f1] (NTSC)
@@ -2613,7 +2917,10 @@ GoodName=Chameleon Twist (E) [!]
 CRC=B9AF8CC6 DEC9F19F
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [AB7D5366FEDCF8EC2D414B6001BEB399]
 GoodName=Chameleon Twist (E) [b1]
@@ -2650,14 +2957,20 @@ GoodName=Chameleon Twist (J) [!]
 CRC=A4F2F521 F0EB168E
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [397BE52D4FB7DF1E26C6275E05425571]
 GoodName=Chameleon Twist (U) (V1.0) [!]
 CRC=6420535A 50028062
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [AB299B3943161B9C2ABF03F5A9824E9F]
 GoodName=Chameleon Twist (U) (V1.0) [b1]
@@ -2684,15 +2997,20 @@ GoodName=Chameleon Twist (U) (V1.1) [!]
 CRC=D81963C7 4271A3AA
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [45D1D039AB7926ADC748DE640AFD986A]
 GoodName=Chameleon Twist 2 (E) [!]
 CRC=07A69D01 9A7D41A1
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [3A5EDF7256EA5E7AF4B451E07CC54003]
 GoodName=Chameleon Twist 2 (E) [b1]
@@ -2704,8 +3022,10 @@ GoodName=Chameleon Twist 2 (J) [!]
 CRC=0549765A 93B9D042
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [7A638431CE966DDA97B282FF04B1D9D7]
 GoodName=Chameleon Twist 2 (J) [b1]
@@ -2747,8 +3067,10 @@ GoodName=Chameleon Twist 2 (U) [!]
 CRC=CD538CE4 618AFCF9
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [80F4CD56317218264E35894BA22CAD35]
 GoodName=Chameleon Twist 2 (U) [t1]
@@ -2764,8 +3086,11 @@ GoodName=Charlie Blast's Territory (E) [!]
 CRC=FB3C48D0 8D28F69F
 SaveType=None
 Players=4
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [A7C15E0C1E7D898C1B20276DF7A62660]
 GoodName=Charlie Blast's Territory (E) [o1]
@@ -2777,8 +3102,11 @@ GoodName=Charlie Blast's Territory (U) [!]
 CRC=1E0E96E8 4E28826B
 SaveType=None
 Players=4
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [7FFD84FC7D112EAB4EEF15CB10189A38]
 GoodName=Charlie Blast's Territory (U) [hIR]
@@ -2795,7 +3123,10 @@ GoodName=Chopper Attack (E) [!]
 CRC=2E359339 3FA5EDA6
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [AC129AB2688C02419FC190A87F2A2E93]
 GoodName=Chopper Attack (E) [b1]
@@ -2812,7 +3143,10 @@ GoodName=Chopper Attack (U) [!]
 CRC=214CAD94 BE1A3B24
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [14AEB927F3620EFE48AF7FC748C1931F]
 GoodName=Chopper Attack (U) [b1]
@@ -2854,7 +3188,10 @@ GoodName=Choro Q 64 (J) [!]
 CRC=2BCCF9C4 403D9F6F
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [2C944319017A21652566CC4196C714CC]
 GoodName=Choro Q 64 (J) [b1]
@@ -2885,6 +3222,7 @@ RefMD5=8287A908E36E79B2D3AF0BD22C43ECD9
 GoodName=Choro Q 64 II - Hacha Mecha Grand Prix Race (J) [!]
 CRC=26CD0F54 53EBEFE0
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -2893,7 +3231,10 @@ Transferpak=Yes
 GoodName=Chou Kuukan Night Pro Yakyuu King (J) [!]
 CRC=8ACE6683 3FBA426E
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [5224CCBE260A4B7713D662D9BC269063]
 GoodName=Chou Kuukan Night Pro Yakyuu King (J) [b1]
@@ -2909,15 +3250,21 @@ RefMD5=78838C202C4FF5A460586451EE9182AA
 GoodName=Chou Kuukan Night Pro Yakyuu King 2 (J) [!]
 CRC=3A180FF4 5C8E8AF7
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9466618F4497DA6C9091E05CC9666786]
 GoodName=Chou Snobow Kids (J) [!]
 CRC=A7941528 61F1199D
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [74341014043CC42D8804DADBF252B344]
 GoodName=Chou Snobow Kids (J) [f1] (PAL)
@@ -2933,8 +3280,10 @@ GoodName=City-Tour GP - Zennihon GT Senshuken (J) [!]
 CRC=F8009DB0 6B291823
 Players=2
 SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [4808E8129B22AC8B3185B37243113005]
@@ -2955,8 +3304,12 @@ RefMD5=2A0BF5A9A136D57AF01D199B16899634
 [30E7E083B978408D5B7760D0CE4DC61D]
 GoodName=Clay Fighter - Sculptor's Cut (U) [!]
 CRC=FA5A3DFF B4C9CDB9
-SaveType=None
 Players=4
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [052BB2C8C4174633A0D38DEB4D31C719]
 GoodName=Clay Fighter - Sculptor's Cut (U) [b1]
@@ -2988,6 +3341,10 @@ GoodName=Clay Fighter 63 1-3 (Beta) [!]
 CRC=2B6FA7C0 09A71225
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [BE41BA94878999987DC8D2FD3A5551D9]
 GoodName=Clay Fighter 63 1-3 (Beta) [b1]
@@ -2998,6 +3355,10 @@ GoodName=Clay Fighter 63 1-3 (E) [!]
 CRC=8E9692B3 4264BB2A
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [46B95EA3EB82654439A6750443BCDE53]
 GoodName=Clay Fighter 63 1-3 (E) [b1][h1C]
@@ -3014,6 +3375,10 @@ GoodName=Clay Fighter 63 1-3 (U) [!]
 CRC=F03C24CA C5237BCC
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [7A4ACAB8997D180C045D9286C917ED1B]
 GoodName=Clay Fighter 63 1-3 (U) [b1]
@@ -3048,7 +3413,10 @@ GoodName=Command & Conquer (E) (M2) [!]
 CRC=AE5B9465 C54D6576
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [4D972AE7FAA1AA3ED26026F6F46C8A6A]
 GoodName=Command & Conquer (E) (M2) [b1]
@@ -3075,7 +3443,10 @@ GoodName=Command & Conquer (G) [!]
 CRC=B5025BAD D32675FD
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [19A646E0148EA6695E797C1990919B8A]
 GoodName=Command & Conquer (G) [f1] (Z64)
@@ -3087,7 +3458,10 @@ GoodName=Command & Conquer (U) [!]
 CRC=95286EB4 B76AD58F
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [57044E8F223D117F55B22E7FD2EDF71E]
 GoodName=Command & Conquer (U) [b1]
@@ -3112,7 +3486,10 @@ GoodName=Conker's Bad Fur Day (E) [!]
 CRC=373F5889 9A6CA80A
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [70E9EB9BF2F7BC76CA38CE450BA01C2E]
 GoodName=Conker's Bad Fur Day (U) (Debug Version) [f1] (Decrypted)
@@ -3123,21 +3500,30 @@ RefMD5=00E2920665F2329B95797A7EAABC2390
 GoodName=Conker's Bad Fur Day (U) (Demo) (V_ECTS_Decrypted)
 CRC=A08D0F77 6F82E38C
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [00E2920665F2329B95797A7EAABC2390]
 GoodName=Conker's Bad Fur Day (U) [!]
 CRC=30C7AC50 7704072D
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [DB7A03B77D44DB81B8A3FCDFC4B72D8C]
 GoodName=Cruis'n Exotica (U) [!]
 CRC=46A3F7AF 0F7591D0
 SaveType=Eeprom 4KB
 Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [A8266778591994EFA3A3B9E6E806F8C8]
 GoodName=Cruis'n Exotica (U) [t1]
@@ -3149,14 +3535,20 @@ GoodName=Cruis'n USA (E) [!]
 CRC=503EA760 E1300E96
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [00A3E885F8D899646228A21D946B2102]
 GoodName=Cruis'n USA (U) (V1.0) [!]
 CRC=FF2F2FB4 D161149A
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [190906A8A5F1C1D4909F6374A784ECA4]
 GoodName=Cruis'n USA (U) (V1.0) [T+Ita0.40]
@@ -3198,28 +3590,40 @@ GoodName=Cruis'n USA (U) (V1.1) [!]
 CRC=5306CF45 CBC49250
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [2838A9018AD2BCB8B7F6161C746A1B71]
 GoodName=Cruis'n USA (U) (V1.2) [!]
 CRC=B3402554 7340C004
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [AF950A1B6C460D7FC3E78375D35047EF]
 GoodName=Cruis'n World (E) [!]
 CRC=83F3931E CB72223D
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [20DB5E4DDB0CD5B04C4BF09CDC95592F]
 GoodName=Cruis'n World (E) (V1.1) [!]
 CRC=33E61153 97A2E2C5
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [626478CC0790B1452045A3D853B46C18]
 GoodName=Cruis'n World (E) [b1]
@@ -3251,7 +3655,10 @@ GoodName=Cruis'n World (U) [!]
 CRC=DFE61153 D76118E6
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [B97C963235635672CBEAB35154DFDFA2]
 GoodName=Cruis'n World (U) [b1]
@@ -3299,34 +3706,50 @@ CRC=37BDF228 92CF779C
 [33F2BC6847985F96DE8177147DCD3B85]
 GoodName=Custom Robo (Ch) (iQue) [!]
 Players=2
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A06D2E83CF2628915E8847F609474661]
 GoodName=Custom Robo (J) [!]
 CRC=83CB0B87 7E325457
 Players=2
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [115118DD5E0F02D82BA1BF070A7B78F1]
 GoodName=Custom Robo V2 (J) [!]
 CRC=079501B9 AB0232AB
 Players=4
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [8C4A4CD472D610CDA5459B3A92F21D30]
 GoodName=CyberTiger (E) [!]
 CRC=D1A78A07 52A3DD3E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [88072F30D4F9CF384B2B3A0300649218]
 GoodName=CyberTiger (U) [!]
 CRC=E8FC8EA1 9F738391
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9801AAA87D650C42B021F94D5C34C7A4]
 GoodName=DKONG Demo (PD)
@@ -3348,7 +3771,10 @@ CRC=201DA461 EC0C992B
 GoodName=Dance Dance Revolution - Disney Dancing Museum (J) [!]
 CRC=7188F445 84410A68
 Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [3A1488C2A8A8F2AB9368D7C056EB02A2]
 GoodName=Dance Dance Revolution - Disney Dancing Museum (J) [o1]
@@ -3365,6 +3791,10 @@ GoodName=Dark Rift (E) [!]
 CRC=7ED67CD4 B4415E6D
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [0DD2887AF64C5786C1C66877AFCC0B97]
 GoodName=Dark Rift (E) [b1]
@@ -3376,6 +3806,10 @@ GoodName=Dark Rift (U) [!]
 CRC=A4A52B58 23759841
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [CBFEAD02C508DADFB44A00E7F7ED61B8]
 GoodName=Dark Rift (U) [t1]
@@ -3387,8 +3821,10 @@ GoodName=Deadly Arts (U) [!]
 CRC=F5363349 DBF9D21B
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F403FCEB3FCD41BB5830142989FC9486]
 GoodName=Deadly Arts (U) [b1]
@@ -3400,14 +3836,20 @@ GoodName=Defi au Tetris Magique (F) [!]
 CRC=3F66A9D9 9BCB5B00
 SaveType=None
 Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [772FA166E5DB51EFFC77FB8D832AC4D2]
 GoodName=Densha de Go! 64 (J) [!]
 CRC=17C54A61 4A83F2E7
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [BA99C445ADC6994C97FE6463F3E0EC10]
@@ -3426,32 +3868,42 @@ GoodName=Derby Stallion 64 (J) (Beta)
 CRC=96BA4EFB C9988E4E
 Players=4
 SaveType=Flash RAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [7F57463856540104B21A5289312B626F]
 GoodName=Derby Stallion 64 (J) [!]
 CRC=A5F667E1 DA1FBD1F
 Players=4
 SaveType=Flash RAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [BDA717ECC8434F12F313342485828B58]
 GoodName=Destruction Derby 64 (E) (M3) [!]
 CRC=630AA37D 896BD7DB
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=1
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [7FCCB47498EEC06E96AE9372247D1E90]
 GoodName=Destruction Derby 64 (U) [!]
 CRC=DEE584A2 0F161187
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=1
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [02EEF6ED11174664A548626337879E8C]
 GoodName=Destruction Derby 64 (U) [f1] (PAL)
@@ -3495,7 +3947,12 @@ RefMD5=6D75719BFA6244C4591070D3F7356072
 GoodName=Dezaemon 3D (J) [!]
 CRC=8979169C F189F6A0
 Players=1
+;Unclear
+;SaveType=SRAM 768KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [01E34CD8A451F0B5AEF93CCF9ADB37AF]
 GoodName=Dezaemon 3D (J) [b1]
@@ -3534,8 +3991,10 @@ GoodName=Diddy Kong Racing (E) (M3) (V1.0) [!]
 CRC=FD73F775 9724755A
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [79748E4E030B047DBAE8252C21305C75]
 GoodName=Diddy Kong Racing (E) (M3) (V1.0) [f1]
@@ -3552,8 +4011,10 @@ GoodName=Diddy Kong Racing (E) (M3) (V1.1) [!]
 CRC=596E145B F7D9879F
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [35CF26D4D33717BA730D7978E2F2107D]
 GoodName=Diddy Kong Racing (E) (M3) (V1.1) [f1] (Z64)
@@ -3565,8 +4026,10 @@ GoodName=Diddy Kong Racing (J) [!]
 CRC=7435C9BB 39763CF4
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [0D68A405BCB04318A294DBEABF1DE063]
 GoodName=Diddy Kong Racing (J) [f1] (Z64)
@@ -3578,8 +4041,10 @@ GoodName=Diddy Kong Racing (U) (M2) (V1.0) [!]
 CRC=53D440E7 7519B011
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [94D81D14A2D768DD0EDA3A845AFB25CD]
 GoodName=Diddy Kong Racing (U) (M2) (V1.0) [T+Bra_EmuBrazil]
@@ -3666,8 +4131,10 @@ GoodName=Diddy Kong Racing (U) (M2) (V1.1) [!]
 CRC=E402430D D2FCFC9D
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [FBCCFED51A43B0012CE927CC73D6AADA]
 GoodName=Diddy Kong Racing SRAM by Group5 (PD)
@@ -3686,7 +4153,10 @@ GoodName=Disney's Donald Duck - Goin' Quackers (U) [!]
 CRC=C16C421B A21580F7
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [BD1DE2FC1CF31096423563A40ECBF933]
@@ -3694,8 +4164,10 @@ GoodName=Disney's Tarzan (E) [!]
 CRC=D614E5BF A76DBCC1
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [AF740B224E5DD0BD09F7254811559ADF]
@@ -3708,8 +4180,10 @@ GoodName=Disney's Tarzan (F) [!]
 CRC=001A3BD0 AFB3DE1A
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [DF3CDD959E8C63B45F557FC197CE0E63]
@@ -3717,8 +4191,10 @@ GoodName=Disney's Tarzan (G) [!]
 CRC=4C261323 4F295E1A
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [A29E203DDB6293B7D105BF4A2EEEDD1E]
@@ -3731,8 +4207,10 @@ GoodName=Disney's Tarzan (U) [!]
 CRC=CBFE69C7 F2C0AB2A
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [C56AD8ABD0FB5EFEF1FA0229F9A2EFF0]
@@ -3995,7 +4473,10 @@ GoodName=Donald Duck - Quack Attack (E) (M5) [!]
 CRC=3DF17480 193DED5A
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [07C4944DDAAD234F1F6B0B200BEA60B2]
@@ -4016,13 +4497,20 @@ SaveType=Eeprom 4KB
 [AF83E0CF36298E62E9EB2EB8C89AA710]
 GoodName=Animal Crossing (Ch) (iQue) [!]
 CRC=916EB31B F47097A5
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [118E9CE360B97A6F8DAB2C9F30660BF5]
 GoodName=Donkey Kong 64 (E) [!]
 CRC=11936D8C 6F2C4B43
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [428067DC7DB42DFC977A775F0A6E55B1]
@@ -4045,15 +4533,21 @@ GoodName=Donkey Kong 64 (J) [!]
 CRC=053C89A7 A5064302
 SaveType=Eeprom 16KB
 Players=4
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [98A5836E3A5DA7BD0B5819E7498ACEA2]
 GoodName=Donkey Kong 64 (U) (Kiosk Demo) [!]
 CRC=0DD4ABAB B5A2A91E
 SaveType=Eeprom 16KB
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [843DB032839BF1AA74759F2E39A2ABDC]
 GoodName=Donkey Kong 64 (U) (Kiosk Demo) [b1]
@@ -4075,8 +4569,11 @@ GoodName=Donkey Kong 64 (U) [!]
 CRC=EC58EABF AD7C7169
 SaveType=Eeprom 16KB
 Players=4
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [6B4772AA1743FEAC1919618B3FC6B3E1]
 GoodName=Donkey Kong 64 (U) [b1]
@@ -4103,7 +4600,10 @@ GoodName=Doom 64 (E) [!]
 CRC=2C739EAC 9EF77726
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [B482F51B616F4337F1B3BF5EFDD650D4]
 GoodName=Doom 64 (E) [b1]
@@ -4115,7 +4615,10 @@ GoodName=Doom 64 (J) [!]
 CRC=7AA65B36 FDCEE5AD
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [053BB6D2E14D67F0FB0B509F2A6B4485]
 GoodName=Doom 64 (J) [b1]
@@ -4127,7 +4630,10 @@ GoodName=Doom 64 (U) (V1.0) [!]
 CRC=A83E101A E937B69D
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [BF710F7D1D51EC89AC3F58022B2B5D7F]
 GoodName=Doom 64 (U) (V1.0) [T+Bra1.0_Doom64BR]
@@ -4164,12 +4670,20 @@ GoodName=Doom 64 (U) (V1.1) [!]
 CRC=423E96F4 CE88F05B
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [C2166455E94E89E9E3AB612B4377C443]
 GoodName=Doraemon - Nobita to 3tsu no Seireiseki (J) [!]
 CRC=BFF7B1C2 AEBF148E
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [989E7B15D24649B784813E1A07DF6887]
 GoodName=Doraemon - Nobita to 3tsu no Seireiseki (J) [b1]
@@ -4194,9 +4708,12 @@ RefMD5=C2166455E94E89E9E3AB612B4377C443
 [0580D96A71671C9E6972FDCF5897CC26]
 GoodName=Doraemon 2 - Nobita to Hikari no Shinden (J) [!]
 CRC=B6306E99 B63ED2B2
-SaveType=Eeprom 16KB
 Players=1
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [7CC16A6090CAC3749DD6B71CA7A58605]
 GoodName=Doraemon 2 - Nobita to Hikari no Shinden (J) [b1]
@@ -4226,9 +4743,12 @@ RefMD5=0580D96A71671C9E6972FDCF5897CC26
 [A4A1D490BA67831775FC381B846E2168]
 GoodName=Doraemon 3 - Nobita no Machi SOS! (J) [!]
 CRC=A8275140 B9B056E8
-SaveType=Eeprom 16KB
 Players=1
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [FB7565FE1EAAED1CACFAE3B011FA6CB6]
 GoodName=Doraemon 3 - Nobita no Machi SOS! (J) [f1] (PAL-NTSC)
@@ -4240,7 +4760,10 @@ GoodName=Doubutsu no Mori (J) [!]
 CRC=BD8E206D 98C35E1C
 Players=1
 SaveType=Flash RAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [4AB8D6535028805F5794D3F01003CFD5]
 GoodName=Doubutsu no Mori (J) [T+Eng2007-08-10_Brandon Dixon]
@@ -4276,18 +4799,34 @@ RefMD5=A4F7C57C180297B2E7BA5A5FEB44FE0B
 GoodName=Dr. Mario 64 (Ch) (iQue) [!]
 CRC=EF62A343 11E41E37
 Players=4
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [FE49420725F9C1CF0F15BA5682D27709]
 GoodName=Dr. Mario 64 (Ch) (V2) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [B524D10A8A26764EB2198ACEC3F09948]
 GoodName=Dr. Mario 64 (Ch) (V4) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [1A7936367413E5D6874ABDA6D623AD32]
 GoodName=Dr. Mario 64 (U) [!]
 CRC=769D4D13 DA233FFE
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [0AD0800D351F77EC31092096D58C25F0]
 GoodName=Dragon King by CrowTRobo (PD) [b1]
@@ -4308,9 +4847,12 @@ CRC=AE6b1E11 B7CBD69E
 [F120FADB52B414EB4FB7D13092AC3CDB]
 GoodName=Dual Heroes (E) [!]
 CRC=B6524461 ED6D04B1
-SaveType=None
-Mempak=Yes
 Players=2
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [B01D031BE1789565E2B8A44CD76B96C6]
 GoodName=Dual Heroes (E) [b1]
@@ -4332,7 +4874,10 @@ GoodName=Dual Heroes (J) [!]
 CRC=056EAB63 C215FCD5
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [A7D3E42EFFD6E7935DA7C9A6B6899CAC]
 GoodName=Dual Heroes (J) [o1]
@@ -4349,7 +4894,10 @@ GoodName=Dual Heroes (U) [!]
 CRC=A62230C3 F0834488
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [E3EF8D7ACCA9CCB551C26B0F879E6B25]
 GoodName=Dual Heroes (U) [b1]
@@ -4361,8 +4909,11 @@ GoodName=Duck Dodgers Starring Daffy Duck (U) (M3) [!]
 CRC=FBB9F1FA 6BF88689
 Players=1
 SaveType=Eeprom 4KB
-CountPerOp=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [B5A5A71483679DCCACBDA770647A9DBF]
 GoodName=Duck Dodgers Starring Daffy Duck (U) (M3) [t1]
@@ -4374,9 +4925,11 @@ GoodName=Duke Nukem - ZER0 H0UR (E) [!]
 CRC=DC36626A 3F3770CB
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=1
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [51A1EEE441240229BEB2E6CD8FAB285C]
 GoodName=Duke Nukem - ZER0 H0UR (E) [f1] (NTSC)
@@ -4388,18 +4941,22 @@ GoodName=Duke Nukem - ZER0 H0UR (F) [!]
 CRC=32CA974B B2C29C50
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=1
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [026789D47DB5FE202A76F89797B33AC7]
 GoodName=Duke Nukem - ZER0 H0UR (U) [!]
 CRC=04DAF07F 0D18E688
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=1
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [69ED326664E48BAA9CE743E6E9C450DA]
 GoodName=Duke Nukem - ZER0 H0UR (U) [b1]
@@ -4431,8 +4988,10 @@ GoodName=Duke Nukem 64 (E) [!]
 CRC=57BFF74D DE747743
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [BB2472B3F8A41FBF3AEC3CCEF7EA8C78]
 GoodName=Duke Nukem 64 (E) (Beta)
@@ -4454,16 +5013,20 @@ GoodName=Duke Nukem 64 (F)
 CRC=1E12883D D3B92718
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [C7F1A43764A26DA2E43F2A36A5F76E4C]
 GoodName=Duke Nukem 64 (U) [!]
 CRC=A273AB56 DA33DB9A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9BE63892A2AA2B20B75B3AC4E7B7DCDF]
 GoodName=Duke Nukem 64 (U) [b1]
@@ -4530,18 +5093,22 @@ RefMD5=5809670A42CA34D39A39598EFA82F5F3
 [1830EDE2557E8685E6F76D05CC65076A]
 GoodName=ECW Hardcore Revolution (E) [!]
 CRC=8C38E5DB B37C27D7
-SaveType=None
-Mempak=Yes
 Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5D1E41AA28169E71B4919FA08F1ACD9B]
 GoodName=ECW Hardcore Revolution (G) [!]
 CRC=2138A076 408AD8B2
-SaveType=None
-Mempak=Yes
 Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [91545C2642DB6349B8D18BF0BEE29162]
 GoodName=ECW Hardcore Revolution (E) [b1]
@@ -4553,14 +5120,20 @@ GoodName=ECW Hardcore Revolution (U) [!]
 CRC=BDF9766D BD068D70
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [BF2DF4B86FAA2181A7ACFE2643FA2293]
 GoodName=Earthworm Jim 3D (E) (M6) [!]
 CRC=492B9DE8 C6CCC81C
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [97EA079ECF105EA16654A855644D870A]
 GoodName=Earthworm Jim 3D (E) (M6) [b1]
@@ -4572,6 +5145,10 @@ GoodName=Earthworm Jim 3D (U) [!]
 CRC=DF574191 9EB5123D
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [554EE4BF15388DDE586DE90AC72EF5FA]
 GoodName=Earthworm Jim 3D (U) [T+Rus]
@@ -4597,7 +5174,10 @@ RefMD5=980DFB38AD9A883119DE135F45B7DB36
 GoodName=Eikou no Saint Andrews (J) [!]
 CRC=0DED0568 1502515E
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [936DB74AE766BB1219E8A712F0D06E4A]
 GoodName=Eikou no Saint Andrews (J) [b1]
@@ -4626,8 +5206,12 @@ CRC=6D9D1FE4 84D10BEA
 [15DF97A59B2354B130DEC3FB86BBA513]
 GoodName=Elmo's Letter Adventure (U) [!]
 CRC=F2A653CB 60633B3B
-SaveType=None
 Players=1
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [F733453ED26AFA0ACA8D3EB3B5B6D8EA]
@@ -4635,13 +5219,20 @@ GoodName=Elmo's Number Journey (U) [!]
 CRC=02B1538F C94B88D0
 Players=1
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [9B456ACB96291FC8B55232A08AE03346]
 GoodName=Eltale Monsters (J) [!]
 CRC=E13AE2DC 4FB65CE8
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [752EF6D2C2A6DBBB8CBAEFB596412C1D]
 GoodName=Eltale Monsters (J) [b1]
@@ -4673,42 +5264,58 @@ CRC=D49DFF90 8DB53A8C
 GoodName=Excitebike 64 (Ch) (iQue) [!]
 Players=4
 CountPerOp=1
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [876F87C91A4B6339DAA8FC1F41EB7ACD]
 GoodName=Excitebike 64 (Ch) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [8FA253FD69B73DF9A831EF2F731491F2]
 GoodName=Excitebike 64 (E) [!]
 CRC=202A8EE4 83F88B89
-SaveType=Eeprom 16KB
 Players=4
-CountPerOp=1
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [BF15A61AFF71C93BF5E05243F57BCA1D]
 GoodName=Excitebike 64 (J) [!]
 CRC=861C3519 F6091CE5
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [E0018C33346714B63A55C0E040F23DEA]
 GoodName=Excitebike 64 (U) (Kiosk Demo) [!]
 CRC=AF754F7B 1DD17381
 SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [7200D1C1CF489FAFFF767729F215E6E6]
 GoodName=Excitebike 64 (U) (V1.0) [!]
 CRC=07861842 A12EBC9F
-SaveType=Eeprom 16KB
 Players=4
-CountPerOp=1
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [496929EA74183198D121035EA808C480]
 GoodName=Excitebike 64 (U) (V1.0) [b1]
@@ -4728,11 +5335,13 @@ RefMD5=7200D1C1CF489FAFFF767729F215E6E6
 [21954E4E404D9E87DBDB87DD309F3E94]
 GoodName=Excitebike 64 (U) (V1.1) [!]
 CRC=F9D411E3 7CB29BC0
-SaveType=Eeprom 16KB
 Players=4
-CountPerOp=1
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [6DCFDE0423D1DB58EA9E6A8F1BFFD849]
 GoodName=Explode Demo by NaN (PD)
@@ -4743,8 +5352,10 @@ GoodName=Extreme-G (E) (M5) [!]
 CRC=8E9D834E 1E8B29A9
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [BF72E10EB79E00E095829112576F01FE]
 GoodName=Extreme-G (E) (M5) [b1]
@@ -4776,16 +5387,20 @@ GoodName=Extreme-G (J) [!]
 CRC=EE802DC4 690BD57D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [3E660D3F991C0529E90BFEC0244DB31A]
 GoodName=Extreme-G (U) [!]
 CRC=FDA245D2 A74A3D47
-SaveType=None
-Mempak=Yes
 Players=4
+SaveType=None
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6D954294E254E239B3EA694C2D9ADFF9]
 GoodName=Extreme-G (U) [h1C]
@@ -4807,24 +5422,30 @@ GoodName=Extreme-G XG2 (E) (M5) [!]
 CRC=1185EC85 4B5A7731
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F17884A2C16FB6FD11A74D65B1388B4A]
 GoodName=Extreme-G XG2 (J) [!]
 CRC=399B9B81 D533AD11
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [44FE06BA3686C02A7988F27600A533DA]
 GoodName=Extreme-G XG2 (U) [!]
 CRC=5CD4150B 470CC2F1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [B0F9C3EC65C1C88A43C694EBF429E008]
 GoodName=Extreme-G XG2 (U) [t1]
@@ -4836,7 +5457,10 @@ GoodName=F-1 Pole Position 64 (E) (M3) [!]
 CRC=FDD248B2 569A020E
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [ACBB37B24238F82B2333B710CBEE388A]
 GoodName=F-1 Pole Position 64 (E) (M3) [b1]
@@ -4848,7 +5472,10 @@ GoodName=F-1 Pole Position 64 (U) (M3) [!]
 CRC=AE82687A 9A3F388D
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [6CE5D16E977B1D4E0E71E209B2932099]
 GoodName=F-1 Pole Position 64 (U) (M3) [b1]
@@ -4870,7 +5497,10 @@ GoodName=F-1 World Grand Prix (E) (Prototype) [!]
 CRC=CC3CC8B3 0EC405A4
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [08B8942E977A81CAF81DAC2237E1AA65]
 GoodName=F-1 World Grand Prix (E) (Prototype) [h1C]
@@ -4882,21 +5512,30 @@ GoodName=F-1 World Grand Prix (E) [!]
 CRC=C006E3C0 A67B4BBB
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [35F6C42D5A9284688284C24250F4D6BE]
 GoodName=F-1 World Grand Prix (F) [!]
 CRC=B70BAEE5 3A5005A8
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [A8C78454C70BD73375AAF69C4078D5DA]
 GoodName=F-1 World Grand Prix (G) [!]
 CRC=38442634 66B3F060
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [AA15FA62A776917E594A17B49BBC6980]
 GoodName=F-1 World Grand Prix (G) [b1]
@@ -4928,7 +5567,10 @@ GoodName=F-1 World Grand Prix (J) [!]
 CRC=64BF47C4 F4BD22BA
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [7DFE40E387971269F38FE3CBE803567A]
 GoodName=F-1 World Grand Prix (J) [h1C]
@@ -4938,9 +5580,12 @@ RefMD5=F248F0AAE609111BA9DFF9FD7AFBC485
 [A81B1DE864DF3F4BB0903760BE673F21]
 GoodName=F-1 World Grand Prix (U) [!]
 CRC=CC3CC8B3 0EC405A4
-SaveType=Eeprom 4KB
 Players=2
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [4E450DD2899FE7434110E30E19DD10A2]
 GoodName=F-1 World Grand Prix (U) [h1C]
@@ -4956,7 +5601,11 @@ RefMD5=A81B1DE864DF3F4BB0903760BE673F21
 GoodName=F-1 World Grand Prix II (E) (M4) [!]
 CRC=07C1866E 5775CCDE
 Players=2
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [D9B59E463A73FA880E6682A08D1C3071]
 GoodName=F-1 World Grand Prix II (E) (M4) [f1] (NTSC)
@@ -4971,19 +5620,34 @@ RefMD5=BC0FD2468AC7769A37C3C58CD5699585
 [4024477AAED7DD5FF5EA60BF568123B7]
 GoodName=F-ZERO X (Ch) (iQue) [!]
 Players=4
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [8400C0875E16F599C1B7FC433E339D58]
 GoodName=F-ZERO X (Ch) (V2) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [9729FC397E8D178EA974869E07DF0502]
 GoodName=F-ZERO X (Ch) (V4) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [EE79A8FE287B5DCAEA584439363342FC]
 GoodName=F-ZERO X (E) [!]
 CRC=776646F6 06B9AC2B
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [0722E679F9695D9E5F1D2823DC7D8004]
 GoodName=F-ZERO X (E) [b1]
@@ -5020,7 +5684,10 @@ GoodName=F-ZERO X (J) [!]
 CRC=4D3E622E 9B828B4E
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [C14AE14C6DE0DCA126C423C4ADBEE315]
 GoodName=F-ZERO X (J) [b1]
@@ -5047,14 +5714,20 @@ GoodName=F-ZERO X (U) (DXP Track Pack Hack)
 CRC=3983D1A9 2004158C
 SaveType=SRAM
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [753437D0D8ADA1D12F3F9CF0F0A5171F]
 GoodName=F-ZERO X (U) [!]
 CRC=B30ED978 3003C9F9
 SaveType=SRAM
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [3AE32658B839FFA3189E3CA84E0B884A]
 GoodName=F-ZERO X (U) [f1] (Sex V1.0 Hack)
@@ -5079,16 +5752,20 @@ GoodName=F1 Racing Championship (B) (M2) [!]
 CRC=53CCAD28 AEA6EDA2
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9581FC6CEAC86DC8A2AEE4053043E422]
 GoodName=F1 Racing Championship (E) (M5) [!]
 CRC=3CECBCB8 6126BF07
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AA951294528CA2CF55F810F9FE433F8D]
 GoodName=F1 Racing Championship (E) (M5) [f1] (NTSC)
@@ -5100,7 +5777,10 @@ GoodName=FIFA - Road to World Cup 98 (E) (M7) [!]
 CRC=0E31EDF0 C37249D5
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [479554129EB27A3546BAC96C80AF4F88]
 GoodName=FIFA - Road to World Cup 98 (E) (M7) [o1]
@@ -5112,7 +5792,10 @@ GoodName=FIFA - Road to World Cup 98 (U) (M7) [!]
 CRC=CB1ACDDE CF291DF2
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [4E275B05BABCA9F2CD77749026BEA5ED]
 GoodName=FIFA - Road to World Cup 98 (U) (M7) [b1]
@@ -5144,14 +5827,20 @@ GoodName=FIFA - Road to World Cup 98 - World Cup heno Michi (J) [!]
 CRC=F5733C67 17A3973A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [6432C622C05EA9CD3217E280AC2CE37C]
 GoodName=FIFA 99 (E) (M8) [!]
 CRC=0198A651 FC219D84
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [940FFB6C94F84BFFD972A69ED86DD2FD]
 GoodName=FIFA 99 (E) (M8) [hI]
@@ -5163,7 +5852,10 @@ GoodName=FIFA 99 (U) [!]
 CRC=7613A630 3ED696F3
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [22082B8D892A2560032FD4DA5AB975A1]
 GoodName=FIFA 99 (U) [b1]
@@ -5175,7 +5867,10 @@ GoodName=FIFA Soccer 64 (E) (M3) [!]
 CRC=C3F19159 65D2BC5A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [1D71761771E3BFFC091E38B9E8B5E590]
 GoodName=FIFA Soccer 64 (E) (M3) [b1]
@@ -5207,7 +5902,10 @@ GoodName=FIFA Soccer 64 (U) (M3) [!]
 CRC=C3F19159 65D2BC5A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [CA56F2DE80839EC88750C15A21AA7C53]
 GoodName=FIFA Soccer 64 (U) (M3) [b1]
@@ -5222,7 +5920,11 @@ RefMD5=CC7C58A032AABA19E72CCBFA6B3EEFF6
 [D99B1A3F6D72DEFD76F3620959B94944]
 GoodName=Famista 64 (J) [!]
 CRC=6DFF4C37 B1B763FD
+Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [EACE2271AE7F32A71625C9074115D640]
 GoodName=Famista 64 (J) [b1]
@@ -5261,8 +5963,10 @@ GoodName=Fighter Destiny 2 (U) [!]
 CRC=AEEF2F45 F97E30F1
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [7B5AFA5D60F53FA640A5F2F24F5B2741]
 GoodName=Fighter Destiny 2 (U) [f1] (PAL-NTSC)
@@ -5274,32 +5978,40 @@ GoodName=Fighter's Destiny (E) [!]
 CRC=36F1C74B F2029939
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [44B0BE1C4B48F6119D3AC9424903D0EB]
 GoodName=Fighter's Destiny (F) [!]
 CRC=0C41F9C2 01717A0D
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1CF379ACA2397222AF9F3DC5D8E3C444]
 GoodName=Fighter's Destiny (G) [!]
 CRC=FE94E570 E4873A9C
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [D61D97A7658C419A25A9BAC96B0A3DF8]
 GoodName=Fighter's Destiny (U) [!]
 CRC=52F78805 8B8FCAB7
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6E7C82AFF9F73A3DBF5B18D924BDF103]
 GoodName=Fighter's Destiny (U) [b1]
@@ -5316,26 +6028,32 @@ GoodName=Fighting Cup (J) [!]
 CRC=49E46C2D 7B1A110C
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [0035E8205336982E362402AAEA37D147]
 GoodName=Fighting Force 64 (E) [!]
 CRC=66CF0FFE AD697F9C
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=1
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [E7008D17FD71D9C2BDA1362C885388B2]
 GoodName=Fighting Force 64 (U) [!]
 CRC=32EFC7CB C3EA3F20
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
-CountPerOp=1
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [13962910EFD82C2A2333CF38EE1FCD96]
 GoodName=Fighting Force 64 (U) [T+Ita_Cattivik66]
@@ -5371,20 +6089,24 @@ CRC=5CABD891 6229F6CE
 [ADD115AAD0AB7D33BFD243936D809178]
 GoodName=Flying Dragon (E) [!]
 CRC=22E9623F B60E52AD
-SaveType=None
-Mempak=Yes
 Players=2
-CountPerOp=1
+SaveType=None
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [272B359D8F8AC48ACBF053C262F422E4]
 GoodName=Flying Dragon (U) [!]
 CRC=A92D52E5 1D26B655
-SaveType=None
-Mempak=Yes
 Players=2
-CountPerOp=1
+SaveType=None
+Biopak=No
+Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [46E9A352AD6AFB83B0557EC659957B2E]
 GoodName=Flying Dragon (U) [b1]
@@ -5409,16 +6131,20 @@ GoodName=Forsaken 64 (E) (M4) [!]
 CRC=142A17AA 13028D96
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [74650F7154E0B2DD7C364F511B0D6A77]
 GoodName=Forsaken 64 (G) [!]
 CRC=C3CD76FF 9B9DCBDE
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F023F3189722A96ACDCF0BDD9154EF11]
 GoodName=Forsaken 64 (G) [h1C]
@@ -5435,8 +6161,10 @@ GoodName=Forsaken 64 (U) [!]
 CRC=9E330C01 8C0314BA
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [C61FBF0BE56FBCD8FD373EDFB5D3E538]
 GoodName=Forsaken 64 (U) [b1]
@@ -5463,7 +6191,10 @@ GoodName=Fox Sports College Hoops '99 (U) [!]
 CRC=3261D479 ED0DBC25
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [EE0C756F832827E3ACDF6DBD410ADCA4]
 GoodName=Fox Sports College Hoops '99 (U) [f1] (PAL)
@@ -5497,12 +6228,18 @@ CRC=CEE5C8CD D3D85466
 [097189B4C9BF6775E4685951B6E66F24]
 GoodName=Frogger 2 (U) (Prototype 1) [!]
 CRC=AD19A172 9004666A
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [CB2C9C6104C3EF69A1CF979525F2F73D]
 GoodName=Frogger 2 (U) (Prototype 2) [!]
 CRC=E8E5B179 44AA30E8
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [27F61A55E27EA7F1EDE4CA11966ACC7C]
 GoodName=Frogger 2 (U) (Alpha) [o1]
@@ -5519,7 +6256,10 @@ GoodName=Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (J) 
 CRC=F774EAEE F0D8B13E
 Players=1
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [316C59DAE45C20250A0419A937E7D65B]
@@ -5527,16 +6267,20 @@ GoodName=G.A.S.P!! Fighter's NEXTream (E) [!]
 CRC=68FCF726 49658CBC
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6C73558DE5A1EEE6597D7264F9A11B0C]
 GoodName=G.A.S.P!! Fighter's NEXTream (J) [!]
 CRC=AF8679B6 5E1011BF
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [D7C983F603EE7AE8156C6EAEEF7195C4]
 GoodName=G.A.S.P!! Fighter's NEXTream (J) [o1]
@@ -5564,9 +6308,11 @@ GoodName=GT 64 - Championship Edition (E) (M3) [!]
 CRC=EE4A0E33 8FD588C9
 SaveType=Eeprom 16KB
 Players=2
-CountPerOp=1
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [15DB716942C36A0CB392226001536A2A]
 GoodName=GT 64 - Championship Edition (E) (M3) [b1]
@@ -5588,9 +6334,11 @@ GoodName=GT 64 - Championship Edition (U) [!]
 CRC=C49ADCA2 F1501B62
 Players=2
 SaveType=Eeprom 16KB
-CountPerOp=1
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
+CountPerOp=1
 
 [4695A944B019F3829F2616591659A7CE]
 GoodName=GT 64 - Championship Edition (U) [b1]
@@ -5658,7 +6406,10 @@ GoodName=Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J) [!]
 CRC=457B9CD9 09C55352
 Players=2
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [7EB07675E2E9CB547A3B238AA71F57CC]
@@ -5676,15 +6427,20 @@ GoodName=Ganbare Goemon - Mononoke Sugoroku (J) [!]
 CRC=B2C6D27F 2DA48CFD
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [9B929E0BF8D63E62820F2FA6257CC5CF]
 GoodName=Ganbare Goemon - Neo Momoyama Bakufu no Odori (J) [!]
 CRC=832C168B 56A2CDAE
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [7F4E8F2ECF04BE27E660AC2EFDAC0C68]
@@ -5712,15 +6468,20 @@ GoodName=Ganbare Nippon! Olympics 2000 (J) [!]
 CRC=21FFFD0A FA0D1D98
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [28C2108A375F7731E719333A09439D2F]
 GoodName=Gauntlet Legends (E) [!]
 CRC=D543BCD6 2BA5E256
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [0806E6DB8B2BF0501BE9F2D78D280DCF]
@@ -5733,8 +6494,10 @@ GoodName=Gauntlet Legends (J) [!]
 CRC=70B0260E 6716D04C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [9CB963E8B71F18568F78EC1AF120362E]
@@ -5742,8 +6505,10 @@ GoodName=Gauntlet Legends (U) [!]
 CRC=729B5E32 B728D980
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [50F8E73CA0160EB1A339AC2137A7B559]
@@ -5755,8 +6520,11 @@ RefMD5=9CB963E8B71F18568F78EC1AF120362E
 GoodName=Getter Love!! (J) [!]
 CRC=489C84E6 4C6E49F9
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [3BE170E7E94A03BD4E36732EB137EE39]
 GoodName=Getter Love!! (J) [b1]
@@ -5773,8 +6541,10 @@ GoodName=Gex 3 - Deep Cover Gecko (E) (M2) (Fre-Ger) [!]
 CRC=874733A4 A823745A
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9F0492A34D7A2D7C4E9F29DC1848A04A]
 GoodName=Gex 3 - Deep Cover Gecko (E) (M3) (Eng-Spa-Ita) [!]
@@ -5789,8 +6559,10 @@ GoodName=Gex 3 - Deep Cover Gecko (U) [!]
 CRC=3EDC7E12 E26C1CC9
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6E0FCFF93600A28C379EF52940C54E68]
 GoodName=Gex 3 - Deep Cover Gecko (U) [f1] (PAL)
@@ -5807,14 +6579,20 @@ GoodName=Gex 64 - Enter the Gecko (E) [!]
 CRC=E68A000E 639166DD
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [47F9D900C97ECE154BB40A9C6DCCD3FD]
 GoodName=Gex 64 - Enter the Gecko (U) [!]
 CRC=89FED774 CAAFE21B
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [A33677B04870DE18013B760B4F53F6BF]
 GoodName=Gex 64 - Enter the Gecko (U) [f1] (PAL)
@@ -5839,6 +6617,10 @@ GoodName=Glover (E) (M3) [!]
 CRC=F5237301 99E3EE93
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [8881FBEAE9B84485CF66876B60CD45DF]
 GoodName=Glover (E) (M3) [f1] (NTSC)
@@ -5854,6 +6636,10 @@ GoodName=Glover (U) [!]
 CRC=8E6E01FF CCB4F948
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A1C34717476027DFBA72EEA56F94D650]
 GoodName=Glover (U) [b1]
@@ -5883,8 +6669,10 @@ GoodName=Goemon's Great Adventure (U) [!]
 CRC=4252A5AD AE6FBF4E
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [231BAC1AFB3DE138072C2D697783059B]
@@ -5892,7 +6680,10 @@ GoodName=Golden Nugget 64 (U) [!]
 CRC=4690FB1C 4CD56D44
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [7CE28ADAB6FE43207B4BB19564C38AEF]
 GoodName=Golden Nugget 64 (U) [b1]
@@ -5924,7 +6715,10 @@ GoodName=GoldenEye 007 (E) [!]
 CRC=0414CA61 2E57B8AA
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 Status=4
 
 [ECD4F078DC77F4B2D12C1C0F5CABA323]
@@ -5947,7 +6741,10 @@ GoodName=GoldenEye 007 (J) [!]
 CRC=A24F4CF1 A82327BA
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 Status=4
 
 [FB916F914D9635F8FCBCE37A6466079D]
@@ -5996,7 +6793,10 @@ GoodName=GoldenEye 007 (U) [!]
 CRC=DCBC50D1 09FD1AA3
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 Status=4
 
 [0B5A50E8D477B3BC53BE997264FE84A5]
@@ -6051,9 +6851,11 @@ GoodName=HSV Adventure Racing (A) [!]
 CRC=72611D7D 9919BDD2
 Players=4
 SaveType=None
-CountPerOp=3
-Rumble=Yes
+Biopak=No
 Mempak=Yes
+Rumble=Yes
+Transferpak=No
+CountPerOp=3
 
 [7B38C3F7DA8D9778B41B0047A133590A]
 GoodName=HSV Adventure Racing (A) [b1]
@@ -6069,7 +6871,10 @@ RefMD5=26F7D8F4640EBDFA823F84E5F89D62BF
 GoodName=Hamster Monogatari 64 (J) [!]
 CRC=95A80114 E0B72A7F
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [617197EF2B6B51E58488C9F6B75F112E]
@@ -6090,8 +6895,10 @@ CRC=9856E53D AF483207
 GoodName=Harukanaru Augusta Masters 98 (J) [!]
 CRC=09AE57B1 182A5637
 Players=1
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [397A69AA3829EA5FECB4CDF399084E31]
 GoodName=Harukanaru Augusta Masters 98 (J) [b1]
@@ -6113,6 +6920,10 @@ GoodName=Harvest Moon 64 (U) [!]
 CRC=98DF9DFC 6606C189
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [3CDD87026EFEC9A03648D225F97858A5]
@@ -6148,6 +6959,11 @@ CRC=5D391A40 84D7A637
 GoodName=Heiwa Pachinko World 64 (J) [!]
 CRC=3E70E866 4438BAE8
 Players=1
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [9D0D85E3A0C94B98D6404E8FC28E7B01]
 GoodName=Heiwa Pachinko World 64 (J) [b1]
@@ -6179,8 +6995,10 @@ GoodName=Hercules - The Legendary Journeys (E) (M6) [!]
 CRC=AE90DBEB 79B89123
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [6BBD8C42F6EF8F5B9541D6F4DB657DD7]
@@ -6188,8 +7006,10 @@ GoodName=Hercules - The Legendary Journeys (U) [!]
 CRC=7F3CEB77 8981030A
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [57D8E020643146B325A11612FEFACF74]
@@ -6217,7 +7037,10 @@ GoodName=Hexen (E) [!]
 CRC=95B2B30B 2B6415C1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [E86A8BF46985B7CE8459AFBE5FC3DCC3]
@@ -6230,7 +7053,10 @@ GoodName=Hexen (F) [!]
 CRC=5C1B5FBD 7E961634
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [08CBB141DEC604E4DAD2787F237D57A2]
@@ -6238,7 +7064,10 @@ GoodName=Hexen (G) [!]
 CRC=9AB3B50A BC666105
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [35E9ECE11306EF7D8F5F09F65761D365]
@@ -6251,7 +7080,10 @@ GoodName=Hexen (J) [!]
 CRC=66751A57 54A29D6E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [EB98F1B8C6898AF7417F6882946DA9B3]
@@ -6259,7 +7091,10 @@ GoodName=Hexen (U) [!]
 CRC=9CAB6AEA 87C61C00
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [B06625703DB3A03BAE3D02FD0F904541]
@@ -6287,7 +7122,10 @@ GoodName=Hey You, Pikachu! (U) [!]
 CRC=D3F10E5D 052EA579
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [DCC316EFFC4928F5B0AE8D273D8024BF]
 GoodName=HiRes CFB Demo (PD)
@@ -6298,8 +7136,10 @@ GoodName=Hiryuu no Ken Twin (J) [!]
 CRC=35FF8F1A 6E79E3BE
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [8976913EFBE98EFED3B0B32CBCAA8B49]
@@ -6322,7 +7162,10 @@ GoodName=Holy Magic Century (E) [!]
 CRC=277B129D DD3879FF
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [FA6A2E00BBFF236DAC91F08544AFFA40]
 GoodName=Holy Magic Century (E) [b1]
@@ -6334,7 +7177,10 @@ GoodName=Holy Magic Century (F)
 CRC=B35FEBB0 7427B204
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [668908C495432AD099C5439E38809053]
 GoodName=Holy Magic Century (F) [h1C]
@@ -6351,7 +7197,10 @@ GoodName=Holy Magic Century (G) [!]
 CRC=75FA0E14 C9B3D105
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [ACF823A6EF4E77FE5B940D716DCED6E9]
 GoodName=Holy Magic Century (G) [b1]
@@ -6371,9 +7220,12 @@ RefMD5=AB676C3E9D26A77450DDB4AACD1A3861
 [B1A67AEBC2BE89A800E5EB60C0DFA968]
 GoodName=Hoshi no Kirby 64 (J) (V1.0) [!]
 CRC=C1D702BD 6D416547
-SaveType=SRAM
 Players=4
+SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [460A42ED5612EBBF92F386689067384E]
 GoodName=Hoshi no Kirby 64 (J) (V1.0) [f1]
@@ -6390,29 +7242,40 @@ GoodName=Hoshi no Kirby 64 (J) (V1.1) [!]
 CRC=CA1BB86F 41CCA5C5
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [3EC0471E2CBEE17471DDBF80C56606D5]
 GoodName=Hoshi no Kirby 64 (J) (V1.2) [!]
 CRC=0C581C7A 3D6E20E4
 Players=4
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [35E039F8E79843917D02BE06D00C457B]
 GoodName=Hoshi no Kirby 64 (J) (V1.3) [!]
 CRC=BCB1F89F 060752A2
 Players=4
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [EF34DA35EF8A0734843CB182C19FEB26]
 GoodName=Hot Wheels Turbo Racing (E) (M3) [!]
 CRC=E7D20193 C1158E93
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [BB8A58282C5D4E32B34556407ACD920E]
 GoodName=Hot Wheels Turbo Racing (E) (M3) [b1]
@@ -6424,8 +7287,10 @@ GoodName=Hot Wheels Turbo Racing (U) [!]
 CRC=C7C98F8E 42145DDE
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [50091668743D2DE7CAA253420D32C2D8]
 GoodName=Hot Wheels Turbo Racing (U) [f1] (PAL)
@@ -6442,7 +7307,10 @@ GoodName=Human Grand Prix - New Generation (J) [!]
 CRC=5535972E BD8E3295
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [F9A6FFD35D478A8E2B369460BFAB2CC8]
 GoodName=Human Grand Prix - New Generation (J) [b1]
@@ -6459,8 +7327,10 @@ GoodName=Hybrid Heaven (E) (M3) [!]
 CRC=641D3A7F 86820466
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [24B023696975D27EAE8319EF40001348]
 GoodName=Hybrid Heaven (E) (M3) [b1]
@@ -6477,8 +7347,10 @@ GoodName=Hybrid Heaven (J) [!]
 CRC=0DE2CE36 D41D29E6
 Players=2
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [94B284286A090B5980B7F18A4FA77853]
 GoodName=Hybrid Heaven (J) [b1]
@@ -6495,8 +7367,10 @@ GoodName=Hybrid Heaven (U) [!]
 CRC=102888BF 434888CA
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [115521BAC11608FEBCE874F243ACC66E]
 GoodName=Hybrid Heaven (U) [f1] (PAL)
@@ -6513,8 +7387,10 @@ GoodName=Hydro Thunder (E) [!]
 CRC=B58988E9 B1FC4BE8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [1F57194EA272CF5DB500D228E9C94D75]
@@ -6527,8 +7403,10 @@ GoodName=Hydro Thunder (F) [!]
 CRC=29A045CE ABA9060E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [54F43E6B68782E98CAABEA5E7976B2BE]
@@ -6536,8 +7414,10 @@ GoodName=Hydro Thunder (U) [!]
 CRC=C8DC65EB 3D8C8904
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [22AAD544C062FB8A2DC6B2DEB32DE188]
@@ -6570,7 +7450,10 @@ GoodName=Hyper Olympics in Nagano 64 (J) [!]
 CRC=2FC5C34C 7A05CC9D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [3B6FF1829CBBEAE87704F53950791D64]
 GoodName=Hyper Olympics in Nagano 64 (J) [b1]
@@ -6597,6 +7480,10 @@ GoodName=Ide Yousuke no Mahjong Juku (J) [!]
 CRC=77DA3B8D 162B0D7C
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [DC577D70E9308F94E5F3CE03F3508539]
 GoodName=Ide Yousuke no Mahjong Juku (J) [b1]
@@ -6606,10 +7493,12 @@ RefMD5=92A6FFA1C8D537C7A97C5C613CAE05C6
 [25B297143E9E5CCBB4B80A7FB6AF399B]
 GoodName=Iggy's Reckin' Balls (E) [!]
 CRC=D692CC5E EC58D072
-Players=2
+Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 DisableExtraMem=1
 
 [26CEC7A56ABB81F3468CFA26D8F16B67]
@@ -6620,10 +7509,12 @@ RefMD5=25B297143E9E5CCBB4B80A7FB6AF399B
 [464211ABB602EE1005974D2D835A3BCF]
 GoodName=Iggy's Reckin' Balls (U) [!]
 CRC=E616B5BC C9658B88
-Players=2
+Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 DisableExtraMem=1
 
 [8BF0EAFB7014B7B5CE8E7D778B6B4B99]
@@ -6634,10 +7525,12 @@ RefMD5=464211ABB602EE1005974D2D835A3BCF
 [C70B0B680807F2B8C2C3D5DC495FA8C2]
 GoodName=Iggy-kun no Bura Bura Poyon (J) [!]
 CRC=69458B9E FC95F936
-Players=2
+Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 DisableExtraMem=1
 
 [827106236756DC5B585C4226184835FA]
@@ -6650,7 +7543,10 @@ GoodName=In-Fisherman Bass Hunter 64 (U) [!]
 CRC=8C138BE0 95700E46
 SaveType=Eeprom 4KB
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [1AF93922A67085AB2C777B1F08AF365B]
@@ -6663,35 +7559,50 @@ GoodName=Indiana Jones and the Infernal Machine (U) [!]
 CRC=AF9DCC15 1A723D88
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [63D7AB29BA3DFC5D5B12C1D9C5832355]
 GoodName=Indiana Jones and the Infernal Machine (E) (Unreleased)
 CRC=3A6F8C6B 2897BAEB
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [A7781D441AF55C4FF8AFC68AB3A59313]
 GoodName=Indy Racing 2000 (U) [!]
 CRC=E436467A 82DE8F9B
 SaveType=Eeprom 4KB
 Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [34489365B550F32C97337D86D52D8C84]
 GoodName=International Superstar Soccer '98 (E) [!]
 CRC=F41B6343 C10661E6
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [7DCC05B98E2FA690B478808EBBAD5D1A]
 GoodName=International Superstar Soccer '98 (U) [!]
 CRC=7F0FDA09 6061CE0B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [43B326B27B89288F2D17D22EA49F86BD]
 GoodName=International Superstar Soccer '98 (U) [o1]
@@ -6703,24 +7614,30 @@ GoodName=International Superstar Soccer 2000 (E) (M2) (Eng-Ger) [!]
 CRC=336364A0 06C8D5BF
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [CC2BE97A16744860FAE8A94611479C4C]
 GoodName=International Superstar Soccer 2000 (E) (M2) (Fre-Ita) [!]
 CRC=BAE8E871 35FF944E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [23A4ED8D79882594206173B1D476F0E9]
 GoodName=International Superstar Soccer 2000 (U) (M2) [!]
 CRC=8E835437 CD5748B4
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [ACF18822457A451B09BD88E15A70505C]
 GoodName=International Superstar Soccer 2000 (U) (M2) [f1] (PAL)
@@ -6732,15 +7649,20 @@ GoodName=International Superstar Soccer 2000 (U) (V1.1) (M2) [!]
 CRC=96816CCD 272EA8C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [376803F28CA8B2133671783419933CA2]
 GoodName=International Superstar Soccer 64 (E) [!]
 CRC=E2D37CF0 F57E4EAE
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [7FCC22F4BF1FC82F886C455981D2A420]
@@ -6768,7 +7690,10 @@ GoodName=International Superstar Soccer 64 (U) [!]
 CRC=5F2763C4 62412AE5
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [C0969E1C141BE6E144E651CAB1AEA3D8]
@@ -6799,17 +7724,26 @@ GoodName=International Track & Field Summer Games (E) (M3) [!]
 CRC=6712C779 3B72781D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F9190DBAF547D6D3F5F3569ACCF26061]
 GoodName=iQue Club (Ch) (V3) (iQue) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [1247B093E0FD6CCFD50D15DE59301076]
 GoodName=J.League Dynamite Soccer 64 (J) [!]
 CRC=87766747 91C27165
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [849DA5F1790A386B1CD9118CA1398E9D]
 GoodName=J.League Dynamite Soccer 64 (J) [b1]
@@ -6850,7 +7784,10 @@ RefMD5=1247B093E0FD6CCFD50D15DE59301076
 GoodName=J.League Eleven Beat 1997 (J) [!]
 CRC=4FBFA429 6920BB15
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [E3CE4ADB8A7C0CF39E11A2846E00178A]
 GoodName=J.League Eleven Beat 1997 (J) [b1][h1C]
@@ -6871,7 +7808,10 @@ RefMD5=30E23D3DE446E37E5E7FBEF6794A6FC9
 GoodName=J.League Live 64 (J) [!]
 CRC=54554A42 E4985FFB
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [46F584DBFA1E292F0ECA74CA1B12009C]
 GoodName=J.League Live 64 (J) [b1]
@@ -6882,6 +7822,10 @@ RefMD5=209DB8333EEB526AE9A91209175348CE
 GoodName=J.League Tactics Soccer (J) (V1.0) [!]
 CRC=E8D29DA0 15E61D94
 Players=4
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [F604701C59C7D2BBA2492D0073E928F2]
 GoodName=J.League Tactics Soccer (J) (V1.0) [b1]
@@ -6897,6 +7841,10 @@ RefMD5=800ACC7D609ECDB3E09E68CBD05F5FA0
 GoodName=J.League Tactics Soccer (J) (V1.1) [!]
 CRC=C6CE0AAA D117F019
 Players=4
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [45F6B7EAF40E8445205904934EE365A6]
 GoodName=JPEG Slideshow Viewer by Garth Elgar (PD)
@@ -6906,7 +7854,10 @@ CRC=A957851C 535A5667
 GoodName=Jangou Simulation Mahjong Do 64 (J) [!]
 CRC=C73AD016 48C5537D
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [82388A4B44EF74F9C250C8152AB93669]
 GoodName=Jangou Simulation Mahjong Do 64 (J) [b1]
@@ -6932,6 +7883,10 @@ GoodName=Jeopardy! (U) [!]
 CRC=69256460 B9A3F586
 Players=3
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [05318721C273CB65CFBDF78AC2724BF2]
 GoodName=Jeopardy! (U) [h1C]
@@ -6953,16 +7908,20 @@ GoodName=Jeremy McGrath Supercross 2000 (E) [!]
 CRC=21F7ABFB 6A8AA7E8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [8046A4B8ABD4353B2AB9696106CCF8D2]
 GoodName=Jeremy McGrath Supercross 2000 (U) [!]
 CRC=BB30B1A5 FCF712CE
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [29E0AB31B3FC6A6B1EFC11FBDB82CB97]
 GoodName=Jeremy McGrath Supercross 2000 (U) [f1]
@@ -6974,7 +7933,10 @@ GoodName=Jet Force Gemini (E) (M4) [!]
 CRC=68D7A1DE 0079834A
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [821E7F74880BBD04AA9501D3BB25138E]
 GoodName=Jet Force Gemini (E) (M4) [T+Ita0.9beta_Rulesless]
@@ -6990,7 +7952,10 @@ RefMD5=BAAF237E71AA7526C9B2F01C08B68A53
 GoodName=Jet Force Gemini (U) (Kiosk Demo) [!]
 CRC=DFD8AB47 3CDBEB89
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E423A21C971B8A91C3E8980E2605B840]
 GoodName=Jet Force Gemini (U) (Kiosk Demo) [b1]
@@ -7017,7 +7982,10 @@ GoodName=Jet Force Gemini (U) [!]
 CRC=8A6009B6 94ACE150
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [92E6117285EC6A2D836B1C6839DDFD9B]
 GoodName=Jet Force Gemini (U) [b1]
@@ -7033,7 +8001,10 @@ RefMD5=772CC6EAB2620D2D3CDC17BBC26C4F68
 GoodName=Jikkyou G1 Stable (J) (V1.0) [!]
 CRC=AF19D9F5 B70223CC
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [4BBAF03594C6DCECB135AC8C57CB4CD7]
 GoodName=Jikkyou G1 Stable (J) (V1.0) [b1]
@@ -7044,14 +8015,20 @@ RefMD5=878D8A26FD02FDB08200464CB6F566EF
 GoodName=Jikkyou G1 Stable (J) (V1.1) [!]
 CRC=575F340B 9F1398B2
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [1FB40EE386B58FEAB6CF29DDB33BCCCC]
 GoodName=Jikkyou J.League 1999 - Perfect Striker 2 (J) (V1.0) [!]
 CRC=63112A53 A29FA88F
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [3D2CCA1B2E3BDE267769812219EDB864]
 GoodName=Jikkyou J.League 1999 - Perfect Striker 2 (J) (V1.0) [b1]
@@ -7077,14 +8054,20 @@ RefMD5=1FB40EE386B58FEAB6CF29DDB33BCCCC
 GoodName=Jikkyou J.League 1999 - Perfect Striker 2 (J) (V1.1) [!]
 CRC=6309FC17 1D4F5EF3
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [58153AC5C4030D1BFD3C15CF57FB02E7]
 GoodName=Jikkyou J.League Perfect Striker (J) [!]
 CRC=146C4366 72A6DEB3
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [759B8749E55113526E8C1C468E244CA8]
 GoodName=Jikkyou J.League Perfect Striker (J) [b1]
@@ -7110,35 +8093,52 @@ RefMD5=58153AC5C4030D1BFD3C15CF57FB02E7
 GoodName=Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (J) (V1.0) [!]
 CRC=6EDD4766 A93E9BA8
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [F13D0803885B73B4A6B35EDDD40B9253]
 GoodName=Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (J) (V1.1) [!]
 CRC=B00E3829 29F232D1
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [23409668A6E6C4ECE7B5FB0B7D0E8F2C]
 GoodName=Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.0) [!]
 CRC=0AC244D1 1F0EC605
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
 Transferpak=Yes
 
 [B653C963ED8D3A749676810F07CFE4E5]
 GoodName=Jikkyou Powerful Pro Yakyuu 2000 (J) (V1.1) [!]
 CRC=4264DF23 BE28BDF7
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
 Transferpak=Yes
 
 [FDA57F65EB159278223EB9D03267C27F]
 GoodName=Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [!]
 CRC=34495BAD 502E9D26
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [7CC328FFAA5B77CD6247124DD0AF8899]
 GoodName=Jikkyou Powerful Pro Yakyuu 4 (J) (V1.0) [b1]
@@ -7174,13 +8174,20 @@ RefMD5=FDA57F65EB159278223EB9D03267C27F
 GoodName=Jikkyou Powerful Pro Yakyuu 4 (J) (V1.1) [!]
 CRC=D7891F1C C3E43788
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [E9F989E09E3F1519AEFE619889A4F710]
 GoodName=Jikkyou Powerful Pro Yakyuu 5 (J) (V1.0) [!]
 CRC=D22943DA AC2B77C0
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [CAFF2DAC142F169EE76965CA00518B26]
 GoodName=Jikkyou Powerful Pro Yakyuu 5 (J) (V1.0) [b1]
@@ -7201,18 +8208,30 @@ RefMD5=E9F989E09E3F1519AEFE619889A4F710
 GoodName=Jikkyou Powerful Pro Yakyuu 5 (J) (V1.1) [!]
 CRC=1C8CDF74 F761051F
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [68A27FBAB060857C267A639931D2C3D6]
 GoodName=Jikkyou Powerful Pro Yakyuu 5 (J) (V1.2) [!]
 CRC=AC173077 5A14C012
 Players=4
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [060D0313E23B660180441FCC7D24D7DB]
 GoodName=Jikkyou Powerful Pro Yakyuu 6 (J) (V1.0) [!]
 CRC=B75E20B7 B3FEFDFD
+Players=2
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
 Transferpak=Yes
 
 [E6129460E23170FFD4EC4B09D5E0CC56]
@@ -7223,13 +8242,21 @@ RefMD5=060D0313E23B660180441FCC7D24D7DB
 [23EE24FABA0EDFB04B5B0407E174496B]
 GoodName=Jikkyou Powerful Pro Yakyuu 6 (J) (V1.1) [!]
 CRC=3C084040 081B060C
+Players=2
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
 Transferpak=Yes
 
 [03BD8E5CA2B1B7D74398DB4739979282]
 GoodName=Jikkyou Powerful Pro Yakyuu 6 (J) (V1.2) [!]
 CRC=438E6026 3BA24E07
+Players=2
+SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
 Transferpak=Yes
 
 [A05E7DB2409DEECCA36E48E9D931CACB]
@@ -7242,26 +8269,39 @@ Mempak=Yes
 GoodName=Jikkyou World Soccer - World Cup France '98 (J) (V1.1) [!]
 CRC=C954B38C 6F62BEB3
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [2E5FD9303138E8F558BF67BB9E799960]
 GoodName=Jikkyou World Soccer - World Cup France '98 (J) (V1.2) [!]
 CRC=E1C7ABD6 4E707F28
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [EF0F425689586850A6F5796124B0C85B]
 GoodName=Jikkyou World Soccer 3 (J) [!]
 CRC=E0A79F8C 32CC97FA
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [68230D510015FF6817EF898C0B8B636C]
 GoodName=Jinsei Game 64 (J) [!]
 CRC=4AAAF6ED 376428AD
 Players=4
+SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [FBB0F6AF0A931EE4FEAEE4F3CC7DBE03]
 GoodName=Jinsei Game 64 (J) [f1] (PAL)
@@ -7273,8 +8313,10 @@ GoodName=John Romero's Daikatana (E) (M3) [!]
 CRC=0F743195 D8A6DB95
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [2B417AD282DB321C9C67EDA7131A7F06]
 GoodName=John Romero's Daikatana (E) (M3) [f1] (NTSC)
@@ -7291,24 +8333,30 @@ GoodName=John Romero's Daikatana (J) [!]
 CRC=9D7E3C4B E60F4A6C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5B4C268422469F50B94779E655F2B798]
 GoodName=John Romero's Daikatana (U) [!]
 CRC=D0151AB0 FE5CA14B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [DFF0EFE2B35FCDE506D21B0C0BD373A5]
 GoodName=Kakutou Denshou - F-Cup Maniax (J) [!]
 CRC=4F29474F 30CB707A
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9A70D30114F440B5240C10260AB2C8ED]
 GoodName=Kakutou Denshou - F-Cup Maniax (J) [f1] (PAL)
@@ -7320,7 +8368,10 @@ GoodName=Ken Griffey Jr.'s Slugfest (U) [!]
 CRC=36281F23 009756CF
 SaveType=Flash RAM
 Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [040A9EA84FA3C73A8F318358E3250AA4]
 GoodName=Ken Griffey Jr.'s Slugfest (U) [b1]
@@ -7371,7 +8422,10 @@ GoodName=Killer Instinct Gold (E) [!]
 CRC=979B263E F8470004
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [A63F43CC53D9E57A045E1E20A5B12592]
 GoodName=Killer Instinct Gold (E) [o1]
@@ -7383,7 +8437,10 @@ GoodName=Killer Instinct Gold (U) (V1.0) [!]
 CRC=9E8FE2BA 8B270770
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [F73EA6171B04CD9FF05B76274E824194]
 GoodName=Killer Instinct Gold (U) (V1.0) [b1]
@@ -7440,7 +8497,10 @@ GoodName=Killer Instinct Gold (U) (V1.1) [!]
 CRC=9E8FCDFA 49F5652B
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [0CFF6A7C1B1334E07585F0C5CDB53B40]
 GoodName=Killer Instinct Gold (U) (V1.1) [o1]
@@ -7452,7 +8512,10 @@ GoodName=Killer Instinct Gold (U) (V1.2) [!]
 CRC=F908CA4C 36464327
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [2D79C395765A601F967CD3EF7CBF439E]
 GoodName=Killer Instinct Gold (U) (V1.2) [b1]
@@ -7469,8 +8532,10 @@ GoodName=King Hill 64 - Extreme Snowboarding (J) [!]
 CRC=519EA4E1 EB7584E8
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [CE9AE0AA6DBBF965B1F72BC3AA6A7CEF]
 GoodName=King Hill 64 - Extreme Snowboarding (J) [b1]
@@ -7486,15 +8551,20 @@ RefMD5=CCA4E87EC206B5B65AEAB9531C0F275B
 GoodName=Kira to Kaiketsu! 64 Tanteidan (J) [!]
 CRC=75BC6AD6 78552BC9
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [A44B7A612964A6D6139D0426E569D9C9]
 GoodName=Kirby 64 - The Crystal Shards (E) [!]
 CRC=0D93BA11 683868A6
 Players=4
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E3BFAF1AD4A58A3AB7FD7310C1F45D81]
 GoodName=Kirby 64 - The Crystal Shards (E) [b1]
@@ -7511,7 +8581,10 @@ GoodName=Kirby 64 - The Crystal Shards (U) [!]
 CRC=46039FB4 0337822C
 Players=4
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [329C0A564D3B4477E2887097389AB7D6]
 GoodName=Kirby 64 - The Crystal Shards (U) [b1]
@@ -7538,21 +8611,30 @@ GoodName=Knife Edge - Nose Gunner (E) [!]
 CRC=4A997C74 E2087F99
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [436BA873E9466AAB237D9429348A5F70]
 GoodName=Knife Edge - Nose Gunner (J) [!]
 CRC=931AEF3F EF196B90
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [8043D829FCD4F8F72DD81E5C6DDE916F]
 GoodName=Knife Edge - Nose Gunner (U) [!]
 CRC=FCE0D799 65316C54
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [ABFDAA35C995C839D0773D3601D59E67]
 GoodName=Knife Edge - Nose Gunner (U) [b1][t1]
@@ -7579,16 +8661,20 @@ GoodName=Knockout Kings 2000 (E) [!]
 CRC=E3D6A795 2A1C5D3C
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [008B473841CE4D9AC050D55F99B4B5D4]
 GoodName=Knockout Kings 2000 (U) [!]
 CRC=0894909C DAD4D82D
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [630400D4E2DCED3DDE56DFCCF39A512A]
 GoodName=Knockout Kings 2000 (U) [f1] (PAL)
@@ -7600,8 +8686,10 @@ GoodName=Kobe Bryant in NBA Courtside (E) [!]
 CRC=1739EFBA D0B43A68
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [54FD2659FCCE58FCC6EE544F95F8F7A3]
 GoodName=Kobe Bryant in NBA Courtside (E) [f1]
@@ -7613,8 +8701,10 @@ GoodName=Kobe Bryant's NBA Courtside (U) [!]
 CRC=616B8494 8A509210
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [EF9A84FBF0B4C31E581648F256E8ED81]
 GoodName=Kobe Bryant's NBA Courtside (U) [f1]
@@ -7659,8 +8749,10 @@ GoodName=LEGO Racers (E) (M10) [!]
 CRC=F478D8B3 9716DD6D
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=3
 
 [26B5EAA13DC5B5E35307FE8C0CF5B6BA]
@@ -7668,8 +8760,10 @@ GoodName=LEGO Racers (U) (M10) [!]
 CRC=096A40EA 8ABE0A10
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=3
 
 [97C4CAE584F427EC44266E9B98FBF7B6]
@@ -7711,7 +8805,11 @@ CRC=FF0AC362 F4EC09B3
 GoodName=Last Legion UX (J) [!]
 CRC=7F304099 52CF5276
 Players=2
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [8E55FD6990472A08568324309C2FD31F]
 GoodName=Last Legion UX (J) [a1]
@@ -7731,40 +8829,52 @@ RefMD5=EB11FC0797AE1107201C4601FEE5471A
 [0C13E0449A28EA5B925CDB8AF8D29768]
 GoodName=Zelda no Densetsu - Toki no Ocarina - Zelda Collection Version (J) (GC) [!]
 CRC=F7F52DB8 2195E636
+Players=1
 SaveType=SRAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 ; End Credits Fix
 Cheat0=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
 
 [33FB7852C180B18EA0B9620B630F413F]
 GoodName=Zelda no Densetsu - Toki no Ocarina GC (J) (GC) [!]
 CRC=F611F4BA C584135C
+Players=1
 SaveType=SRAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 ; End Credits Fix
 Cheat0=D109A834 0320,8109A834 0000,D109A836 F809,8109A836 0000
 
 [69895C5C78442260F6EAFB2506DC482A]
 GoodName=Zelda no Densetsu - Toki no Ocarina GC URA (J) (GC) [!]
 CRC=F43B45BA 2F0E9B6F
+Players=1
 SaveType=SRAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 ; End Credits Fix
 Cheat0=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
 
 [13FAB67E603B002CEAF0EEA84130E973]
 GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [!]
 CRC=E97955C6 BC338D38
+Players=1
 SaveType=Flash RAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [5798E844953662880C5EB4134F886909]
 GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (V1.0) [T+Ita1.0Beta_Vampire]
@@ -7804,10 +8914,13 @@ RefMD5=13FAB67E603B002CEAF0EEA84130E973
 [BECCFDED43A2F159D03555027462A950]
 GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) [!]
 CRC=0A5D8F83 98C5371A
+Players=1
 SaveType=Flash RAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [71FBAE5D2B27926EA54E92CE2FC91622]
 GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) (Debug Version)
@@ -7817,10 +8930,13 @@ RefMD5=BECCFDED43A2F159D03555027462A950
 [609B47B79DA21F3DF9B31D06C95C09A1]
 GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (VC) [!]
 CRC=0A5D8F83 98C5371A
+Players=1
 SaveType=Flash RAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [6DC88503DF78FE4FAA16BCF7AEC4D1E7]
 GoodName=Legend of Zelda, The - Majora's Mask (E) (M4) (V1.1) [T+Ita1.0Beta_Vampire]
@@ -7830,10 +8946,13 @@ RefMD5=BECCFDED43A2F159D03555027462A950
 [2A0A8ACB61538235BC1094D297FB6556]
 GoodName=Legend of Zelda, The - Majora's Mask (U) [!]
 CRC=5354631C 03A2DEF0
+Players=1
 SaveType=Flash RAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [9C7D1B51ECBC9AC333D00273F96758B1]
 GoodName=Legend of Zelda, The - Majora's Mask (U) [T+Pol1.0]
@@ -7882,26 +9001,35 @@ CRC=BF799345 39FF7A02
 [AC0751DBC23AB2EC0C3144203ACA0003]
 GoodName=Legend of Zelda, The - Majora's Mask (U) (GC)
 CRC=B443EB08 4DB31193
+Players=1
 SaveType=Flash RAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [DBE9AF0DB46256E42B5C67902B696549]
 GoodName=Legend of Zelda, The - Majora's Mask - Collector's Edition (E) (M4) (GC) [!]
 CRC=6AECEC4F F0924814
+Players=1
 SaveType=Flash RAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [9F04C8E68534B870F707C247FA4B50FC]
 GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [!]
 CRC=EC7011B7 7616D72B
+Players=1
 SaveType=SRAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [A04EBD753276C52E95E25AF7683DA32D]
 GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.0) [T+Chi.02_madcell]
@@ -7921,15 +9049,24 @@ RefMD5=9F04C8E68534B870F707C247FA4B50FC
 [1BF5F42B98C3E97948F01155F12E2D88]
 GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.1) [!]
 CRC=D43DA81F 021E1E19
+Players=1
 SaveType=SRAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [2258052847BDD056C8406A9EF6427F13]
 GoodName=Zelda no Densetsu - Toki no Ocarina (J) (V1.2) [!]
 CRC=693BA2AE B7F14E9F
-RefMD5=1BF5F42B98C3E97948F01155F12E2D88
+Players=1
+SaveType=SRAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [E040DE91A74B61E3201DB0E2323F768A]
 GoodName=Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [!]
@@ -7937,7 +9074,10 @@ CRC=B044B569 373C1985
 Status=4
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [2B60EF777F759B4F0E19DDF3CB84D9AB]
 GoodName=Legend of Zelda, The - Ocarina of Time (E) (M3) (V1.0) [b1]
@@ -7960,15 +9100,21 @@ CRC=B2055FBD 0BAB4E0C
 Status=4
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [5BD1FE107BF8106B2AB6650ABECD54D6]
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.0) [!]
 CRC=EC7011B7 7616D72B
 Status=4
-SaveType=SRAM
 Players=1
+SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [A43A350385FA814EC9793B7ACD9E18F4]
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.0) (Room121 Hack)
@@ -8138,9 +9284,12 @@ RefMD5=5BD1FE107BF8106B2AB6650ABECD54D6
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.1) [!]
 CRC=D43DA81F 021E1E19
 Status=4
-SaveType=SRAM
 Players=1
+SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [92C842FC8CF706FF290044D40A64D346]
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.1) [T+Ita100]
@@ -8187,7 +9336,10 @@ GoodName=Legend of Zelda, The - Ocarina of Time (U) (V1.2) [!]
 CRC=693BA2AE B7F14E9F
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [CD09029EDCFB7C097AC01986A0F83D3F]
 GoodName=Legend of Zelda, The - Ocarina of Time (U) (GC) [!]
@@ -8195,7 +9347,10 @@ CRC=F3DD35BA 4152E075
 Status=4
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 ; End Credits Fix
 Cheat0=D109A814 0320,8109A814 0000,D109A816 F809,8109A816 0000
 
@@ -8205,7 +9360,10 @@ CRC=09465AC3 F8CB501B
 Status=4
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 ; End Credits Fix
 Cheat0=D109A8E4 0320,8109A8E4 0000,D109A8E6 F809,8109A8E6 0000
 
@@ -8220,7 +9378,10 @@ CRC=1D4136F3 AF63EEA9
 Status=4
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 ; End Credits Fix
 Cheat0=D109A8C4 0320,8109A8C4 0000,D109A8C6 F809,8109A8C6 0000
 
@@ -8250,7 +9411,10 @@ CRC=F034001A AE47ED06
 Status=4
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 ; End Credits Fix
 Cheat0=D109A7F4 0320,8109A7F4 0000,D109A7F6 F809,8109A7F6 0000
 
@@ -8273,29 +9437,52 @@ RefMD5=DA35577FE54579F6A266931CC75F512D
 GoodName=Legend of Zelda, The - Ocarina of Time (Ch) (iQue) [!]
 CRC=B1E1E07B 051269DD
 Players=1
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [9729A68F40F197D4D040FA641FF099E7]
 GoodName=Legend of Zelda, The - Ocarina of Time (Ch) (V2) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [912628118E67FEA670ED2C63F7A7B003]
 GoodName=Legend of Zelda, The - Ocarina of Time (Ch) (V4) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A475E9F8615513666A265C464708AE8F]
 GoodName=Legend of Zelda, The - Ocarina of Time (Ch) (Traditional) (iQue) [!]
 CRC=3D81FB3E BD843E34
 Players=1
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [55685D6324EFDE5BC9D26C98706B0B8A]
 GoodName=Les Razmoket - La Chasse Aux Tresors (F) [!]
 CRC=2B696CB4 7B93DCD8
 Players=4
+SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [AEE5016E6D60D12AD768E9F6D10ADDE8]
 GoodName=Let's Smash Tennis (J) [!]
 CRC=3D67C62B 31D03150
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [EF878DFACF5CD5C00BA3297B0DC888D2]
 GoodName=Light Force First N64 Demo by Fractal (PD)
@@ -8330,7 +9517,10 @@ GoodName=Lode Runner 3-D (E) (M5) [!]
 CRC=60460680 305F0E72
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 Status=3
 
 [6B1E294A9199E6F22DBC6ABC59BD7568]
@@ -8343,7 +9533,10 @@ GoodName=Lode Runner 3-D (J) [!]
 CRC=964ADD0B B29213DB
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 Status=3
 
 [D038813541589F0B3F1F900F4FD22C9B]
@@ -8351,7 +9544,10 @@ GoodName=Lode Runner 3-D (U) [!]
 CRC=255018DF 57D6AE3A
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 Status=3
 
 [5FBA92D908B9962F26D389C85F6E88CF]
@@ -8374,7 +9570,10 @@ GoodName=Looney Tunes - Duck Dodgers (E) (M6) [!]
 CRC=0AA0055B 7637DF65
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [4CCFF861AD2CFD65CC660F496C1D1664]
 GoodName=Lt. Duck Dodgers (Prototype)
@@ -8388,7 +9587,10 @@ GoodName=Lylat Wars (A) (M3) [!]
 CRC=2483F22B 136E025E
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [B182BBBC8CE22BD3F44BB6ED91F6ACD4]
 GoodName=Lylat Wars (A) (M3) [f1]
@@ -8410,7 +9612,10 @@ GoodName=Lylat Wars (E) (M3) [!]
 CRC=F4CBE92C B392ED12
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [F0FF28B0D26CDEFC11F22FE73148A6DC]
 GoodName=Lylat Wars (E) (M3) [f1]
@@ -8478,8 +9683,10 @@ GoodName=MRC - Multi Racing Championship (E) (M3) [!]
 CRC=B8F0BD03 4479189E
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [362D10C7D270AE48D83D1D7BB78BF527]
 GoodName=MRC - Multi Racing Championship (E) (M3) [b1]
@@ -8511,8 +9718,10 @@ GoodName=MRC - Multi Racing Championship (J) [!]
 CRC=A6B6B413 15D113CC
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [C306C80A07743F75B0C69AF2B484E957]
 GoodName=MRC - Multi Racing Championship (J) [b1]
@@ -8544,8 +9753,10 @@ GoodName=MRC - Multi Racing Championship (U) [!]
 CRC=2AF9B65C 85E2A2D7
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [E38F1DAE2A2023A529B47A26E4666759]
 GoodName=MRC - Multi Racing Championship (U) [b1]
@@ -8576,6 +9787,10 @@ GoodName=Mace - The Dark Age (E) [!]
 CRC=1145443D 11610EDB
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [9CF16783687686C8FE2ABE0B71316C3D]
 GoodName=Mace - The Dark Age (E) [b1]
@@ -8602,6 +9817,10 @@ GoodName=Mace - The Dark Age (U) [!]
 CRC=6B700750 29D621FE
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [DF342B032ED1ED15C24448EC6BE9F34E]
 GoodName=Mace - The Dark Age (U) [b1]
@@ -8658,8 +9877,10 @@ GoodName=Madden Football 64 (E) [!]
 CRC=A197CB52 7520DE0E
 SaveType=None
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5CBF54627693F800524038127BBF46BF]
 GoodName=Madden Football 64 (E) [b1]
@@ -8671,8 +9892,10 @@ GoodName=Madden Football 64 (U) [!]
 CRC=13836389 265B3C76
 SaveType=None
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5CA2A7F712B6C5737D0B46E67C8DDA44]
 GoodName=Madden Football 64 (U) [b1]
@@ -8714,8 +9937,10 @@ GoodName=Madden NFL 2000 (U) [!]
 CRC=0CB81686 5FD85A81
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [441FA65FAA5C12339F89A0BB7DB43C8F]
@@ -8723,17 +9948,21 @@ GoodName=Madden NFL 2001 (U) [!]
 CRC=EB38F792 190EA246
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [AD0F2EC565D7575FB37512BC8DF8A092]
 GoodName=Madden NFL 2002 (U) [!]
 CRC=D7134F8D C11A00B5
+Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
-Players=4
+Transferpak=No
 CountPerOp=1
 
 [E7BF80861A0AB2A788959463D953B5D5]
@@ -8741,8 +9970,10 @@ GoodName=Madden NFL 99 (E) [!]
 CRC=3925D625 8C83C75E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [9CB5F5CD6AB141454D645C92FD9BF67C]
@@ -8755,8 +9986,10 @@ GoodName=Madden NFL 99 (U) [!]
 CRC=DEB78BBA 52F6BD9D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [C049FCD4CB185A553D8122CFE6C30139]
@@ -8769,8 +10002,10 @@ GoodName=Madden NFL 99 (U) (V1.1) [!]
 CRC=DF09D625 1791C87D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [5F3D42D5F96191F3CE50D70E0E42127A]
@@ -8783,7 +10018,10 @@ GoodName=Magical Tetris Challenge (E) [!]
 CRC=E4906679 9F243F05
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [20D02EECFA887DC5A31948B18B4BB18D]
 GoodName=Magical Tetris Challenge (E) [b1]
@@ -8800,14 +10038,20 @@ GoodName=Magical Tetris Challenge (G) [!]
 CRC=E1EF93F7 14908B0B
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [79FCC98002D1F4C79DEAF55784222DF8]
 GoodName=Magical Tetris Challenge (U) [!]
 CRC=75B61647 7ADABF78
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [BD5BB4CE1FACE911F9D8C777E2594998]
 GoodName=Magical Tetris Challenge (U) [b1][hI]
@@ -8824,7 +10068,10 @@ GoodName=Magical Tetris Challenge Featuring Mickey (J) [!]
 CRC=80C8564A 929C65AB
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [9F6DB67262220C62536CEBE0AF3C8E73]
 GoodName=Magical Tetris Challenge Featuring Mickey (J) [b1]
@@ -8835,7 +10082,10 @@ RefMD5=F1FF1F364C459701F42BEB8989675D44
 GoodName=Mahjong 64 (J) [!]
 CRC=C53EDC41 ECE19359
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [E67651E58A4B864765A752E3BEB5F4E4]
 GoodName=Mahjong 64 (J) [o1]
@@ -8851,6 +10101,10 @@ RefMD5=8AE2E8F0C356FEE638C8D908DCBB3381
 GoodName=Mahjong Hourouki Classic (J) [!]
 CRC=CCCC821E 96E88A83
 Players=1
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [50A8B47E5F8FE5BF955AFA70FE3893AC]
 GoodName=Mahjong Hourouki Classic (J) [b1]
@@ -8871,7 +10125,10 @@ RefMD5=E942A3EEB1EB572BADD6F705EB12A22C
 GoodName=Mahjong Master (J) [!]
 CRC=0FC42C70 8754F1CD
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [AD1AD9FE15C4565FF88B9B48AF6F300C]
 GoodName=Mahjong Master (J) [b1]
@@ -8893,8 +10150,10 @@ GoodName=Major League Baseball Featuring Ken Griffey Jr. (E) [!]
 CRC=CDB998BE 1024A5C8
 Players=2
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [62CD83FC8FC8E8CF8899320BF25474CE]
 GoodName=Major League Baseball Featuring Ken Griffey Jr. (E) [b1]
@@ -8911,8 +10170,10 @@ GoodName=Major League Baseball Featuring Ken Griffey Jr. (U) [!]
 CRC=80C1C05C EA065EF4
 Players=2
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [97FE61E8719CF0A4747301E97C759CBF]
 GoodName=Major League Baseball Featuring Ken Griffey Jr. (U) [b1]
@@ -8994,6 +10255,8 @@ GoodName=Mario Golf (E) [!]
 CRC=62E957D0 7FC15A5D
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -9027,6 +10290,8 @@ GoodName=Mario Golf (U) [!]
 CRC=664BA3D4 678A80B7
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -9070,6 +10335,8 @@ GoodName=Mario Golf 64 (J) (V1.0) [!]
 CRC=D48944D1 B0D93A0E
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -9103,28 +10370,49 @@ GoodName=Mario Golf 64 (J) (V1.1) [!]
 CRC=734F816B C6A6EB67
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
 [78771BEB349D481E69BAA9225B36D63A]
 GoodName=Mario Kart 64 (Ch) (V4) (iQue) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [5EA0ED74CF1DDAAA964D728A129E7CF9]
 GoodName=Mario Kart 64 (Ch) (V5) (iQue) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [C70AF6197E67B310F316C34CCED64C19]
 GoodName=Mario Kart 64 (Ch) (V2) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [76176B237D4F60E59F98D247283D9365]
 GoodName=Mario Kart 64 (Ch) (V6) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [8FAD1E4FA7BAF1443B7F21AD1947B429]
 GoodName=Mario Kart 64 (E) (V1.0) [!]
 CRC=C3B6DE9D 65D2DE76
 Status=3
-SaveType=Eeprom 4KB
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 ; Multiplayer Timing Fix
 Cheat0=81001A1C 2409,81001A1E 0002,81001C74 240A,81001C76 0002
 
@@ -9152,9 +10440,12 @@ RefMD5=8FAD1E4FA7BAF1443B7F21AD1947B429
 GoodName=Mario Kart 64 (E) (V1.1) [!]
 CRC=2577C7D4 D18FAAAE
 Status=3
-SaveType=Eeprom 4KB
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 ; Multiplayer Timing Fix
 Cheat0=81001A1C 2409,81001A1E 0002,81001C74 240A,81001C76 0002
 
@@ -9172,9 +10463,12 @@ RefMD5=2BB149A583FDEFEA96805F628FE42FD9
 GoodName=Mario Kart 64 (J) (V1.0) [!]
 CRC=6BFF4758 E5FF5D5E
 Status=3
-SaveType=Eeprom 4KB
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 ; Multiplayer Timing Fix
 Cheat0=81001A1C 2409,81001A1E 0002,81001C74 240A,81001C76 0002
 
@@ -9202,9 +10496,12 @@ RefMD5=BF964CECA78A13A82055EBDA80B95CCA
 GoodName=Mario Kart 64 (J) (V1.1) [!]
 CRC=C9C3A987 5810344C
 Status=3
-SaveType=Eeprom 4KB
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 ; Multiplayer Timing Fix
 Cheat0=81001A1C 2409,81001A1E 0002,81001C74 240A,81001C76 0002
 
@@ -9227,9 +10524,12 @@ RefMD5=60535265BAE43DDFCBDB0D71594B1693
 GoodName=Mario Kart 64 (U) [!]
 CRC=3E5055B6 2E92DA52
 Status=3
-SaveType=Eeprom 4KB
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 ; Multiplayer Timing Fix
 Cheat0=81001A38 2409,81001A3A 0002,81001A3C 2409,81001A3E 0002,81001C90 240A,81001C92 0002,81001C94 240A,81001C96 0002
 
@@ -9308,7 +10608,10 @@ GoodName=Mario Party (E) (M3) [!]
 CRC=9C663069 80F24A80
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [2608A4D7A695D0B1A1BBC47695EACE0E]
@@ -9326,7 +10629,10 @@ GoodName=Mario Party (J) [!]
 CRC=ADA815BE 6028622F
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [8BC2712139FBF0C56C8EA835802C52DC]
@@ -9334,7 +10640,10 @@ GoodName=Mario Party (U) [!]
 CRC=2829657E A0621877
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [D072DDBCC5961AE85E6FA9BF50241370]
@@ -9347,7 +10656,10 @@ GoodName=Mario Party 2 (E) (M5) [!]
 CRC=82380387 DFC744D9
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [F23E4CD437465F3E725262253CF3EA59]
@@ -9355,7 +10667,10 @@ GoodName=Mario Party 2 (J) [!]
 CRC=ED567D0F 38B08915
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [04840612A35ECE222AFDB2DFBF926409]
@@ -9363,7 +10678,10 @@ GoodName=Mario Party 2 (U) [!]
 CRC=9EA95858 AF72B618
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [F253C5A0FB69AB56A1548D435AF84D0F]
@@ -9379,25 +10697,34 @@ RefMD5=04840612A35ECE222AFDB2DFBF926409
 [8E62EC6FBE3CC9FF6284191C9C88E68F]
 GoodName=Mario Party 3 (E) (M4) [!]
 CRC=C5674160 0F5F453C
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [ED99F330CE7A2638AB13351012EEB86B]
 GoodName=Mario Party 3 (J) [!]
 CRC=0B0AB4CD 7B158937
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [76A8BBC81BC2060EC99C9645867237CC]
 GoodName=Mario Party 3 (U) [!]
 CRC=7C3829D9 6E8247CE
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [BDD79F498F37D01B8958F56EC6FFA097]
@@ -9421,22 +10748,29 @@ CRC=3BA7CDDC 464E52A0
 Status=2
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [FFF9B3E22ABB9B60215DAFB13AD5A4DE]
 GoodName=Mario Tennis (E) [!]
 CRC=839F3AD5 406D15FA
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
 [759358FAD1ED5AE31DCB2001A07F2FE5]
 GoodName=Mario Tennis (U) [!]
 CRC=5001CF4F F30CB3BD
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -9448,8 +10782,10 @@ RefMD5=759358FAD1ED5AE31DCB2001A07F2FE5
 [8EB1C2443D0B2E6EDA52A4EEA66D6C35]
 GoodName=Mario Tennis 64 (J) [!]
 CRC=3A6C42B5 1ACADA1B
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -9462,6 +10798,10 @@ RefMD5=8EB1C2443D0B2E6EDA52A4EEA66D6C35
 GoodName=Mario no Photopie (J) [!]
 CRC=9A9890AC F0C313DF
 Players=1
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [6BAB5F2A62A4BABAF456D5DA2976871D]
 GoodName=Mario no Photopie (J) [a1]
@@ -9482,11 +10822,19 @@ GoodName=Mega Man 64 (U) [!]
 CRC=0EC158F5 FB3E6896
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [CD0824E9405185AF434837BA1C8C0CD5]
 GoodName=Mega Man 64 (U) (Beta) [!]
 CRC=27C985A8 ED7CE5C6
+Players=1
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [01A1304D98A58E2D5069079A4F4441F9]
 GoodName=Mega Man 64 (U) [t1][f1] (PAL-NTSC)
@@ -9518,16 +10866,20 @@ GoodName=Mia Hamm Soccer 64 (U) (M2) [!]
 CRC=1001F10C 3D51D8C1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [892222CC4BAF9958405D20BC492175BF]
 GoodName=Michael Owens WLS 2000 (E) [!]
 CRC=E36166C2 8613A2E5
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6A814E33BB6D449BE23FBBCAC7606C0B]
 GoodName=Michael Owens WLS 2000 (E) [b1]
@@ -9549,13 +10901,18 @@ GoodName=Mickey no Racing Challenge USA (J) [!]
 CRC=736AE6AF 4117E9C7
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [5BA3DC37860C08A209F24286B8DFEC8C]
 GoodName=Mickey's Speedway USA (E) (M5) [!]
 CRC=DED0DD9A E78225A7
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -9564,6 +10921,8 @@ GoodName=Mickey's Speedway USA (U) [!]
 CRC=FA8C4571 BBE7F9C0
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -9575,9 +10934,12 @@ RefMD5=0BF64427CF68E49C70E9EC2C9D815209
 [9A8465E302263D635557A14AA197FE3C]
 GoodName=Micro Machines 64 Turbo (E) (M5) [!]
 CRC=2A49018D D0034A02
+Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [68246CF0AB9DE7B6F84751FCC86A959A]
 GoodName=Micro Machines 64 Turbo (E) (M5) [b1]
@@ -9597,9 +10959,12 @@ RefMD5=9A8465E302263D635557A14AA197FE3C
 [74EB415E16C333B252847A8E09432FD9]
 GoodName=Micro Machines 64 Turbo (U) [!]
 CRC=F1850C35 ACE07912
+Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [BB9F2E48015D9DFB347B4BE4C2DFB334]
 GoodName=Micro Machines 64 Turbo (U) [a1][!]
@@ -9619,9 +10984,12 @@ RefMD5=74EB415E16C333B252847A8E09432FD9
 [2B86775EA4D848202E4F4A39C33571CA]
 GoodName=Midway's Greatest Arcade Hits Volume 1 (U) [!]
 CRC=E4B35E4C 1AC45CC9
-SaveType=None
-Mempak=Yes
 Players=2
+SaveType=None
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [47EA6F037B093381CA88A41FBB6C4199]
 GoodName=Midway's Greatest Arcade Hits Volume 1 (U) [b1]
@@ -9663,8 +11031,10 @@ GoodName=Mike Piazza's Strike Zone (U) [!]
 CRC=09D53E16 3AB268B9
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F5978A54BB22E3BC4D46C0C3E9597B12]
 GoodName=Mike Piazza's Strike Zone (U) [h1C]
@@ -9686,8 +11056,10 @@ GoodName=Milo's Astro Lanes (E) [!]
 CRC=9A490D9D 8F013ADC
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [988B490C2AEBF7DE3C274B7EAEEF0999]
 GoodName=Milo's Astro Lanes (E) [o1]
@@ -9704,8 +11076,10 @@ GoodName=Milo's Astro Lanes (U) [!]
 CRC=2E955ECD F3000884
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AC004667AB4578BAA9A1C0A7771E8B17]
 GoodName=Milo's Astro Lanes (U) [b1]
@@ -9749,6 +11123,10 @@ GoodName=Mischief Makers (E) [!]
 CRC=418BDA98 248A0F58
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [5690D74157C6623E2928A6F0353EF4AF]
@@ -9761,6 +11139,10 @@ GoodName=Mischief Makers (U) (V1.0) [!]
 CRC=0B93051B 603D81F9
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [CCF012DF82022D4797CE4CC5405E084F]
@@ -9778,6 +11160,10 @@ GoodName=Mischief Makers (U) (V1.1) [!]
 CRC=BFA526B4 0691E430
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [599B5D40B51F53C2C9A909E0139702FC]
@@ -9785,7 +11171,10 @@ GoodName=Mission Impossible (E) [!]
 CRC=2256ECDA 71AB1B9C
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [5CDC052C88A5CADCC3C73B165163E8C7]
 GoodName=Mission Impossible (E) [b1]
@@ -9797,7 +11186,10 @@ GoodName=Mission Impossible (F) [!]
 CRC=20095B34 343D9E87
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [FF9CC9E03993DD15F1436AF3874F94CF]
 GoodName=Mission Impossible (F) [b1]
@@ -9814,14 +11206,20 @@ GoodName=Mission Impossible (G) [!]
 CRC=93EB3F7E 81675E44
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [66C7EB8148E0714B5A71F5717DFF8642]
 GoodName=Mission Impossible (I) [!]
 CRC=EBA949DC 39BAECBD
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [CA60967822CCCEFE22299691B453D893]
 GoodName=Mission Impossible (I) [f1] (NTSC)
@@ -9833,7 +11231,10 @@ GoodName=Mission Impossible (S) [!]
 CRC=5F6A04E2 D4FA070D
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [217B0E4723DBACDA40B70B26E610F5F9]
 GoodName=Mission Impossible (S) [f1] (NTSC)
@@ -9845,14 +11246,20 @@ GoodName=Mission Impossible (S) (V1.1) [!]
 CRC=5F6DDEA2 4DD9E759
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [EEBDFBD7CB57202D70CFFFCAAF55E93E]
 GoodName=Mission Impossible (U) [!]
 CRC=26035CF8 802B9135
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [550F4C177942FC0DF00B646C42EB4A90]
 GoodName=Mission Impossible (U) [b1]
@@ -9879,8 +11286,10 @@ GoodName=Monaco Grand Prix (U) [!]
 CRC=28768D6D B379976C
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9BF4D7FBE8157C9D6866A90269DCA7CB]
 GoodName=Monaco Grand Prix (U) [f1] (PAL)
@@ -9892,8 +11301,10 @@ GoodName=Monaco Grand Prix - Racing Simulation 2 (E) (M4) [!]
 CRC=28705FA5 B509690E
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F81580C9C480DDF1B8F7E6A56D1B9CD5]
 GoodName=Money Creates Taste Demo by Count0 (POM '99) (PD) [f1]
@@ -9908,6 +11319,10 @@ GoodName=Monopoly (U) [!]
 CRC=5AC383E1 D712E387
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [26C3654D20B8718A75B5FE8DA5B3284A]
@@ -9920,7 +11335,10 @@ GoodName=Monster Truck Madness 64 (E) (M5) [!]
 CRC=D3D806FC B43AA2A8
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=3
 
 [12534DAB32DBFC6CA4F66D05729102E6]
@@ -9933,7 +11351,10 @@ GoodName=Monster Truck Madness 64 (U) [!]
 CRC=B19AD999 7E585118
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=3
 
 [3C9F329D5E0C7FE57355B8DC68F79331]
@@ -9945,15 +11366,21 @@ RefMD5=514D61D3B3D5E6326869783EB2E84A00
 GoodName=Morita Shougi 64 (J) [!]
 CRC=E8E8DD70 415DD198
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [264B82F0FC2431D6EEFDE9C9F3ED7596]
 GoodName=Mortal Kombat 4 (E) [!]
 CRC=73036F3B CE0D69E9
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [58EFAF3D7D0985BC426245EFA5418CC2]
 GoodName=Mortal Kombat 4 (E) [h1C]
@@ -9970,8 +11397,10 @@ GoodName=Mortal Kombat 4 (U) [!]
 CRC=417DD4F4 1B482FE2
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [CCD5A3B82976D65B3B42E8E2B2B43B48]
 GoodName=Mortal Kombat 4 (U) [b1]
@@ -10013,8 +11442,10 @@ GoodName=Mortal Kombat Mythologies - Sub-Zero (E) [!]
 CRC=FF44EDC4 1AAE9213
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [DAFEE0C1FC99882A2C6A340BF0E58A08]
 GoodName=Mortal Kombat Mythologies - Sub-Zero (E) [h1C]
@@ -10031,8 +11462,10 @@ GoodName=Mortal Kombat Mythologies - Sub-Zero (U) [!]
 CRC=C34304AC 2D79C021
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [8F2544F095EF7D9A5096E3D52472D699]
 GoodName=Mortal Kombat Mythologies - Sub-Zero (U) [b1]
@@ -10091,8 +11524,12 @@ CRC=947A4B47 90BFECA6
 [7A558BBAD8CE8828414A9CF3B044A87D]
 GoodName=Mortal Kombat Trilogy (E) [!]
 CRC=8C3D1192 BEF172E1
-SaveType=None
 Players=2
+SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [1C6FE6A40AAC4BD515373B6ED8D25DBF]
 GoodName=Mortal Kombat Trilogy (E) [b1]
@@ -10144,6 +11581,10 @@ GoodName=Mortal Kombat Trilogy (U) (V1.0) [!]
 CRC=D9F75C12 A8859B59
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [7CD386C8D2E69DBBF55F02A564BD6A9A]
 GoodName=Mortal Kombat Trilogy (U) (V1.0) [b1]
@@ -10230,12 +11671,20 @@ GoodName=Mortal Kombat Trilogy (U) (V1.1) [!]
 CRC=19F55D46 73A27B34
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [3DCB15043063BD656A0223C519218CFB]
 GoodName=Mortal Kombat Trilogy (U) (V1.2) [!]
 CRC=83F33AA9 A901D40D
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [27F761B7DD73E12BB311772780D6B9F4]
 GoodName=Mortal Kombat Trilogy (U) (V1.2) [t1] (Hit Anywhere)
@@ -10276,8 +11725,10 @@ GoodName=Ms. Pac-Man - Maze Madness (U) [!]
 CRC=1938525C 586E9656
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F905CA22CC030BBED516F3D1B6C2153A]
 GoodName=My Angel Demo (PD)
@@ -10288,8 +11739,10 @@ GoodName=Mystical Ninja 2 Starring Goemon (E) (M3) [!]
 CRC=7F9345D3 841ECADE
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [75AD771425CBE2B1E8C7B4D94E67B1CA]
@@ -10307,8 +11760,10 @@ GoodName=Mystical Ninja Starring Goemon (E) [!]
 CRC=F5360FBE 2BF1691D
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [DBD2BC43FCDADACD234AEFC8130A5413]
@@ -10331,8 +11786,10 @@ GoodName=Mystical Ninja Starring Goemon (U) [!]
 CRC=FCBCCB21 72903C6B
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [42E282A3F208C4BDE50A4A4301181B16]
@@ -10384,8 +11841,10 @@ GoodName=NASCAR 2000 (U) [!]
 CRC=DF331A18 5FD4E044
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [DB3A918FA61E1FB3110CFE6E9DA33E97]
 GoodName=NASCAR 2000 (U) [f1] (PAL)
@@ -10397,8 +11856,10 @@ GoodName=NASCAR 99 (E) (M3) [!]
 CRC=AE4992C9 9253B253
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [A31AD7E7E6177BED7345635FDA563FCA]
 GoodName=NASCAR 99 (E) (M3) [h1C]
@@ -10410,8 +11871,10 @@ GoodName=NASCAR 99 (U) [!]
 CRC=23749578 80DC58FD
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AC88A7D81FF0B712EA3A302419F3A927]
 GoodName=NASCAR 99 (U) [b1]
@@ -10443,7 +11906,10 @@ GoodName=NBA Courtside 2 - Featuring Kobe Bryant (U) [!]
 CRC=916852D8 73DBEAEF
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [EE4DCAED6759CE013BC7B5E8E815B343]
 GoodName=NBA Courtside 2 - Featuring Kobe Bryant (U) [f1] (PAL)
@@ -10470,7 +11936,10 @@ GoodName=NBA Hangtime (E) [!]
 CRC=C788DCAE BD03000A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [0057A561D7034392D4267A4134DA41B0]
 GoodName=NBA Hangtime (E) [h1C]
@@ -10482,7 +11951,10 @@ GoodName=NBA Hangtime (U) [!]
 CRC=4E69B487 FE18E290
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [9C595E5A5F027385A340ADDF609852DD]
 GoodName=NBA Hangtime (U) [b1]
@@ -10519,8 +11991,10 @@ GoodName=NBA In the Zone '98 (J) [!]
 CRC=36ACBA9B F28D4D94
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [4151ED80568EFCCA34F8831D957EB7A6]
 GoodName=NBA In the Zone '98 (J) [o1]
@@ -10537,8 +12011,10 @@ GoodName=NBA In the Zone '98 (U) [!]
 CRC=6A121930 665CC274
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [EE43F010F2E87BC68535D333FE64C516]
 GoodName=NBA In the Zone '98 (U) [b1]
@@ -10575,8 +12051,10 @@ GoodName=NBA In the Zone '99 (U) [!]
 CRC=A292524F 3D6C2A49
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [F8F87AEB2C537C9CB2E9913050BFC928]
@@ -10584,16 +12062,20 @@ GoodName=NBA In the Zone 2 (J) [!]
 CRC=AAE11F01 2625A045
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [4244CC48674C26BD848718C05688F821]
 GoodName=NBA In the Zone 2000 (E) [!]
 CRC=B3054F9F 96B69EB5
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AF6521E33FDE918B9A2298FA0BD3AA90]
 GoodName=NBA In the Zone 2000 (E) [h1C]
@@ -10605,8 +12087,10 @@ GoodName=NBA In the Zone 2000 (U) [!]
 CRC=8DF95B18 ECDA497B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F4401BCC9DD25254503E32B482EB3FAA]
 GoodName=NBA In the Zone 2000 (U) [f1] (PAL)
@@ -10618,16 +12102,20 @@ GoodName=NBA Jam 2000 (E) [!]
 CRC=B6D0CAA0 E3F493C8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AFECC9A2DF7B1A66A6B7AB3AA8B4BD2E]
 GoodName=NBA Jam 2000 (U) [!]
 CRC=EBEEA8DB F2ECB23C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [E25F3A1136C9C81702E0827040C5A115]
 GoodName=NBA Jam 2000 (U) [f1] (PAL)
@@ -10639,7 +12127,10 @@ GoodName=NBA Jam 99 (E) [!]
 CRC=E600831E 59F422A8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [0A9D53EF71A0C6F2AE3A0435E3D58747]
 GoodName=NBA Jam 99 (E) [h1C]
@@ -10651,7 +12142,10 @@ GoodName=NBA Jam 99 (U) [!]
 CRC=810729F6 E03FCFC1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [7344483130995CA211B5B9FF9891A9DE]
 GoodName=NBA Jam 99 (U) [b1]
@@ -10668,32 +12162,40 @@ GoodName=NBA Live 2000 (E) (M4) [!]
 CRC=EB499C8F CD4567B6
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [FC47F85CC501C8C5BD9D0CA4DB48258F]
 GoodName=NBA Live 2000 (U) (M4) [!]
 CRC=5F25B0EE 6227C1DB
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [226C19C8759314AC740420DDC3A34EB4]
 GoodName=NBA Live 99 (E) (M5) [!]
 CRC=CF84F45F 00E4F6EB
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [DBE79AE6531B491B8F8EE8B2B814D665]
 GoodName=NBA Live 99 (U) (M5) [!]
 CRC=57F81C9B 1133FA35
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [7044E135E702B32DFCF13E688461967F]
 GoodName=NBA Live 99 (U) (M5) [b1]
@@ -10715,16 +12217,20 @@ GoodName=NBA Pro 98 (E) [!]
 CRC=ACDE962F B2CBF87F
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [C5EBBDD41EAEA8BD02CF520640CCCCDF]
 GoodName=NBA Pro 99 (E) [!]
 CRC=8D1780B6 57B3B976
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9A203506DB213F97FE28210AAF56F820]
 GoodName=NBA Pro 99 (E) [f1] (NTSC)
@@ -10736,7 +12242,10 @@ GoodName=NBA Showtime - NBA on NBC (U) [!]
 CRC=3FFE80F4 A7C15F7E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [76DB89759121710C416ECFB1736B5E39]
@@ -10787,8 +12296,10 @@ GoodName=NFL Blitz (U) [!]
 CRC=D094B170 D7C4B5CC
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F0A1CC3D1D99A60F35D37DDCCF43CABB]
 GoodName=NFL Blitz (U) [f1] (PAL)
@@ -10800,16 +12311,20 @@ GoodName=NFL Blitz - Special Edition (U) [!]
 CRC=30EAD54F 31620BF6
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [BA49514441023722F02D41C62612F6C3]
 GoodName=NFL Blitz 2000 (U) (V1.0) [!]
 CRC=15A00969 34E5A285
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [DDBE4248EA34E11C091A975776042670]
 GoodName=NFL Blitz 2000 (U) (V1.0) [f1] (PAL)
@@ -10826,8 +12341,10 @@ GoodName=NFL Blitz 2001 (U) [!]
 CRC=36FA35EB E85E2E36
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [D13A38B9639CF1944FE7024E4C58739D]
 GoodName=NFL Blitz 2001 (U) [f1] (PAL-NTSC)
@@ -10839,16 +12356,20 @@ GoodName=NFL Quarterback Club 2000 (E) [!]
 CRC=88BD5A9E E81FDFBF
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [EC18E3131040842E32EBAB66C7496EBD]
 GoodName=NFL Quarterback Club 2000 (U) [!]
 CRC=E3AB4ED0 83040DD2
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [55224F1148F873A689604F2DC6432682]
 GoodName=NFL Quarterback Club 2000 (U) [b1]
@@ -10865,16 +12386,20 @@ GoodName=NFL Quarterback Club 2001 (U) [!]
 CRC=28784622 FFB22985
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [A18CA5DBC85668667AA467ADD6A62B39]
 GoodName=NFL Quarterback Club 98 (E) [!]
 CRC=4B629EF4 99B21D9B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [37954BA9067840FAFF851092043F0435]
 GoodName=NFL Quarterback Club 98 (E) [o1]
@@ -10886,8 +12411,10 @@ GoodName=NFL Quarterback Club 98 (U) [!]
 CRC=D89BE2F8 99C97ADF
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [B39D12910D12498605A9F793C29866BE]
 GoodName=NFL Quarterback Club 98 (U) [b1]
@@ -10904,8 +12431,10 @@ GoodName=NFL Quarterback Club 99 (E) [!]
 CRC=52A3CF47 4EC13BFC
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [EBDC155D7462F8C73DB4730C6BF4010D]
 GoodName=NFL Quarterback Club 99 (E) [b1]
@@ -10917,32 +12446,40 @@ GoodName=NFL Quarterback Club 99 (U) [!]
 CRC=BE76EDFF 20452D09
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [B7E41D34D209B6CFA92E3D622F911C4E]
 GoodName=NHL 99 (E) [!]
 CRC=287D601E ABF4F8AE
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [A62FA044BCB5507D358424ABDA6419DB]
 GoodName=NHL 99 (U) [!]
 CRC=591A806E A5E6921D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [349F61F9747F2D2098F305924C97A1BF]
 GoodName=NHL Blades of Steel '99 (U) [!]
 CRC=82EFDC30 806A2461
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9FF8AFF664781384A5FC01449DC5AD8D]
 GoodName=NHL Blades of Steel '99 (U) [f1] (PAL)
@@ -10954,8 +12491,10 @@ GoodName=NHL Breakaway 98 (E) [!]
 CRC=29CE7692 71C58579
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [43D788E7CAEA1146228B763C13E8E740]
 GoodName=NHL Breakaway 98 (E) [f1] (NTSC)
@@ -10982,8 +12521,10 @@ GoodName=NHL Breakaway 98 (U) [!]
 CRC=6DFDCDC3 4DE701C8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1D178B74A163711CA9C06327F3B709CF]
 GoodName=NHL Breakaway 98 (U) [h1C]
@@ -11005,8 +12546,10 @@ GoodName=NHL Breakaway 99 (E) [!]
 CRC=874621CB 0031C127
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [417AFE49BF73F3663C5F5F0AF897FC79]
 GoodName=NHL Breakaway 99 (E) [b1]
@@ -11018,8 +12561,10 @@ GoodName=NHL Breakaway 99 (U) [!]
 CRC=441768D0 7D73F24F
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [07C102E1ADF6190E05EF3C897090DFD3]
 GoodName=NHL Breakaway 99 (U) [b1]
@@ -11036,8 +12581,10 @@ GoodName=NHL Pro 99 (E) [!]
 CRC=A9895CD9 7020016C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [BCEE33DC37C872A188A72EEAF41369F4]
 GoodName=NHL Pro 99 (E) [o1]
@@ -11053,7 +12600,10 @@ GoodName=Nagano Winter Olympics '98 (E) [!]
 CRC=6D452016 713C09EE
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [D5CE3A477104213499FFEA3A0BCB1555]
 GoodName=Nagano Winter Olympics '98 (E) [h1C]
@@ -11070,7 +12620,10 @@ GoodName=Nagano Winter Olympics '98 (U) [!]
 CRC=8D2BAE98 D73725BF
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [48782BC5728F38099B21E8B281ADC1CA]
 GoodName=Nagano Winter Olympics '98 (U) [T+Ita_HRG]
@@ -11107,7 +12660,10 @@ GoodName=Namco Museum 64 (U) [!]
 CRC=5129B6DA 9DEF3C8C
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [EAD417FF24EAB32E2BF45CEA9200D425]
 GoodName=Namco Museum 64 (U) [f1] (PAL)
@@ -11138,7 +12694,10 @@ GoodName=Neon Genesis Evangelion (J) [!]
 CRC=147E0EDB 36C5B12C
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [34F5F402064F76B375771EBF80DBE734]
 GoodName=Neon Genesis Evangelion (J) [b1]
@@ -11209,14 +12768,20 @@ GoodName=New Tetris, The (E) [!]
 CRC=E61CFF0A CE1C0D71
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [7A28179B00734C9AA0F0609FAFAAFD5F]
 GoodName=New Tetris, The (U) [!]
 CRC=2153143F 992D6351
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [0B13983A634732FDE9D2D638C0A14C51]
 GoodName=New Tetris, The (U) [f1] (PAL)
@@ -11238,8 +12803,10 @@ GoodName=Nightmare Creatures (U) [!]
 CRC=2857674D CC4337DA
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [60A2CFF1515D4C7902DDE32A6E01D411]
 GoodName=Nightmare Creatures (U) [b1]
@@ -11265,6 +12832,10 @@ RefMD5=4116CF435DB315A2481AF8D1E9352FEB
 GoodName=Nintama Rantarou 64 Game Gallery (J) [!]
 CRC=CD3C3CDF 317793FA
 Players=4
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [66DB457B130D31A286A23D6E4DD9726E]
@@ -11273,7 +12844,10 @@ CRC=67D20729 F696774C
 Status=3
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [B2DF29627E0219A9C14605F46803C94C]
@@ -11344,8 +12918,10 @@ GoodName=Nuclear Strike 64 (E) (M2) [!]
 CRC=8A97A197 272DF6C1
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [59C28E02BAF4065051C63EA51736892A]
@@ -11358,8 +12934,10 @@ GoodName=Nuclear Strike 64 (G) [!]
 CRC=8F50B845 D729D22F
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [FFC584040D0D052FBAB4CB6C19245449]
@@ -11367,8 +12945,10 @@ GoodName=Nuclear Strike 64 (U) [!]
 CRC=4998DDBB F7B7AEBC
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [76C8EFDD11F6D2E553055B801A022653]
@@ -11390,6 +12970,7 @@ RefMD5=FFC584040D0D052FBAB4CB6C19245449
 GoodName=Nushi Tsuri 64 (J) (V1.0) [!]
 CRC=D83BB920 CC406416
 Players=1
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -11424,6 +13005,7 @@ RefMD5=50C10082D0C077FDB5658EF5A6E3F54F
 GoodName=Nushi Tsuri 64 (J) (V1.1) [!]
 CRC=C5F1DE79 5D4BEB6E
 Players=1
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -11443,6 +13025,8 @@ RefMD5=EEB69597E42E2F5D2914070ACF161B4F
 GoodName=Nushi Tsuri 64 - Shiokaze ni Notte (J) [!]
 CRC=5B9B1618 1B43C649
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 CountPerOp=1
@@ -11451,15 +13035,19 @@ CountPerOp=1
 GoodName=O.D.T. (E) (M5) [!]
 CRC=E86415A6 98395B53
 Players=1
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [4116E492168AAFFF1BD3100C7B0AA28F]
 GoodName=O.D.T. (U) (M3) [!]
 CRC=2655BB70 667D9925
 Players=1
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [09BA01C6EC8B178A27FBEE3A9DEE8EB6]
 GoodName=Oerjan Intro by Oerjan (POM '99) (PD)
@@ -11470,8 +13058,10 @@ GoodName=Off Road Challenge (E) [!]
 CRC=812289D0 C2E53296
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F30DFECB19DBD82A2FD334A8A37B8D38]
 GoodName=Off Road Challenge (E) [b1]
@@ -11488,8 +13078,10 @@ GoodName=Off Road Challenge (U) [!]
 CRC=319093EC 0FC209EF
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [DC34F5AA26488352B4D025EDBF47FE39]
 GoodName=Off Road Challenge (U) [b1]
@@ -11511,12 +13103,20 @@ GoodName=Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [!]
 CRC=0375CF67 56A93FAA
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [55CD360F12BE8063C9E7B6F59F268170 ]
 GoodName=Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) (VC) [!]
 CRC=0375CF67 56A93FAA
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A3F64D34614A0B01B6A49AE4031ACBDF]
 GoodName=Ogre Battle 64 - Person of Lordly Caliber (J) (V1.1) [b1]
@@ -11538,21 +13138,30 @@ GoodName=Ogre Battle 64 - Person of Lordly Caliber (U) (V1.0) [!]
 CRC=E6419BC5 69011DE3
 Players=1
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [EBB4B4D2808DF427AAA3085A41B8A954]
 GoodName=Ogre Battle 64 - Person of Lordly Caliber (U) (V1.1) [!]
 CRC=0ADAECA7 B17F9795
 Players=1
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [465DFD27DDAB4F5488F4DADC09B7F938]
 GoodName=Olympic Hockey Nagano '98 (E) (M4) [!]
 CRC=AE2D3A35 24F0D41A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [02AA0C059EC36145927353C8E617AA41]
 GoodName=Olympic Hockey Nagano '98 (E) (M4) [h1C]
@@ -11564,14 +13173,20 @@ GoodName=Olympic Hockey Nagano '98 (J) [!]
 CRC=90F43037 5C5370F5
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [9C99C6D9EA98A960056C531CB78EB35B]
 GoodName=Olympic Hockey Nagano '98 (U) [!]
 CRC=7EC22587 EF1AE323
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [8F9810383B86E86EC447F65D47CA74A7]
 GoodName=Olympic Hockey Nagano '98 (U) [T+Ita_cattivik66]
@@ -11602,7 +13217,10 @@ RefMD5=9C99C6D9EA98A960056C531CB78EB35B
 GoodName=Onegai Monsters (J) [!]
 CRC=DC649466 572FF0D9
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [B19805B3DFECF85FEA7E04614362DC28]
 GoodName=Onegai Monsters (J) [b1]
@@ -11614,8 +13232,10 @@ GoodName=Operation WinBack (E) (M5) [!]
 CRC=D5898CAF 6007B65B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F2DF4577D3749345F93BA0606BECA8DD]
 GoodName=PC-Engine 64 (POM '99) (PD) [t1]
@@ -11630,7 +13250,9 @@ GoodName=PD Ultraman Battle Collection 64 (J) [!]
 CRC=F468118C E32EE44E
 Players=2
 SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
+Rumble=No
 Transferpak=Yes
 
 [4FD424DF60F80EE7E362A9572049BA11]
@@ -11653,6 +13275,10 @@ GoodName=PGA European Tour (E) (M5) [!]
 CRC=EE08C602 6BC2D5A6
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [2F6B0ACB7270F78C972F5E6D4C75B02B]
 GoodName=PGA European Tour (E) (M5) [f1] (NTSC)
@@ -11669,6 +13295,10 @@ GoodName=PGA European Tour (U) [!]
 CRC=B54CE881 BCCB6126
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [8E79EC6D9F8DB1C50100860BF4437462]
 GoodName=POMbaer Demo by Kid Stardust (POM '99) (PD)
@@ -11682,7 +13312,10 @@ CRC=EDAFD3C0 39EF3599
 GoodName=Pachinko 365 Nichi (J) [!]
 CRC=74554B3B F4AEBCB5
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [2002438491F94C468CB487032AC4AA33]
 GoodName=Pachinko 365 Nichi (J) [b1]
@@ -11704,12 +13337,24 @@ CRC=26AD85C5 F908A36B
 
 [8F8F50AB00C4089AE32C6B9FEFD69543]
 GoodName=Paper Mario (Ch) (iQue) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [C4D652425AA4F2FC1D12564DF01F8A04]
 GoodName=Paper Mario (Ch) (V2) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [D9597922207298A87FA46878C017E6DA]
 GoodName=Paper Mario (Ch) (V4) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A9BE6A493A680642D840F859A65816CA]
 GoodName=Paper Mario (E) (M4) [!]
@@ -11717,7 +13362,10 @@ CRC=19AB29AF C71BCD28
 Status=2
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [A722F8161FF489943191330BF8416496]
@@ -11726,7 +13374,10 @@ CRC=65EEE53A ED7D733C
 Status=2
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [8595BA0A0D2EA73944228BDED4A969AD]
@@ -11747,8 +13398,10 @@ GoodName=Paperboy (U) [!]
 CRC=3E198D9E F2E1267E
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [12827E2EF6EB1FF0F8AA494E671C3094]
 GoodName=Paperboy (U) [f1] (PAL)
@@ -11780,7 +13433,10 @@ GoodName=Parlor! Pro 64 - Pachinko Jikki Simulation Game (J) [!]
 CRC=CFE2CB31 4D6B1E1D
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [6DF573EE08C4577BBBF117B813D93B19]
 GoodName=Pause Demo by RedboX (PD)
@@ -11792,7 +13448,10 @@ CRC=C83CEB83 FDC56219
 Status=3
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [B6DF5A75CED54DFEE0E29BCE9ABD0AAF]
 GoodName=Penny Racers (E) [h1C]
@@ -11810,7 +13469,10 @@ CRC=73ABB1FB 9CCA6093
 Players=4
 Status=3
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [26F033C7716A10755A3D22C62ACF6851]
 GoodName=Penny Racers (U) [hI]
@@ -11820,8 +13482,9 @@ RefMD5=518B14054A667A3B9E0B72D3BF784E41
 [D9B5CD305D228424891CE38E71BC9213]
 GoodName=Perfect Dark (E) (M5) [!]
 CRC=E4B08007 A602FF33
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -11834,8 +13497,9 @@ RefMD5=D9B5CD305D228424891CE38E71BC9213
 [AD2DE210A3455BA5EC541F0C78D91444]
 GoodName=Perfect Dark (E) (Debug) (2000-04-26) [!]
 CRC=F9864452 890A5EA3
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -11843,8 +13507,9 @@ Transferpak=Yes
 [538D2B75945EAE069B29C46193E74790]
 GoodName=Perfect Dark (J) [!]
 CRC=96747EB4 104BB243
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -11852,8 +13517,9 @@ Transferpak=Yes
 [7F4171B0C8D17815BE37913F535E4E93]
 GoodName=Perfect Dark (U) (V1.0) [!]
 CRC=DDF460CC 3CA634C0
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -11866,8 +13532,9 @@ RefMD5=7F4171B0C8D17815BE37913F535E4E93
 [E03B088B6AC9E0080440EFED07C1E40F]
 GoodName=Perfect Dark (U) (V1.1) [!]
 CRC=41F2B98F B458B466
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -11875,8 +13542,9 @@ Transferpak=Yes
 [AA93F4DF16FCEADA399A749F5AD2F273]
 GoodName=Perfect Dark (U) (Debug) (2000-03-22) [!]
 CRC=2CE75AEF E16825BC
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
 Transferpak=Yes
@@ -11886,7 +13554,10 @@ GoodName=Pikachu Genki Dechu (J) [!]
 CRC=3F245305 FC0B74AA
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [D0AE6C07AC0481EBA5FF9CE798A69574]
 GoodName=Pikachu Genki Dechu (J) [b1]
@@ -11898,6 +13569,10 @@ GoodName=Pilotwings 64 (E) (M3) [!]
 CRC=1AA05AD5 46F52D80
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [F21E2A3A05ACF49586F32DCE5C449FE4]
@@ -11920,6 +13595,10 @@ GoodName=Pilotwings 64 (J) [!]
 CRC=09CC4801 E42EE491
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [2740F1B89CE7D78A5D31CF60C97A0C11]
@@ -11932,6 +13611,10 @@ GoodName=Pilotwings 64 (U) [!]
 CRC=C851961C 78FCAAFA
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [E28F8F19E56CC6C7A0F3A3286AEB60C1]
@@ -12041,12 +13724,22 @@ GoodName=Pocket Monsters Snap (J) [!]
 CRC=EC0F690D 32A7438C
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [33FDAB9712D9FEA793A3AE44293999C3]
 GoodName=Pocket Monsters Snap (J) (VC) [!]
 CRC=E0044E9E CD659D0D
-RefMD5=FBDD74ED68E6A0CD734562D56CCB752D
+Players=1
+SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
+CountPerOp=1
 
 [42CC0FE1442B0A498DFD8F743179C51A]
 GoodName=Pocket Monsters Snap (J) [b1]
@@ -12068,6 +13761,9 @@ GoodName=Pocket Monsters Stadium (J) [!]
 CRC=665E8259 D098BD1D
 Players=2
 SaveType=SRAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [B43B3C7A3D2149FEEDC8BA3B8198BE5D]
@@ -12093,8 +13789,11 @@ RefMD5=C46E087D966A35095DF96799B0B4FFAE
 [2449BB712A64E3363A6CBD56F5ADEDA5]
 GoodName=Pocket Monsters Stadium 2 (J) [!]
 CRC=63775886 5FB80E7B
-SaveType=Flash RAM
 Players=4
+SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [907403B12D2AD59A0F186A1632AE39B9]
@@ -12122,6 +13821,9 @@ GoodName=Pocket Monsters Stadium Kin Gin (J) [!]
 CRC=EE4FD7C2 9CF1D938
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [2EF9FA16DE2A09EA15B6289447F40490]
@@ -12129,48 +13831,80 @@ GoodName=Pokemon Puzzle League (E) [!]
 CRC=4A1CD153 D830AEF8
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [FBF566693BCA3145D86DF34D18DCDD43]
 GoodName=Pokemon Puzzle League (E) (VC) [!]
 CRC=4A1CD153 D830AEF8
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A3BA044DFC00BB766B4B2BFB9D4B5BE9]
 GoodName=Pokemon Puzzle League (F) [!]
 CRC=3EB2E6F3 062F9EFE
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [866D401C51CC05A3188C9A2D4E7BFEE5]
 GoodName=Pokemon Puzzle League (F) (VC) [!]
 CRC=3EB2E6F3 062F9EFE
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [000364BAC80E41D9060A31A5923874B7]
 GoodName=Pokemon Puzzle League (G) [!]
 CRC=7A4747AC 44EEEC23
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [45B507AAAF0CCDB6EFE3CD717F0DDB95]
 GoodName=Pokemon Puzzle League (G) (VC) [!]
 CRC=7A4747AC 44EEEC23
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [E722576A15182CFED6782379CE4BC8BE]
 GoodName=Pokemon Puzzle League (U) [!]
 CRC=19C553A7 A70F4B52
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [D6F58B98115E78D841089074401AE524]
 GoodName=Pokemon Puzzle League (U) (VC) [!]
 CRC=19C553A7 A70F4B52
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [DC09E2685EB95471311E57B3605F4894]
 GoodName=Pokemon Puzzle League (U) [t1]
@@ -12187,6 +13921,10 @@ GoodName=Pokemon Snap (A) [!]
 CRC=7BB18D40 83138559
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [A88FCF3FF00F21D3CEC44D2E0FAAAAD8]
@@ -12199,6 +13937,10 @@ GoodName=Pokemon Snap (E) [!]
 CRC=4FF5976F ACF559D8
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [E9028F9CCC307806695DD81742D05D5D]
@@ -12206,6 +13948,10 @@ GoodName=Pokemon Snap (F) [!]
 CRC=BA6C293A 9FAFA338
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [5FA70A63E352EA804607999674381749]
@@ -12218,6 +13964,10 @@ GoodName=Pokemon Snap (G) [!]
 CRC=5753720D 2A8A884D
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [D0453459095F69BE36D675D8F743069B]
@@ -12225,6 +13975,10 @@ GoodName=Pokemon Snap (I) [!]
 CRC=C0C85046 61051B05
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [A45D7115BE5A06FD1567F9F913C3BDF8]
@@ -12232,6 +13986,10 @@ GoodName=Pokemon Snap (S) [!]
 CRC=817D286A EF417416
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [FC3C9329B7CDD67CF7650ABF63B9A580]
@@ -12239,6 +13997,10 @@ GoodName=Pokemon Snap (U) [!]
 CRC=CA12B547 71FA4EE4
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [CCA6F7593302D46ADA66C991C976DA2D]
@@ -12271,6 +14033,10 @@ GoodName=Pokemon Snap Station (U) [!]
 CRC=39119872 07722E9F
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [B88F0EC125C54685FA516D233B564842]
@@ -12283,6 +14049,9 @@ GoodName=Pokemon Stadium (E) (V1.0) [!]
 CRC=84077275 57315B9C
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [9CC940F5F463416F0B2C15F07A088F33]
@@ -12295,6 +14064,9 @@ GoodName=Pokemon Stadium (E) (V1.1) [!]
 CRC=91C9E05D AD3AAFB9
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [0E85A098D0F0E8A7EB572A69612A6873]
@@ -12302,6 +14074,9 @@ GoodName=Pokemon Stadium (F) [!]
 CRC=A23553A3 42BF2D39
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [4688C66F8C13EDA13DD5678176A7FD8A]
@@ -12314,6 +14089,9 @@ GoodName=Pokemon Stadium (G) [!]
 CRC=42011E1B E3552DB5
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [8FAA825507E6CD3F388CC33343FAE547]
@@ -12326,6 +14104,9 @@ GoodName=Pokemon Stadium (I) [!]
 CRC=A53FA82D DAE2C15D
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [D14A499BC4E324974EAE3E42DEC58625]
@@ -12333,6 +14114,9 @@ GoodName=Pokemon Stadium (S) [!]
 CRC=B6E549CE DC8134C0
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [8D296A614A47AC99B80D1EDE669E62B3]
@@ -12345,6 +14129,9 @@ GoodName=Pokemon Stadium (U) (V1.0) [!]
 CRC=90F5D9B3 9D0EDCF0
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [C9214988B08511D2F44FAC2FAD2EE67A]
@@ -12357,6 +14144,9 @@ GoodName=Pokemon Stadium (U) (V1.1) [!]
 CRC=1A122D43 C17DAF0F
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [A7087A96A709E4C662A459B4B4159094]
@@ -12374,6 +14164,9 @@ GoodName=Pokemon Stadium (U) (V1.2) [!]
 CRC=9C8FB2FA 9B84A09B
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [B1271DB50D6EF8F6B53CC640C3743E4F]
@@ -12381,6 +14174,9 @@ GoodName=Pokemon Stadium 2 (E) [!]
 CRC=2952369C B6E4C3A8
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [BB1623BD4751240138DE55E18D3ACA7E]
@@ -12393,6 +14189,9 @@ GoodName=Pokemon Stadium 2 (F) [!]
 CRC=AC5AA5C7 A9B0CDC3
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [484F3E696C94980ACF3D7068F9ACC98F]
@@ -12400,6 +14199,9 @@ GoodName=Pokemon Stadium 2 (G) [!]
 CRC=439B7E7E C1A1495D
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [5A04D7F1AB9C6B080176567AA7168D3A]
@@ -12407,6 +14209,9 @@ GoodName=Pokemon Stadium 2 (I) [!]
 CRC=EFCEAF00 22094848
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [B26AAFD452C9816E1B7AA0954E75825F]
@@ -12414,6 +14219,9 @@ GoodName=Pokemon Stadium 2 (S) [!]
 CRC=D0A1FC5B 2FB8074B
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [1561C75D11CEDF356A8DDB1A4A5F9D5D]
@@ -12421,6 +14229,9 @@ GoodName=Pokemon Stadium 2 (U) [!]
 CRC=03571182 892FD06D
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [BBDC4C4F1C474298189312008A1768C4]
@@ -12428,8 +14239,10 @@ GoodName=Polaris SnoCross (U) [!]
 CRC=41380792 A167E045
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F27CBDB653AAF1D4856A53D5951F36DD]
 GoodName=Polaris SnoCross (U) [o1][t1]
@@ -12492,7 +14305,10 @@ RefMD5=8EACC93671249508BF12CF6EC101056D
 GoodName=Power League 64 (J) [!]
 CRC=D7A6DCFA CCFEB6B7
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [6504FC6F3ADB596F7D68060EB39A75B4]
 GoodName=Power League 64 (J) [o1]
@@ -12504,7 +14320,10 @@ GoodName=Power Rangers - Lightspeed Rescue (E) [!]
 CRC=39F60C11 AB2EBA7D
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [24B5BFA896802253D2B715FC760D1B3E]
 GoodName=Power Rangers - Lightspeed Rescue (E) [f1] (NTSC)
@@ -12516,19 +14335,29 @@ GoodName=Power Rangers - Lightspeed Rescue (U) [!]
 CRC=CF8957AD 96D57EA9
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [2991BB68ECA54813D6B834ADBBBACC4C]
 GoodName=Powerpuff Girls, The - Chemical X-Traction (U) [!]
 CRC=FC74D475 9A0278AB
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [25BAFC84BA4D87854DC44DF3EF8764EA]
 GoodName=Premier Manager 64 (E) [!]
 CRC=F3D27F54 C111ACF9
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [527F05F166398599F0A1B10F8E1F9585]
 GoodName=Premier Manager 64 (E) [f1] (NTSC)
@@ -12544,7 +14373,10 @@ RefMD5=25BAFC84BA4D87854DC44DF3EF8764EA
 GoodName=Pro Mahjong Kiwame 64 (J) (V1.0) [!]
 CRC=9BA10C4E 0408ABD3
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [D1624977A3C25192671772623FA76438]
@@ -12561,14 +14393,20 @@ RefMD5=7995D76F4CE236B0F0289F47AE523D32
 GoodName=Pro Mahjong Kiwame 64 (J) (V1.1) [!]
 CRC=0AE2B37C FBC174F0
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [F1A2E4DD22ADF4F90DA4BDDCA37D5F18]
 GoodName=Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (J) [!]
 CRC=1BDCB30F A132D876
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [4FA4DC582C23EEE81FEB39B7EEBD15D6]
@@ -12583,6 +14421,8 @@ CRC=C5C4F0D5 4EEF2573
 GoodName=Puyo Puyo 4 - Puyo Puyo Party (J) [!]
 CRC=4B4672B9 2DBE5DE7
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -12590,7 +14430,10 @@ Transferpak=Yes
 GoodName=Puyo Puyo Sun 64 (J) [!]
 CRC=94807E6B 60CC62E4
 Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [20C7ABF5A4DB8DC1C70725FD213E29A2]
 GoodName=Puyo Puyo Sun 64 (J) [b1]
@@ -12602,8 +14445,10 @@ GoodName=Puzzle Bobble 64 (J) [!]
 CRC=C0DE0747 A2DF72D3
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9B463A87DA73B8C923B05C3BD46EDB09]
 GoodName=Puzzle Bobble 64 (J) [f1] (PAL)
@@ -12628,8 +14473,10 @@ GoodName=Quake 64 (E) [!]
 CRC=16931D74 65DC6D34
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [30EDCCA84850E3B4129936350A9B6B8B]
 GoodName=Quake 64 (E) [o1]
@@ -12646,8 +14493,10 @@ GoodName=Quake 64 (U) [!]
 CRC=9F5BF79C D2FE08A0
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [87F35BC0C6E2EAD981B49D691095B118]
 GoodName=Quake 64 (U) [b1]
@@ -12693,8 +14542,10 @@ GoodName=Quake II (E) [!]
 CRC=7433D9D7 2C4322D0
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [55A789C553827114306E29D71E26E5DC]
@@ -12707,8 +14558,10 @@ GoodName=Quake II (U) [!]
 CRC=BDA8F143 B1AF2D62
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [920FAACCE1F8A80022433ACFD5CD2BC3]
@@ -12721,7 +14574,10 @@ GoodName=Quest 64 (U) [!]
 CRC=C8BB4DD9 CC5F430B
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [6F32B4DE3B3FC0C719BF9EA27EFC18BE]
 GoodName=Quest 64 (U) [b1]
@@ -12774,14 +14630,20 @@ GoodName=RR64 - Ridge Racer 64 (E) [!]
 CRC=FEE97010 4E94A9A0
 SaveType=Eeprom 16KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [990F97D56456FC23E52BD263E709E21E]
 GoodName=RR64 - Ridge Racer 64 (U) [!]
 CRC=2500267E 2A7EC3CE
-SaveType=Eeprom 16KB
 Players=4
+SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [8CF63267BA38AB73763354C79C4ADB74]
 GoodName=RR64 - Ridge Racer 64 (U) [f1] (PAL)
@@ -12797,8 +14659,11 @@ RefMD5=990F97D56456FC23E52BD263E709E21E
 GoodName=RTL World League Soccer 2000 (G) [!]
 CRC=658F8F37 1813D28D
 Players=4
+SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [09BEE9D7EB1159D11E49BDFB03A2C4CC]
 GoodName=RTL World League Soccer 2000 (G) [f1] (NTSC)
@@ -12815,8 +14680,10 @@ GoodName=Racing Simulation 2 (G) [!]
 CRC=2877AC2D C3DC139A
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6160D5DE99BE421ACB620D2D203C2FEC]
 GoodName=Racing Simulation 2 (G) [h1C]
@@ -12827,7 +14694,10 @@ RefMD5=AA57D69867F53456F351A289EBA08C3D
 GoodName=Rakuga Kids (E) [!]
 CRC=67D21868 C5424061
 Players=2
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [28FE768CED3C87659B343A7811CFAC0A]
 GoodName=Rakuga Kids (E) [b1]
@@ -12848,7 +14718,10 @@ RefMD5=167A3502F06CF0EEF56758533F3D0E52
 GoodName=Rakuga Kids (J) [!]
 CRC=9F1ECAF0 EEC48A0E
 Players=2
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [378C6CE13DF3363F77D76B64C8DAB287]
 GoodName=Rakuga Kids (J) [b1]
@@ -12865,8 +14738,10 @@ GoodName=Rally '99 (J) [!]
 CRC=35D9BA0C DF485586
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [035B02E493A388E950FB42F4B3D891F8]
 GoodName=Rally '99 (J) [f1] (PAL)
@@ -12878,16 +14753,20 @@ GoodName=Rally Challenge 2000 (U) [!]
 CRC=73A88E3D 3AC5C571
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [08E02F52E0547686A9BFAC7CBB03C129]
 GoodName=Rampage - World Tour (E) [!]
 CRC=84D44448 67CA19B0
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [410146EA14CF34D134BC97C78522D322]
 GoodName=Rampage - World Tour (E) [h1C]
@@ -12899,8 +14778,10 @@ GoodName=Rampage - World Tour (U) [!]
 CRC=C29FF9E4 264BFE7D
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1659F9F8C8A5C24F775B245BDA574462]
 GoodName=Rampage - World Tour (U) [b1]
@@ -12942,16 +14823,20 @@ GoodName=Rampage 2 - Universal Tour (E) [!]
 CRC=5DFC4249 99529C07
 Players=3
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [8113D0EA2008402D4631F241F625D16B]
 GoodName=Rampage 2 - Universal Tour (U) [!]
 CRC=673D099B A4C808DE
 Players=3
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [EBAFB5C3BCC84543A8E7FEF1993E573F]
 GoodName=Rampage 2 - Universal Tour (U) [t1]
@@ -12972,7 +14857,10 @@ GoodName=Rat Attack (E) (M6) [!]
 CRC=20FD0BF1 F5CF1D87
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 ; Allows the game to boot
 Cheat0=F117DAEC 8014,F117DAEE A1D0
 
@@ -12991,7 +14879,10 @@ GoodName=Rat Attack (U) (M6) [!]
 CRC=0304C48E AC4001B8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 ; Allows the game to boot
 Cheat0=F117E34C 8014,F117E34E A8F0
 
@@ -13000,7 +14891,10 @@ GoodName=Rayman 2 - The Great Escape (E) (M5) [!]
 CRC=60D5E10B 8BEDED46
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [EF2001F581A80D760C51D130725A9930]
 GoodName=Rayman 2 - The Great Escape (E) (M5) [f1] (NTSC)
@@ -13017,7 +14911,10 @@ GoodName=Rayman 2 - The Great Escape (U) (M5) [!]
 CRC=F3C5BF9B 160F33E2
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [2B1D9F38389522A372D950E1BC6FA13F]
 GoodName=Rayman 2 - The Great Escape (U) (M5) [t1]
@@ -13029,8 +14926,10 @@ GoodName=Razor Freestyle Scooter (U) [!]
 CRC=3918834A 15B50C29
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [FAA64ABB0D222FCC0C6E2515D3805D9F]
@@ -13038,16 +14937,20 @@ GoodName=Re-Volt (E) (M4) [!]
 CRC=C3E7E29E 5D7251CC
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [3FC4D3187435443455F8355B2D3F8934]
 GoodName=Re-Volt (U) [!]
 CRC=0F1FA987 BFC1AFA6
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [377DAF6EDD0C996422D2A9C8C5DEC033]
 GoodName=Re-Volt (U) [f1] (Country Check)
@@ -13069,8 +14972,10 @@ GoodName=Ready 2 Rumble Boxing (E) (M3) [!]
 CRC=8BD4A334 1E138B05
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [70F73D01FEAF768758F31B23DE2C2620]
 GoodName=Ready 2 Rumble Boxing (E) (M3) [t1] (P1 Untouchable)
@@ -13082,8 +14987,10 @@ GoodName=Ready 2 Rumble Boxing (U) [!]
 CRC=EAB7B429 BAC92C57
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [25620A9C9F372023A8BA862330E6373A]
 GoodName=Ready 2 Rumble Boxing (U) [f1] (PAL)
@@ -13100,8 +15007,10 @@ GoodName=Ready 2 Rumble Boxing - Round 2 (U) [!]
 CRC=E9219533 13FBAFBD
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [CB97350D5CAB48EAB8B954D91C0E5DAC]
@@ -13114,7 +15023,10 @@ GoodName=Resident Evil 2 (E) (M2) [!]
 CRC=9B500E8E E90550B3
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [DD21150CBC21C05420304599EC57411C]
@@ -13122,7 +15034,10 @@ GoodName=Resident Evil 2 (U) (V1.0) [!]
 CRC=2F493DD0 2E64DFD9
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [1ADD2C0217662B307CDFD876B35FBF7A]
@@ -13130,7 +15045,10 @@ GoodName=Resident Evil 2 (U) (V1.1) [!]
 CRC=AA18B1A5 07DB6AEB
 Players=1
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [AD922DAE446A301E1AAFE1DFBAD75A2E]
@@ -13138,8 +15056,10 @@ GoodName=Road Rash 64 (E) [!]
 CRC=02D8366A 6CABEF9C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=3
 
 [5EB2B1892B68767EB1D310FF7507D34E]
@@ -13152,8 +15072,10 @@ GoodName=Road Rash 64 (U) [!]
 CRC=F050746C 247B820B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=3
 
 [7966F17F36C43D3807C0949AAD45168A]
@@ -13171,16 +15093,20 @@ GoodName=Roadsters Trophy (E) (M6) [!]
 CRC=74E87A70 6293AED4
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [D3644B398C090528E0ED9EB3C140366E]
 GoodName=Roadsters Trophy (U) (M3) [!]
 CRC=0B6B4DDB 9671E682
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [AE705F25C57ACABBD0E8BAE5EC6E237F]
@@ -13198,6 +15124,9 @@ GoodName=Robot Ponkottsu 64 - 7tsu no Umi no Caramel (J) [!]
 CRC=272B690F AD0A7A77
 Players=2
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
+Rumble=No
 Transferpak=Yes
 
 [34779AF3681F58E4F642F03EAEF198F9]
@@ -13218,7 +15147,10 @@ GoodName=Robotron 64 (E) [!]
 CRC=9FF69D4F 195F0059
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [360044D5675A328E62191250F43B6671]
 GoodName=Robotron 64 (E) [h1C]
@@ -13230,7 +15162,10 @@ GoodName=Robotron 64 (U) [!]
 CRC=AC8E4B32 E7B47326
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [C4A9BBF989DDFAF5F389E4ADC6195DBC]
 GoodName=Robotron 64 (U) [b1]
@@ -13272,14 +15207,20 @@ GoodName=Rocket - Robot on Wheels (E) (M3) [!]
 CRC=9FD375F8 45F32DC8
 SaveType=Eeprom 4KB
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [C2907EB2F9A350793317ECE878A3B8E3]
 GoodName=Rocket - Robot on Wheels (U) [!]
 CRC=0C5EE085 A167DD3E
 SaveType=Eeprom 4KB
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E8CBAADEDB6D19ACC142BE3105E94C4F]
 GoodName=Rocket - Robot on Wheels (U) [b1]
@@ -13301,7 +15242,10 @@ GoodName=Rockman Dash (J) [!]
 CRC=D666593B D7A25C07
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [14F1F43A0314C3E36D9D248E1F03EC2E]
 GoodName=Ronaldinho's Soccer 64 (B) (Unl) (Pirate)
@@ -13320,14 +15264,20 @@ GoodName=Rugrats - Die grosse Schatzsuche (G) [!]
 CRC=451ACA0F 7863BC8A
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [8C432235A57D34BC4A9B8B290E21E01E]
 GoodName=Rugrats - Scavenger Hunt (U) [!]
 CRC=0C02B3C5 9E2511B8
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [C3ED4CD05978DECFD761FA2503DCB39E]
 GoodName=Rugrats - Scavenger Hunt (U) [f1] (PAL)
@@ -13339,7 +15289,10 @@ GoodName=Rugrats - Treasure Hunt (E) [!]
 CRC=4D3ADFDA 7598FCAE
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [950161325C7E11A057CC85C95685DB05]
 GoodName=Rugrats - Treasure Hunt (E) [h1C]
@@ -13351,14 +15304,20 @@ GoodName=Rugrats in Paris - The Movie (E) [!]
 CRC=0AC61D39 ABFA03A6
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [207EFE58C7C221DBDFFF285AB80126C1]
 GoodName=Rugrats in Paris - The Movie (U) [!]
 CRC=1FC21532 0B6466D4
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [F3515A45EC01D2C9FEAFBAB2B85D72C4]
 GoodName=Rugrats in Paris - The Movie (U) [T+Spa0.10]
@@ -13370,8 +15329,10 @@ GoodName=Rush 2 - Extreme Racing USA (E) (M6) [!]
 CRC=B7CF2136 FA0AA715
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [8A59477C29B4353FEAB85303C58B98F0]
@@ -13389,8 +15350,10 @@ GoodName=Rush 2 - Extreme Racing USA (U) [!]
 CRC=EDD6E031 68136013
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [7ED3F10BC32CF76F172D8C31D15A2799]
@@ -13398,8 +15361,10 @@ GoodName=S.C.A.R.S. (E) (M3) [!]
 CRC=918E2D60 F865683E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [0DC80ADCD95AF4FC8FE2C7E648CA64F0]
 GoodName=S.C.A.R.S. (E) (M3) [h1C]
@@ -13411,8 +15376,10 @@ GoodName=S.C.A.R.S. (U) [!]
 CRC=769147F3 2033C10E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [D0A050E86E27126FD7324B5674A30764]
 GoodName=S.C.A.R.S. (U) [f1] (PAL)
@@ -13429,8 +15396,10 @@ GoodName=SD Hiryuu no Ken Densetsu (J) [!]
 CRC=EBF5F6B7 C956D739
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F29A0A02C41815EE3F5437E409EC327B]
 GoodName=SD Hiryuu no Ken Densetsu (J) [f1] (PAL)
@@ -13528,7 +15497,10 @@ CRC=52BA5D2A 9BE3AB78
 GoodName=Saikyou Habu Shougi (J) [!]
 CRC=5E3E60E8 4AB5D495
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [D92EEBA87794311C8F4443C29CC177C5]
 GoodName=Saikyou Habu Shougi (J) [h1C]
@@ -13563,8 +15535,10 @@ GoodName=San Francisco Rush - Extreme Racing (E) (M3) [!]
 CRC=61D116B0 FA24D60C
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [4FDF9E702D4A6A75124623D9434BF99F]
 GoodName=San Francisco Rush - Extreme Racing (E) (M3) [h1C]
@@ -13576,8 +15550,10 @@ GoodName=San Francisco Rush - Extreme Racing (U) (M3) (V1.0) [!]
 CRC=2A6B1820 6ABCF466
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [2A8086945375826FA6495F1EF2F1DFB6]
 GoodName=San Francisco Rush - Extreme Racing (U) (M3) (V1.0) [b1]
@@ -13614,16 +15590,20 @@ GoodName=San Francisco Rush - Extreme Racing (U) (M3) (V1.1) [!]
 CRC=AC9F7DA7 A8C029D8
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [02B16AC23998F78F09AF6513F4ACB664]
 GoodName=San Francisco Rush 2049 (E) (M6) [!]
 CRC=51D29418 D5B46AE3
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [AF5BE0ADFF51A8E9C6D771282C295810]
@@ -13631,8 +15611,10 @@ GoodName=San Francisco Rush 2049 (U) [!]
 CRC=B9A9ECA2 17AAE48E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [1977D63B511A900628DB2A3A104160AC]
@@ -13645,29 +15627,40 @@ GoodName=Scooby-Doo! - Classic Creep Capers (E) [!]
 CRC=E3BD221D 3C0834D3
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [16CC6DB10A56331B56F374B4FB254D5E]
 GoodName=Scooby-Doo! - Classic Creep Capers (U) (V1.0) [!]
 CRC=0C814EC4 58FE5CA8
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [01CD9938DAE5DCDD4B264AE7F26C6D4D]
 GoodName=Scooby-Doo! - Classic Creep Capers (U) (V1.1) [!]
 CRC=569433AD F7E13561
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [FE2605193736A128AD65DB1C9835A130]
 GoodName=Shadow Man (B) [!]
 CRC=93A625B9 2D6022E6
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [A485A6E9E30B7D55D23D8DD043770C64]
@@ -13675,8 +15668,10 @@ GoodName=Shadow Man (E) (M3) [!]
 CRC=60C437E5 A2251EE3
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [235511BBDB21AF5A767BDB7502A80F06]
@@ -13684,8 +15679,10 @@ GoodName=Shadow Man (F) [!]
 CRC=EA06F8C3 07C2DEED
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [AF40EF12CE923FF1C26E76CC9D9B9ED9]
@@ -13693,8 +15690,10 @@ GoodName=Shadow Man (G) [!]
 CRC=84D5FD75 BBFD3CDF
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [CFBDC1C5E419FF162DF02A0065D9BC1D]
@@ -13717,8 +15716,10 @@ GoodName=Shadow Man (U) [!]
 CRC=3A4760B5 2D74D410
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [474647AEDFA95AEF73229A2784897EDD]
@@ -13746,21 +15747,30 @@ GoodName=Shadowgate 64 - Trials Of The Four Towers (E) (M2) (Ita-Spa) [!]
 CRC=02B46F55 61778D0B
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [11169A32D449EC3A8903CA8A9D69A6AA]
 GoodName=Shadowgate 64 - Trials Of The Four Towers (E) (M3) (Fre-Ger-Dut) [!]
 CRC=2BC1FCF2 7B9A0DF4
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [E8955C3B743FDDFE403E52E769E9853F]
 GoodName=Shadowgate 64 - Trials Of The Four Towers (E) [!]
 CRC=D84EEA84 45B2F1B4
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [5582CF3BB6E6B11D6D97F6FDD1EE9A3B]
 GoodName=Shadowgate 64 - Trials Of The Four Towers (E) [f1] (NTSC)
@@ -13782,14 +15792,20 @@ GoodName=Shadowgate 64 - Trials Of The Four Towers (J) [!]
 CRC=CCEDB696 D3883DB4
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [407A1A18BD7DBE0485329296C3F84EB8]
 GoodName=Shadowgate 64 - Trials Of The Four Towers (U) (M2) [!]
 CRC=036897CE E0D4FA54
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [3B21996F8C6496903C01DCBD77DDD6EE]
 GoodName=Shadowgate 64 - Trials Of The Four Towers (U) (M2) [f1] (PAL)
@@ -13809,7 +15825,10 @@ CRC=9D9C362D 5BE66B08
 GoodName=Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (J) [!]
 CRC=D137A2CA 62B65053
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [16EC788C8A4E7EEE268FDF9072A4F0D4]
@@ -13821,7 +15840,10 @@ RefMD5=13893DB9E919C4E7CF0C0B0064CCB554
 GoodName=Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [!]
 CRC=EF703CA4 4D4A9AC9
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [DC1A78608B19DBE2AE3DC0CAD9B79472]
 GoodName=Shin Nihon Pro Wrestling - Toukon Road - Brave Spirits (J) [b1]
@@ -13833,7 +15855,10 @@ GoodName=Shin Nihon Pro Wrestling - Toukon Road 2 - The Next Generation (J) [!]
 CRC=551C7F43 9149831C
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [37149C4064A1D120B9F4F5482A915262]
 GoodName=Shuffle Puck 64 (PD)
@@ -13843,7 +15868,10 @@ CRC=F7DF7D0D ED52018F
 GoodName=Sim City 2000 (J) [!]
 CRC=B1D5280C 4BA7BC2A
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [FD2D06E59BF17A1BD1DA98454F83AB0D]
 GoodName=Sim City 2000 (J) [b1]
@@ -13883,7 +15911,10 @@ CRC=909535F8 118FEF8F
 GoodName=Simon for N64 V0.1a by Jean-Luc Picard (POM '99) (PD)
 CRC=18531B7D 074AF73E
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 Status=1
 
 [F7F44996DD1140469C6C866DA0AFFAD7]
@@ -13916,8 +15947,10 @@ GoodName=Snobow Kids (J) [!]
 CRC=84FC04FF B1253CE9
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [A29129B8C044D8A825F7F3780153FCC7]
 GoodName=Snobow Kids (J) [h1C]
@@ -13934,8 +15967,10 @@ GoodName=Snow Speeder (J) [!]
 CRC=2EF4D519 C64A0C5E
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F0FE973338C7170D54CB41602B9D48A3]
 GoodName=Snow Speeder (J) [b1]
@@ -13947,8 +15982,10 @@ GoodName=Snowboard Kids (E) [!]
 CRC=5FD7CDA0 D9BB51AD
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [55D13DC1512B1A3656DB8130E59E31D2]
 GoodName=Snowboard Kids (E) [h1C]
@@ -13960,8 +15997,10 @@ GoodName=Snowboard Kids (U) [!]
 CRC=DBF4EA9D 333E82C0
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [FB1F9F093F6081E5695F688B9EFD4095]
 GoodName=Snowboard Kids (U) [b1]
@@ -13991,16 +16030,22 @@ RefMD5=EB31F4F9C1FE26A3A663F74E9790516E
 [47B5E3955D54F969941533F26691AB38]
 GoodName=Snowboard Kids 2 (E) [!]
 CRC=C2751D1A F8C19BFF
-SaveType=Eeprom 4KB
 Players=4
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [08E1152E9D9742E9BBF6C224B6958F2D]
 GoodName=Snowboard Kids 2 (U) [!]
 CRC=930C29EA 939245BF
 SaveType=Eeprom 4KB
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [22C7FCDBC74DE237E0FC7778D8A6E671]
 GoodName=Snowboard Kids 2 (U) [f1] (PAL)
@@ -14020,24 +16065,31 @@ CRC=AAA66229 98CA5CAA
 GoodName=Sonic Wings Assault (J) [!]
 CRC=22212351 4046594B
 Players=2
-Rumble=Yes
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [D313AF5F8AF4D19F732A1A2C4D4D66BB]
 GoodName=South Park (B) [!]
 CRC=D21AF769 DE1A0E3D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [40CC2085A5C12456BEF830B047068326]
 GoodName=South Park (E) (M3) [!]
 CRC=20B53662 7B61899F
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [26C99A528862342791193CA6AAACC9DD]
 GoodName=South Park (E) (M3) [b1]
@@ -14054,16 +16106,20 @@ GoodName=South Park (G) [!]
 CRC=91B66D42 16AC4E46
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1730119B0455EF89C4E495DEC8E950A5]
 GoodName=South Park (U) [!]
 CRC=7ECBE939 3C331795
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [BE22C6B95553B9CD5E0934B66BC36C84]
 GoodName=South Park (U) [b1]
@@ -14085,12 +16141,20 @@ GoodName=South Park - Chef's Luv Shack (E) [!]
 CRC=C00CA948 8E60D34B
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [6AF573EB055648A8542AA82D9524FB2F]
 GoodName=South Park - Chef's Luv Shack (U) [!]
 CRC=C00CA948 8E60D34B
 Players=4
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [FE2AA269FD3EC81C358845BBA6CA0167]
 GoodName=South Park - Chef's Luv Shack (U) [f1] (Country Check)
@@ -14102,16 +16166,20 @@ GoodName=South Park Rally (E) [!]
 CRC=4F8AFC3A F7912DF2
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1C494719032FF99382B167C43FB11762]
 GoodName=South Park Rally (U) [!]
 CRC=07F3B276 EC8F3D39
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [CD17388E175BCF0F621EE9313D5A1C8D]
 GoodName=South Park Rally (U) [f1] (PAL)
@@ -14133,6 +16201,10 @@ GoodName=Space Dynamites (J) [!]
 CRC=37463412 EAC5388D
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [19BA66FEE088181BBB0ACA6894BB8971]
 GoodName=Space Dynamites (J) [b1]
@@ -14144,8 +16216,10 @@ GoodName=Space Invaders (U) [!]
 CRC=EBFE2397 FF74DA34
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [63FA04C30C4A0FBE162BCDEC3CB42888]
 GoodName=Space Invaders (U) [f1] (PAL)
@@ -14167,7 +16241,10 @@ GoodName=Space Station Silicon Valley (E) (M7) [!]
 CRC=FC70E272 08FFE7AA
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [5919371BCA053C750D1CB357C58953A5]
 GoodName=Space Station Silicon Valley (E) (M7) [b1]
@@ -14179,14 +16256,20 @@ GoodName=Space Station Silicon Valley (J) [!]
 CRC=BFE23884 EF48EAAF
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [868B37D1B66D1D994E2BAD4E218BF129]
 GoodName=Space Station Silicon Valley (U) [!]
 CRC=BFE23884 EF48EAAF
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [4A8F8EBB93AF51878C8FB9057AD5F43C]
 GoodName=Space Station Silicon Valley (U) [f1] (PAL)
@@ -14203,7 +16286,10 @@ GoodName=Space Station Silicon Valley (U) (V1.1) [!]
 CRC=FC70E272 8FFE7AA
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [630E4122B0743A29C246DA2C257F92DA]
 GoodName=Spacer by Memir (POM '99) (PD)
@@ -14241,8 +16327,10 @@ GoodName=Spider-Man (U) [!]
 CRC=A60ED171 3D85D06E
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [8C5D52229DA5A223EA2DA093A5B9D31B]
 GoodName=Spider-Man (U) [t1]
@@ -14272,16 +16360,27 @@ RefMD5=515C86480A7FC1238BFE252BD2C53B36
 
 [B2242070800BF82E78CE33DC92A1DB84]
 GoodName=Star Fox 64 (Ch) (V5) (iQue) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [3DCD5E15AA35A73C68DB4F56E2670FA2]
 GoodName=Star Fox 64 (Ch) (V4) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [446D5215C4D34EB8AB0F355F324B8D0E]
 GoodName=Star Fox 64 (J) (V1.0) [!]
 CRC=FFCAA7C1 68858537
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [C4179723DC6E5D319C97F2F66AB05162]
 GoodName=Star Fox 64 (J) (V1.0) [f1]
@@ -14323,14 +16422,20 @@ GoodName=Star Fox 64 (J) (V1.1) (VC) [!]
 CRC=65AEDEEF 3857C728
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [CAF9A78DB13EE00002FF63A3C0C5EABB]
 GoodName=Star Fox 64 (U) (V1.0) [!]
 CRC=A7D015F8 2289AA43
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [5653B6DDAE328C870138E71EC30122A1]
 GoodName=Star Fox 64 (U) (V1.0) [f1]
@@ -14392,7 +16497,10 @@ GoodName=Star Fox 64 (U) (V1.1) [!]
 CRC=BA780BA0 0F21DB34
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [F0CD3B2DB0F20FFDD64BF081176EB421]
 GoodName=Star Fox 64 (U) (V1.1) [t1] (Energy)
@@ -14409,7 +16517,10 @@ GoodName=Star Soldier - Vanishing Earth (J) [!]
 CRC=B703EB23 28AAE53A
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [565DA8D53422F16207ECF11A81D2E649]
 GoodName=Star Soldier - Vanishing Earth (J) [b1]
@@ -14436,7 +16547,10 @@ GoodName=Star Soldier - Vanishing Earth (U) [!]
 CRC=DDD93C85 DAE381E8
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [A68B65E6B4BC976AD9DEAB335DE3BF70]
 GoodName=Star Soldier - Vanishing Earth (U) [t1]
@@ -14453,14 +16567,20 @@ GoodName=Star Twins (J) [!]
 CRC=F163A242 F2449B3B
 Players=4
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [7F919D2E35CBE561E139AE8FE93ACA86]
 GoodName=Star Wars - Rogue Squadron (E) (M3) (V1.0) [!]
 CRC=7EE0E8BB 49E411AA
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E1376F9B151EE3DA3E8ED52D970480EF]
 GoodName=Star Wars - Rogue Squadron (E) (M3) (V1.0) (Language Select Hack)
@@ -14475,14 +16595,22 @@ RefMD5=7F919D2E35CBE561E139AE8FE93ACA86
 [A9DD498E6A28F55311CE4EF057E164B8]
 GoodName=Star Wars - Rogue Squadron (E) (M3) (V1.1) [!]
 CRC=219191C1 33183C61
-RefMD5=7F919D2E35CBE561E139AE8FE93ACA86
+Players=1
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [47CAC4E2A6309458342F21A9018FFBF0]
 GoodName=Star Wars - Rogue Squadron (U) (M3) (V1.0) [!]
 CRC=66A24BEC 2EADD94F
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [0583AD9FDD1E3D10076AAB40E5B4E7BB]
 GoodName=Star Wars - Rogue Squadron (U) (M3) (V1.0) [b1]
@@ -14502,13 +16630,22 @@ RefMD5=47CAC4E2A6309458342F21A9018FFBF0
 [2E458D7CC355D7918493B0E0362C9A20]
 GoodName=Star Wars - Rogue Squadron (U) (M3) (V1.1) [!]
 CRC=C7F30CFA ECB0FA36
-RefMD5=47CAC4E2A6309458342F21A9018FFBF0
+Players=1
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [591CF8E672C9CC0FE9C871CC56DCC854]
 GoodName=Star Wars - Shadows of the Empire (E) [!]
 CRC=4D486681 AB7D9245
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [818737338B3F1D87B7E1B7FB55057BB5]
 GoodName=Star Wars - Shadows of the Empire (E) [b1]
@@ -14544,6 +16681,10 @@ GoodName=Star Wars - Shadows of the Empire (U) (V1.0) [!]
 CRC=264D7E5C 18874622
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [C88637DCC7A00FED6297B61E79CF75A9]
 GoodName=Star Wars - Shadows of the Empire (U) (V1.0) [b1]
@@ -14575,6 +16716,10 @@ GoodName=Star Wars - Shadows of the Empire (U) (V1.1) [!]
 CRC=4147B091 63251060
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [E8EE7D44858C1AB90C1F48A649DC98B6]
 GoodName=Star Wars - Shadows of the Empire (U) (V1.1) [b1]
@@ -14596,6 +16741,10 @@ GoodName=Star Wars - Shadows of the Empire (U) (V1.2) [!]
 CRC=4DD7ED54 74F9287D
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [3FE2B38E18152162A34E3002DEA071F7]
 GoodName=Star Wars - Shadows of the Empire (U) (V1.2) [b1]
@@ -14617,13 +16766,20 @@ GoodName=Star Wars - Shutsugeki! Rogue Chuutai (J) [!]
 CRC=827E4890 958468DC
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [5B6B6B0C8C9A40286DCF61706B6A05CB]
 GoodName=Star Wars - Teikoku no Kage (J) [!]
 CRC=FE24AC63 1B41AA17
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [B5FDFDF26E1F27EAF0BD849CAA4CC3B8]
 GoodName=Star Wars - Teikoku no Kage (J) [o1]
@@ -14640,7 +16796,10 @@ GoodName=Star Wars Episode I - Battle for Naboo (E) [!]
 CRC=EAE6ACE2 020B4384
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [3CB88B934572E7520F35E5458798775B]
@@ -14648,7 +16807,10 @@ GoodName=Star Wars Episode I - Battle for Naboo (U) [!]
 CRC=3D02989B D4A381E2
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [B4724120C269A1DC86991D34B1561F3D]
@@ -14666,7 +16828,10 @@ GoodName=Star Wars Episode I - Racer (E) (M3) [!]
 CRC=53ED2DC4 06258002
 Players=2
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [8CC7E31925FBFA13A584F529E8912207]
 GoodName=Star Wars Episode I - Racer (E) (M3) [f1] (Save)
@@ -14678,7 +16843,10 @@ GoodName=Star Wars Episode I - Racer (J) [!]
 CRC=61F5B152 046122AB
 Players=2
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [CFA21E43DAC50DFF3122ABF3AF3511F8]
 GoodName=Star Wars Episode I - Racer (J) [b1]
@@ -14690,7 +16858,10 @@ GoodName=Star Wars Episode I - Racer (U) [!]
 CRC=72F70398 6556A98B
 Players=2
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E4353B43CB4302B7A308A42D6BB04435]
 GoodName=Star Wars Episode I - Racer (U) [f1] (Save)
@@ -14723,7 +16894,10 @@ CRC=BC9B2CC3 4ED04DA5
 Status=1
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [432DF5EAC0BA573C6587A5BB4E51834A]
 GoodName=StarCraft 64 (Beta) [f1]
@@ -14746,7 +16920,10 @@ CRC=42CF5EA3 9A1334DF
 Status=1
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [B75945407D7DEA00A2A29AD24056A416]
 GoodName=StarCraft 64 (E) [b1]
@@ -14768,13 +16945,20 @@ CRC=0684FBFB 5D3EA8A5
 Status=1
 Players=2
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [A9C393AA232B32798ADF378F4318F99F]
 GoodName=Starshot - Space Circus Fever (E) (M3) [!]
 CRC=D89E0E55 B17AA99A
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [B23BFC7DC874DDAA2005F9AFF59A47FF]
 GoodName=Starshot - Space Circus Fever (E) (M3) [f1] (NTSC100%)
@@ -14801,6 +16985,10 @@ GoodName=Starshot - Space Circus Fever (U) (M3) [!]
 CRC=94EDA5B8 8673E903
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [BD22A79568534B42EAA3D8DB9A7C4C91]
 GoodName=Starshot - Space Circus Fever (U) (M3) [b1]
@@ -14812,8 +17000,10 @@ GoodName=Stunt Racer 64 (U) [!]
 CRC=9510D8D7 35100DD2
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [14DDF19382385774F253049ABEAF01D2]
 GoodName=Summer64 Demo by Lem (PD) [b1]
@@ -14827,7 +17017,9 @@ CRC=4794B85F 3EBD5B68
 GoodName=Super B-Daman - Battle Phoenix 64 (J) [!]
 CRC=F4646B69 C5751095
 Players=4
+Biopak=No
 Mempak=Yes
+Rumble=No
 Transferpak=Yes
 
 [4168C145279EA29912BA0E35DCA35289]
@@ -14841,16 +17033,20 @@ GoodName=Super Bowling (J) [!]
 CRC=F3F2F385 6E490C7F
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [FA3A043997A3ACDF17337385B126BC04]
 GoodName=Super Bowling (U) [!]
 CRC=AA1D215A 91CBBE9A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [7FCF424B960F4E429FD683A4B19B3356]
 GoodName=Super Fighter Demo Halley's Comet Software (PD)
@@ -14863,9 +17059,17 @@ CRC=635A42C5 BDC58EDC
 [29047FBA820695BD14C5BD7AA1AA4400]
 GoodName=Super Mario 64 (Ch) (iQue) [!]
 Players=1
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [B4BD31B13E474DF29922150E1EF3F328]
 GoodName=Super Mario 64 (Ch) (V6) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [45676429EF6B90E65B517129B700308E]
 GoodName=Super Mario 64 (E) (M3) [!]
@@ -14873,6 +17077,10 @@ CRC=A03CF036 BCC1C5D2
 Players=1
 Status=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [9EE432F07F1E4E9A13CD0090CCC5A94B]
 GoodName=Super Mario 64 (E) (M3) [b1]
@@ -14915,6 +17123,10 @@ CRC=4EAA3D0E 74757C24
 Players=1
 Status=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [DBF7F4D881E1DF604C41367B04233E74]
 GoodName=Super Mario 64 (J) [h1C]
@@ -14927,6 +17139,10 @@ CRC=635A2BFF 8B022326
 Players=1
 Status=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [E458F74E694B2916EBA9818103F7CF13]
 GoodName=Super Mario 64 (U) (Enable Hidden Scroller Hack)
@@ -15014,12 +17230,15 @@ CRC=635A42C5 BDC58EDC
 RefMD5=20B854B239203BAF6C961B850A4A51A2
 
 [2D727C3278AA232D94F2FB45AEC4D303]
-GoodName=Super Mario 64 - Shindou Edition (J) [!]
+GoodName=Super Mario 64 - Shindou Edition (J) (V1.1) [!]
 CRC=D6FBA4A8 6326AA2C
 Players=1
 Status=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [23033085561CD331CC81F0026FCB2CE2]
 GoodName=Super Mario 64 - Shindou Edition (J) [b1]
@@ -15046,7 +17265,10 @@ GoodName=Super Robot Spirits (J) [!]
 CRC=66572080 28E348E1
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [E92FC6AE193092F6B597E05946B558EB]
 GoodName=Super Robot Spirits (J) [b1]
@@ -15058,7 +17280,9 @@ GoodName=Super Robot Taisen 64 (J) [!]
 CRC=1649D810 F73AD6D2
 Players=1
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
+Rumble=No
 Transferpak=Yes
 
 [462A2AF0E3B72DA4A0E9266078EE5717]
@@ -15082,7 +17306,10 @@ CRC=DD26FDA1 CB4A6BE3
 Status=3
 SaveType=SRAM
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [7F18A06BB16A507E23F9DD636B7046A6]
@@ -15093,9 +17320,17 @@ RefMD5=694DEA68DBF1C3F06FF0476ACF2169E6
 [7B815846EC91E6C4A8B8BAA0CE4078F0]
 GoodName=Super Smash Bros. (Ch) (iQue) [!]
 Players=4
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [3ABC2D34AD3CE623F4ED8F126D30CC80]
 GoodName=Super Smash Bros. (Ch) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [5E54C6C563B09C107F86FB33E914EF81]
 GoodName=Super Smash Bros. (E) (M3) [!]
@@ -15103,7 +17338,10 @@ CRC=93945F48 5C0F2E30
 Status=3
 SaveType=SRAM
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [4D37726FDFEC039CB36E2AAE65B9727D]
@@ -15122,7 +17360,10 @@ CRC=916B8B5B 780B85A4
 Status=3
 SaveType=SRAM
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [508BE860974B75470851A2D25C0FCB36]
@@ -15165,8 +17406,10 @@ GoodName=Super Speed Race 64 (J) [!]
 CRC=9CE02E22 206EF1B0
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [27A7A2A19FC67346BB25E3C5BB3A91CE]
 GoodName=Super Speed Race 64 (J) [o1]
@@ -15198,16 +17441,20 @@ GoodName=Supercross 2000 (E) (M3) [!]
 CRC=2CBB127F 09C2BFD8
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [60347200A1A7CABC0D849EE69EC51DF7]
 GoodName=Supercross 2000 (U) [!]
 CRC=C1452553 5D7B24D9
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [53922802F7744CC38BDD75852214057F]
 GoodName=Supercross 2000 (U) [b1]
@@ -15224,16 +17471,20 @@ GoodName=Superman (E) (M6) [!]
 CRC=B44CAB74 07029A29
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [3F64B4F72E61225EF3AE93976C9BFC7C]
 GoodName=Superman (U) (M3) [!]
 CRC=A2E8F35B C9DC87D9
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1170033980ADC1981505CF958F35F1EB]
 GoodName=Superman (U) (M3) (Beta) [!]
@@ -15274,8 +17525,10 @@ RefMD5=3F64B4F72E61225EF3AE93976C9BFC7C
 GoodName=Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [!]
 CRC=35E811F3 99792724
 Players=2
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [59985249F824F74C335C6C47A6E29C4A]
 GoodName=Susume! Taisen Puzzle Dama Toukon! Marumata Chou (J) [b1]
@@ -15338,8 +17591,10 @@ GoodName=TG Rally 2 (E) [!]
 CRC=F82DD377 8C3FB347
 Players=4
 SaveType=None
-Rumble=Yes
+Biopak=No
 Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [65E67D43E0A9B146D7881CBC803EC5C3]
 GoodName=TR64 Demo by FIres and Icepir8 (PD)
@@ -15385,8 +17640,10 @@ CRC=6C2C6C49 9BE5CA66
 GoodName=Telefoot Soccer 2000 (F) [!]
 CRC=D9042FBB FCFF997C
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [8F96FF06D9B3C3219CEBA5CDB7CF19ED]
 GoodName=Telefoot Soccer 2000 (F) [b1]
@@ -15403,6 +17660,9 @@ GoodName=Tetris 64 (J) [!]
 CRC=963ADBA6 F7D5C89B
 Players=4
 Biopak=Yes
+Mempak=No
+Rumble=No
+Transferpak=No
 SiDmaDuration=100
 
 [1587B17344A43532B791DCEB237D2BFC]
@@ -15433,6 +17693,10 @@ GoodName=Tetrisphere (E) [!]
 CRC=0FE684A9 8BB77AC4
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A87455244919BDA6E44FA32C7E72BFBA]
 GoodName=Tetrisphere (E) [b1]
@@ -15449,6 +17713,10 @@ GoodName=Tetrisphere (U) [!]
 CRC=3C1FDABE 02A4E0BA
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [7211951FDF7DA809D5F3D51CA06CD465]
 GoodName=Tetrisphere (U) [b1]
@@ -15501,6 +17769,10 @@ GoodName=Tigger's Honey Hunt (E) (M7) [!]
 CRC=E0C4F72F 769E1506
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [F8636514B5B0EDEBF376C3111D24417A]
@@ -15508,6 +17780,10 @@ GoodName=Tigger's Honey Hunt (U) [!]
 CRC=4EBFDD33 664C9D84
 Players=1
 SaveType=Flash RAM
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [7B41F28A920112F17401D633B368BA0C]
@@ -15520,15 +17796,20 @@ GoodName=Tokisora Senshi Turok (J) [!]
 CRC=916AE6B8 8817AB22
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [1B991CF41C70FF2C92FFBEFACABE8D03]
 GoodName=Tom Clancy's Rainbow Six (E) [!]
 CRC=4875AF3D 9A66D3A2
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [FC2D2F7EF02484EA0478A5EAFD0CBFF0]
 GoodName=Tom Clancy's Rainbow Six (E) [b1]
@@ -15550,24 +17831,30 @@ GoodName=Tom Clancy's Rainbow Six (F) [!]
 CRC=486BF335 034DCC81
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [FDC76A53B1056D3E50EA6A3E295FE4D1]
 GoodName=Tom Clancy's Rainbow Six (G) [!]
 CRC=8D412933 588F64DB
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [80F3B1ABD9FB9AE73997489DB185A74D]
 GoodName=Tom Clancy's Rainbow Six (U) [!]
 CRC=392A0C42 B790E77D
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [2CF9568A149177AC0B86378FBC8DCB71]
 GoodName=Tom Clancy's Rainbow Six (U) [f1] (PAL)
@@ -15582,8 +17869,11 @@ CRC=5ECE09AE 8230C82D
 GoodName=Tom and Jerry in Fists of Furry (E) (M6) [!]
 CRC=2B4F4EFB 43C511FE
 Players=2
-Rumble=Yes
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [9EAA60F295DBA9A9687E3238DABA14EE]
 GoodName=Tom and Jerry in Fists of Furry (E) (M6) [f1] (NTSC)
@@ -15594,8 +17884,11 @@ RefMD5=46BE5D00682FCC1F7FC0FBA507E8E5C1
 GoodName=Tom and Jerry in Fists of Furry (U) [!]
 CRC=63E7391C E6CCEA33
 Players=2
-Rumble=Yes
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [17D6D6DA5D03C9D295D72A212A719EB2]
 GoodName=Tom and Jerry in Fists of Furry (U) [t1]
@@ -15611,14 +17904,20 @@ GoodName=Tonic Trouble (E) (M5) [!]
 CRC=093F916E 4408B698
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [7D3E935156844DE0002DB875E1076A5C]
 GoodName=Tonic Trouble (U) (V1.1) [!]
 CRC=EF9E9714 C03B2C7D
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [A6C5625FF127D9E741F595EBF3B3ABB9]
 GoodName=Tonic Trouble (U) (V1.1) [b1]
@@ -15640,16 +17939,20 @@ GoodName=Tony Hawk's Pro Skater (E) [!]
 CRC=9F8926A5 0587B409
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5ED7E392198A5FA56EE37EA9E93A8D50]
 GoodName=Tony Hawk's Pro Skater (U) (V1.0) [!]
 CRC=204EC022 B119D185
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [30EC0EEA5C487E5609D9F9F356D21F27]
 GoodName=Tony Hawk's Pro Skater (U) (V1.0) [t1]
@@ -15661,32 +17964,40 @@ GoodName=Tony Hawk's Pro Skater (U) (V1.1) [!]
 CRC=E0144180 650B78C9
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6BE030475C4DB52F273EF8A02B4DAFA8]
 GoodName=Tony Hawk's Pro Skater 2 (E) [!]
 CRC=84EAB557 C88A190F
 Players=2
 SaveType=None
-Rumble=Yes
+Biopak=No
 Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [29974692808C112B306FBD259273DC96]
 GoodName=Tony Hawk's Pro Skater 2 (U) [!]
 CRC=99150E18 1266E6A5
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9D4891BF26881C4541171B0235015FD4]
 GoodName=Tony Hawk's Pro Skater 3 (U)
 CRC=1A7F70B5 00B7B9FD
 Players=2
 SaveType=None
-Rumble=Yes
+Biopak=No
 Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [B6FD2A048D1F4F324CEBC97BA09872BB]
 GoodName=Toon Panic (J) (Prototype)
@@ -15697,8 +18008,10 @@ GoodName=Top Gear Hyper Bike (Beta)
 CRC=75FBDE20 A3189B31
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [0072538EF925645DB310F8E23A480B89]
@@ -15706,8 +18019,10 @@ GoodName=Top Gear Hyper Bike (E) [!]
 CRC=5F3F49C6 0DC714B0
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [561B438F6E8240BEF1DAEB36AAE72675]
@@ -15720,8 +18035,10 @@ GoodName=Top Gear Hyper Bike (J) [!]
 CRC=845B0269 57DE9502
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [7258F4AB367B025C95A4F476C461E717]
@@ -15729,8 +18046,10 @@ GoodName=Top Gear Hyper Bike (U) [!]
 CRC=8ECC02F0 7F8BDE81
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [6C65A252F227AEF18DF2DD3CE04CC821]
@@ -15738,7 +18057,10 @@ GoodName=Top Gear Overdrive (E) [!]
 CRC=D09BA538 1C1A5489
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [11D6FFF288DE1BD61CCBD7CCA0C4A97B]
@@ -15751,7 +18073,10 @@ GoodName=Top Gear Overdrive (J) [!]
 CRC=0578F24F 9175BF17
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [8C0F46FEF9A6034FCF0B7D6952FFEC53]
@@ -15764,7 +18089,10 @@ GoodName=Top Gear Overdrive (U) [!]
 CRC=D741CD80 ACA9B912
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [773FD446DA7F4E392907505053BF2A42]
@@ -15782,16 +18110,20 @@ GoodName=Top Gear Rally (As) [!]
 CRC=1A4D3AD8 59AF7FA9
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1698508F521280D0A80E078EC981D4AC]
 GoodName=Top Gear Rally (E) [!]
 CRC=7F43E701 536328D1
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [48D6C194AE106018DDFC3486A8B347F7]
 GoodName=Top Gear Rally (E) [b1]
@@ -15808,16 +18140,20 @@ GoodName=Top Gear Rally (J) [!]
 CRC=0E596247 753D4B8B
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6F7030284B6BC84A49E07DA864526B52]
 GoodName=Top Gear Rally (U) [!]
 CRC=62269B3D FE11B1E8
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [FA88969ECFA72358EF1C045035442F5C]
 GoodName=Top Gear Rally (U) [b1]
@@ -15844,32 +18180,40 @@ GoodName=Top Gear Rally 2 (Beta)
 CRC=EFDF9140 A4168D6B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [44C4566572DC0662D4299AB5B19043AE]
 GoodName=Top Gear Rally 2 (E) [!]
 CRC=BEBAB677 51B0B5E4
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [B10D781EC625CA45713FD34E5096C24A]
 GoodName=Top Gear Rally 2 (J) [!]
 CRC=CFEF2CD6 C9E973E6
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1FA409FCAC007DDECCC4CF439A0D8DAE]
 GoodName=Top Gear Rally 2 (U) [!]
 CRC=BE5973E0 89B0EDB8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [4648C4F656BD4A74647DF6A7A2985F37]
 GoodName=Top Gear Rally 2 (U) [f1] (PAL)
@@ -15890,8 +18234,10 @@ GoodName=Toy Story 2 - Buzz Lightyear to the Rescue! (E) [!]
 CRC=CCEB3858 26952D97
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [FA0F12C15B3655F9F56888C3249B1CED]
@@ -15899,8 +18245,10 @@ GoodName=Toy Story 2 - Buzz L'eclair A La Rescousse! (F) [!]
 CRC=CB93DB97 7F5C63D5
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [3F40F37B0464DD065067523FB21016DD]
@@ -15908,8 +18256,10 @@ GoodName=Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (G) (V1.0) [!
 CRC=782A9075 E552631D
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [A4A2B825797E2059B5DF60D733461F34]
@@ -15917,8 +18267,10 @@ GoodName=Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (G) (V1.1) [!
 CRC=BC4F2AB8 AA99E32E
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [B44E9C2D9D2F2DE3AF4793B824CCF936]
@@ -15926,8 +18278,10 @@ GoodName=Toy Story 2 - Buzz Lightyear to the Rescue! (U) [!]
 CRC=A150743E CF2522CD
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [9E4F62BD672E3601F1BBF9CDAB791F9F]
@@ -15945,8 +18299,10 @@ GoodName=Toy Story 2 - Buzz Lightyear to the Rescue! (U) (V1.1) [!]
 CRC=C151AD61 280FFF22
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [3D22D5BD7997293612ECDD3046BEBA13]
@@ -15954,6 +18310,8 @@ GoodName=Transformers - Beast Wars Metals 64 (J) [!]
 CRC=91691C3D F4AC5B4D
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
 Transferpak=Yes
 
@@ -15962,15 +18320,20 @@ GoodName=Transformers - Beast Wars Transmetal (U) [!]
 CRC=4D79D316 E8501B33
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [6F2C37A20E6ECCB657FBFC4BA36A34BB]
 GoodName=Triple Play 2000 (U) [!]
 CRC=FE4B6B43 081D29A7
 Players=2
 SaveType=None
-Rumble=Yes
+Biopak=No
 Mempak=Yes
+Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [25E03763FC8A388A33871C58DFEB7C0E]
@@ -15980,15 +18343,26 @@ CRC=F4D89C08 3F34930D
 [5BA3AA2953C47C8B2E615B21E60F2F17]
 GoodName=Tsumi to Batsu - Hoshi no Keishousha (Ch) (iQue) [!]
 Players=2
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [9ABB0F6F79E01FC9A942D6027719C3E4]
 GoodName=Tsumi to Batsu - Hoshi no Keishousha (Ch) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A0657BC99E169153FD46AECCFDE748F3]
 GoodName=Tsumi to Batsu - Hoshi no Keishousha (J) [!]
 CRC=B6BC0FB0 E3812198
 Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [6E51B140A9B0C30D6F55CA7942A969FC]
 GoodName=Tsumi to Batsu - Hoshi no Keishousha (J) [T+Eng1.0_Zoinkity]
@@ -16000,7 +18374,10 @@ GoodName=Turok - Dinosaur Hunter (E) (V1.0) [!]
 CRC=2F7009DD FC3BAC53
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [6D5147A9CD7DDD0F1FA8B8BDA439A734]
 GoodName=Turok - Dinosaur Hunter (E) (V1.0) [b1]
@@ -16017,42 +18394,60 @@ GoodName=Turok - Dinosaur Hunter (E) (V1.1) [!]
 CRC=2F700DCD 176CC5C9
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [548FC0E6035B65BC2108255039859934]
 GoodName=Turok - Dinosaur Hunter (E) (V1.2) [!]
 CRC=2F700DCD 176CC5C9
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [0C0BFD1038EDA4F5C958DC362CDFF2D6]
 GoodName=Turok - Dinosaur Hunter (G) (V1.0) [!]
 CRC=665FD963 B5CC6612
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [388440013641887D85B791CF01729FA8]
 GoodName=Turok - Dinosaur Hunter (G) (V1.1) [!]
 CRC=665FC793 6934A73B
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [F0F687B449A9F4B0BFF08104C35EA08C]
 GoodName=Turok - Dinosaur Hunter (G) (V1.2) [!]
 CRC=665FC793 6934A73B
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [AE5107EFDD3C210E1EDD4ACD9B3CAC31]
 GoodName=Turok - Dinosaur Hunter (U) (V1.0) [!]
 CRC=2F70F10D 5C4187FF
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [E5B207E7C8DBD8BAF9B42C96EF3C42E8]
 GoodName=Turok - Dinosaur Hunter (U) (V1.0) [b1]
@@ -16084,46 +18479,60 @@ GoodName=Turok - Dinosaur Hunter (U) (V1.1) [!]
 CRC=2F700DCD 176CC5C9
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [039875B92C0E4FEF9797EC1744877B17]
 GoodName=Turok - Dinosaur Hunter (U) (V1.2) [!]
 CRC=2F700DCD 176CC5C9
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [72A6AA28608EE93A1CB6FEB0A5F4C28C]
 GoodName=Turok - Legenden des Verlorenen Landes (G) [!]
 CRC=66E4FA0F DE88C7D0
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [241CF94BED487FFF62FFB7B846DA46AB]
 GoodName=Turok - Rage Wars (E) (M3) (Eng-Fre-Ita) [!]
 CRC=B6BE20A5 FACAF66D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [DBA166A42710F40DC78DC52EB37B0BE6]
 GoodName=Turok - Rage Wars (E) [!]
 CRC=1EA26214 E790900F
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [CF5B28578FD62FA1FF8690079F5D68F5]
 GoodName=Turok - Rage Wars (U) (V1.0) [!]
 CRC=ADB9498B DAF28F55
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [07E123E104BA7B335B53932EDB2CFB2F]
 GoodName=Turok - Rage Wars (U) (V1.0) [f1] (PAL)
@@ -16140,32 +18549,40 @@ GoodName=Turok - Rage Wars (U) (V1.1) [!]
 CRC=2388984C DA7B3CC5
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [CE72237707F481CFE97FDE330C2AFCD6]
 GoodName=Turok 2 - Seeds of Evil (E) (Kiosk Demo) [!]
 CRC=E8C95AFC 35D121DA
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [144B10A484A22367FD2679529DBD2FED]
 GoodName=Turok 2 - Seeds of Evil (E) (M4) [!]
 CRC=2E0E7749 B8B49D59
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [E5A39521FA954EB97B96AC2154A5FD7A]
 GoodName=Turok 2 - Seeds of Evil (E) [!]
 CRC=E0B92B94 80E87CBD
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AC1C00167B95929F8EE40DFACB49BB57]
 GoodName=Turok 2 - Seeds of Evil (E) [b1]
@@ -16177,16 +18594,20 @@ GoodName=Turok 2 - Seeds of Evil (G) [!]
 CRC=FE05840B 9393320C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [3BD42F6AEC477C056E1AFEBB3515495C]
 GoodName=Turok 2 - Seeds of Evil (U) (Kiosk Demo) [!]
 CRC=E8C95AFC 35D121DA
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [4250FF0265AD72FC798E6ABA61CFCD0E]
 GoodName=Turok 2 - Seeds of Evil (U) (Kiosk Demo) (Gore On Hack)
@@ -16203,16 +18624,20 @@ GoodName=Turok 2 - Seeds of Evil (U) (V1.1) [!]
 CRC=E0B92B94 B9A7E025
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [FAD4DA8E17CE12F68CDF29180CDD4A90]
 GoodName=Turok 2 - Seeds of Evil (U) (V1.0) [!]
 CRC=49088A11 6494957E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [8DC201A0A9CFD1D2C85EE2B42D8AC49A]
 GoodName=Turok 2 - Seeds of Evil (U) (V1.0) [t1]
@@ -16234,8 +18659,10 @@ GoodName=Turok 3 - Shadow of Oblivion (E) [!]
 CRC=6A162FF2 2093704C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [03D17AA3DC7663502017D3CC5A19AA8B]
 GoodName=Turok 3 - Shadow of Oblivion (E) (Beta) (2000-05-31)
@@ -16262,8 +18689,10 @@ GoodName=Turok 3 - Shadow of Oblivion (U) [!]
 CRC=89A579F1 667E97EF
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [8A5F9B3308107C253EC5DCA198F55C83]
 GoodName=Turok 3 - Shadow of Oblivion (U) [t1]
@@ -16279,8 +18708,10 @@ GoodName=Twisted Edge Extreme Snowboarding (E) [!]
 CRC=E688A5B8 B14B3F18
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [4F0E2AF205BEEB49270154810660FF37]
 GoodName=Twisted Edge Extreme Snowboarding (E) [b1]
@@ -16297,8 +18728,10 @@ GoodName=Twisted Edge Extreme Snowboarding (U) [!]
 CRC=BBC99D32 117DAA80
 Players=2
 SaveType=None
-Rumble=Yes
+Biopak=No
 Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [0B0DF8EC747BF99F3A55A3300CE8BC0D]
 GoodName=U64 (Chrome) Demo by Horizon64 (PD) [a1]
@@ -16328,7 +18761,10 @@ CRC=95013CCC 73F7C072
 GoodName=Uchhannanchan no Hono no Challenger - Denryu IraIra Bou (J) [!]
 CRC=28D5562D E4D5AE50
 Players=2
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [07B7A5CFDE9BC43F02A622387C5B5C58]
@@ -16403,7 +18839,10 @@ GoodName=V-Rally Edition 99 (E) (M3) [!]
 CRC=636E6B19 E57DDC5F
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [7DCEAFF24BB1BB3D9B8FE9B78CCC7048]
 GoodName=V-Rally Edition 99 (E) (M3) [f1] (NTSC)
@@ -16415,14 +18854,20 @@ GoodName=V-Rally Edition 99 (J) [!]
 CRC=4D0224A5 1BEB5794
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [0C3448A9D85300ACB9C5556F27A84B23]
 GoodName=V-Rally Edition 99 (U) [!]
 CRC=3C059038 C8BF2182
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [9768A9874D8329569F8FB27EC0AB723B]
 GoodName=V-Rally Edition 99 (U) [f1] (PAL)
@@ -16494,8 +18939,10 @@ GoodName=Vigilante 8 (E) [!]
 CRC=151F79F4 8EEDC8E5
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [637B9A40BED777FC96EB1BD07EA74783]
 GoodName=Vigilante 8 (E) [h1C]
@@ -16507,8 +18954,10 @@ GoodName=Vigilante 8 (F) [!]
 CRC=E2BC82A2 591CD694
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [B69B84083D1B4EC99A465B3067F74417]
 GoodName=Vigilante 8 (F) [b1]
@@ -16520,16 +18969,20 @@ GoodName=Vigilante 8 (G) [!]
 CRC=6EDA5178 D396FEC1
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [D616ADF6441ACBBD0E6BEF023A8F6031]
 GoodName=Vigilante 8 (U) [!]
 CRC=EA71056A E4214847
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9F42209E413A1A92C788BF7BC26BFB7B]
 GoodName=Vigilante 8 (U) [b1]
@@ -16561,16 +19014,20 @@ GoodName=Vigilante 8 - 2nd Offence (E) [!]
 CRC=DD10BC7E F900B351
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [60CDF7445FAD2ABA05C958F46691501B]
 GoodName=Vigilante 8 - 2nd Offense (U) [!]
 CRC=F5C5866D 052713D9
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5E30D0208FC4CB810A464E5DEFFB29A3]
 GoodName=Vigilante 8 - 2nd Offense (U) [f1] (PAL)
@@ -16582,8 +19039,10 @@ GoodName=Violence Killer - Turok New Generation (J) [!]
 CRC=60006C98 2605A381
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [50272F8EA99E4E06ADD8CCAB5F5A4F41]
 GoodName=Violence Killer - Turok New Generation (J) [b1]
@@ -16595,7 +19054,10 @@ GoodName=Virtual Chess 64 (E) (M6) [!]
 CRC=2FDAA221 A588A7CE
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [4166D03402397A56043AC2CD45F4CB87]
 GoodName=Virtual Chess 64 (E) (M6) [b1]
@@ -16622,7 +19084,10 @@ GoodName=Virtual Chess 64 (U) (M3) [!]
 CRC=82B3248B E73E244D
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [F05BD2DAD01F3E354713380AAFFB63E9]
 GoodName=Virtual Chess 64 (U) (M3) [b1]
@@ -16654,7 +19119,10 @@ GoodName=Virtual Pool 64 (E) [!]
 CRC=98F9F2D0 03D9F09C
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [C4FD61C707977F1BF48DC15E31BD2FB1]
@@ -16667,7 +19135,10 @@ GoodName=Virtual Pool 64 (U) [!]
 CRC=4E4A7643 A37439D7
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [C6855DF00BD5BE8A41DCE809093EE40B]
@@ -16680,16 +19151,20 @@ GoodName=Virtual Pro Wrestling 2 - Oudou Keishou (J) [!]
 CRC=CD094235 88074B62
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5E6202200AF40A8F026780EDFE1E15D0]
 GoodName=Virtual Pro Wrestling 64 (J) [!]
 CRC=045C08C4 4AFD798B
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [7FDC16C96B517D4E433CF7353B22FBA6]
 GoodName=Virtual Pro Wrestling 64 (J) [b1]
@@ -16725,16 +19200,20 @@ GoodName=WCW Backstage Assault (U) [!]
 CRC=396F5ADD 6693ECA7
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [9E943752BCF4FBA9CA3028E596F4EB4A]
 GoodName=WCW Mayhem (E) [!]
 CRC=AA7B0658 9C96937B
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [F1AF35375519E97BB7C0E37E2F68416E]
 GoodName=WCW Mayhem (E) [h1C]
@@ -16746,8 +19225,10 @@ GoodName=WCW Mayhem (U) [!]
 CRC=33BE8CD6 EC186912
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5D7368D95B89F451E68F0832ED2BA8FF]
 GoodName=WCW Mayhem (U) [f1] (PAL)
@@ -16759,8 +19240,10 @@ GoodName=WCW Nitro (U) [!]
 CRC=D4C45A1A F425B25E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=3
 
 [EC097EB33BAD93A8AC6E15F7839762AB]
@@ -16793,16 +19276,20 @@ GoodName=WCW vs. nWo - World Tour (E) [!]
 CRC=8BDBAF68 345B4B36
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [203C3BBFDD10C5A0B7C5D0CDB085D853]
 GoodName=WCW vs. nWo - World Tour (U) (V1.0) [!]
 CRC=2C3E19BD 5113EE5E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6BD5C85E25BF3146A42F962A379B4F54]
 GoodName=WCW vs. nWo - World Tour (U) (V1.0) [b1]
@@ -16814,15 +19301,20 @@ GoodName=WCW vs. nWo - World Tour (U) (V1.1) [!]
 CRC=71BE60B9 1DDBFB3C
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [30C6676EC1D62122F4E7607EF3ABBD41]
 GoodName=WCW-nWo Revenge (E) [!]
 CRC=68E8A875 0CE7A486
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [07F0AD841350BD7CA1E6A99FB7E887E6]
@@ -16835,7 +19327,10 @@ GoodName=WCW-nWo Revenge (U) [!]
 CRC=DEE596AB AF3B7AE7
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [B230D307428F4B69B3A80109AC905A44]
@@ -16863,32 +19358,40 @@ GoodName=WWF - War Zone (E) [!]
 CRC=33A275A4 B8504459
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [2322DA2B9E7DC74678CD683B7A246B49]
 GoodName=WWF - War Zone (U) [!]
 CRC=CD5BEC0F 86FD1008
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [3FDB2E5F9982FDA2C2344A883B8AB6EF]
 GoodName=WWF Attitude (E) [!]
 CRC=5BF45B7B 596BEEE8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [B86EC8D19D7D1A50EA900EA10355A735]
 GoodName=WWF Attitude (G) [!]
 CRC=8F3151C8 4F3AF545
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [5AC5CEDBD22CEEA8DD50CF6084193357]
 GoodName=WWF Attitude (G) [b1]
@@ -16900,8 +19403,10 @@ GoodName=WWF Attitude (U) [!]
 CRC=D2BE2F14 38453788
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [6D4CBA7FB2E910CA1A87E63A4C1924C2]
 GoodName=WWF Attitude (U) [b1]
@@ -16923,8 +19428,10 @@ GoodName=WWF No Mercy (E) (V1.0) [!]
 CRC=6D8DF08E D008C3CF
 SaveType=Flash RAM
 Players=4
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [473FDDBB121255A171A40C14130D0165]
 GoodName=WWF No Mercy (E) (V1.0) [b1]
@@ -16941,16 +19448,20 @@ GoodName=WWF No Mercy (E) (V1.1) [!]
 CRC=8CDB94C2 CB46C6F0
 Players=4
 SaveType=Flash RAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [04C492BE7F89FC6F425238BD67629544]
 GoodName=WWF No Mercy (U) (V1.0) [!]
 CRC=4E4B0640 1B49BCFB
 Players=4
 SaveType=Flash RAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [51074CFE7A319270CF088A7C65387368]
 GoodName=WWF No Mercy (U) (V1.0) [t1]
@@ -16960,15 +19471,22 @@ RefMD5=04C492BE7F89FC6F425238BD67629544
 [66B8EC24557A50514A814F15429BD559]
 GoodName=WWF No Mercy (U) (V1.1) [!]
 CRC=6C80F13B 427EDEAA
-RefMD5=04C492BE7F89FC6F425238BD67629544
+Players=4
+SaveType=Flash RAM
+Biopak=No
+Mempak=Yes
+Rumble=Yes
+Transferpak=No
 
 [B75149F87CC5F3A508643AC377F2FCC9]
 GoodName=WWF WrestleMania 2000 (E) [!]
 CRC=C71353BE AA09A6EE
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [EBB9E3D3782347743BFFB8B6D178FC8A]
 GoodName=WWF WrestleMania 2000 (E) [h1C]
@@ -16980,8 +19498,10 @@ GoodName=WWF WrestleMania 2000 (J) [!]
 CRC=12737DA5 23969159
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AFC5EEDD3FCEEF85458E9C8FA162B303]
 GoodName=WWF WrestleMania 2000 (J) [b1]
@@ -16993,8 +19513,10 @@ GoodName=WWF WrestleMania 2000 (U) [!]
 CRC=90A59003 31089864
 Players=4
 SaveType=SRAM
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [CB174FA89F352DD8451A43FEF2B8D1AA]
 GoodName=WWF WrestleMania 2000 (U) [b1]
@@ -17011,7 +19533,10 @@ GoodName=Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [!]
 CRC=93053075 261E0F43
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [1FC540D2168650E135BCC7D3B542E03A]
 GoodName=Waialae Country Club - True Golf Classics (E) (M4) (V1.0) [b1]
@@ -17021,25 +19546,42 @@ RefMD5=5F1906DF4EB30537C2AC2FCBD005907D
 [F7C1B1EE1CE37CE09AA48C7E0A115EFA]
 GoodName=Waialae Country Club - True Golf Classics (E) (M4) (V1.1) [!]
 CRC=0C5057AD 046E126E
-RefMD5=5F1906DF4EB30537C2AC2FCBD005907D
+Players=4
+SaveType=SRAM
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [DD8154D507C88694AFD69C7AF16A8CD6]
 GoodName=Waialae Country Club - True Golf Classics (U) (V1.0) [!]
 CRC=8066D58A C3DECAC1
 Players=4
 SaveType=SRAM
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [67F75C4DD30922A001C8C32AEB9333AC]
 GoodName=Waialae Country Club - True Golf Classics (U) (V1.1) [!]
 CRC=DD318CE2 B73798BA
-RefMD5=DD8154D507C88694AFD69C7AF16A8CD6
+Players=4
+SaveType=SRAM
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 
 [D25DD15903BDCB7724A2E8A02561987F]
 GoodName=War Gods (E) [!]
 CRC=D715CC70 271CF5D6
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [9FF2BA3C8408DE9F0EDB6D764A97C197]
@@ -17047,6 +19589,10 @@ GoodName=War Gods (U) [!]
 CRC=F7FE28F6 C3F2ACC3
 Players=2
 SaveType=None
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [D08D61E3C244A081C166C6A8D539A181]
@@ -17081,19 +19627,34 @@ RefMD5=9FF2BA3C8408DE9F0EDB6D764A97C197
 
 [1F83663B2C84512FC3706A6CACC1A9F3]
 GoodName=Wave Race 64 (Ch) (iQue) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [A66FEE7AF89D58B24A25C346A0E90172]
 GoodName=Wave Race 64 (Ch) (V2) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [926B1495565435DA0AF29BB660532DA3]
 GoodName=Wave Race 64 (Ch) (V4) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [310659115E9939F219A783ABDD456CE9]
 GoodName=Wave Race 64 (E) (M2) [!]
 CRC=650EFA96 30DDF9A7
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [A992E010BC3740C7C266D4F6E90226A1]
 GoodName=Wave Race 64 (E) (M2) [h1C]
@@ -17110,19 +19671,30 @@ GoodName=Wave Race 64 (J) [!]
 CRC=5C9191D6 B30AC306
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [D05C6F3CAF9059B306CC13535E2A8BA6]
 GoodName=Wave Race 64 (J) (V1.1) [!]
 CRC=44995484 20A5FC5E
-RefMD5=B32E555BC1A375256E8A4021A25339BE
+Players=2
+SaveType=Eeprom 4KB
+Biopak=No
+Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [AE480013F39D4AEC86EEA1B4995600D1]
 GoodName=Wave Race 64 (U) (V1.0) [!]
 CRC=7DE11F53 74872F9D
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [D653E6B050F63B5E1C1E9856319287E1]
 GoodName=Wave Race 64 (U) (V1.0) [t1]
@@ -17134,7 +19706,10 @@ GoodName=Wave Race 64 (U) (V1.1) [!]
 CRC=492F4B61 04E5146A
 Players=2
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [FF67DF97476C210D158779AE6142F239]
 GoodName=Wave Race 64 - Shindou Edition (J) (V1.2) [!]
@@ -17142,8 +19717,10 @@ CRC=535DF3E2 609789F1
 Players=2
 CountPerOp=3
 SaveType=Eeprom 4KB
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [AFBC694A3BA5AE83D3CEEF906BF01839]
 GoodName=Wave Race 64 - Shindou Edition (J) (V1.2) [b1]
@@ -17170,14 +19747,20 @@ GoodName=Wayne Gretzky's 3D Hockey '98 (E) (M4) [!]
 CRC=661B45F3 9ED6266D
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [810F8BC2C8C66BDA3B206C7DD4B6D42F]
 GoodName=Wayne Gretzky's 3D Hockey '98 (U) [!]
 CRC=5A9D3859 97AAE710
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [096726498E698B51AFE72AAB5262A15A]
 GoodName=Wayne Gretzky's 3D Hockey '98 (U) [T+Ita_cattivik66]
@@ -17196,7 +19779,10 @@ GoodName=Wayne Gretzky's 3D Hockey (E) (M4) [!]
 CRC=2209094B 2C9559AF
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [65F1D583B5392D3467BD187224FBBD89]
 GoodName=Wayne Gretzky's 3D Hockey (E) (M4) [b1]
@@ -17213,8 +19799,10 @@ GoodName=Wayne Gretzky's 3D Hockey (J) [!]
 CRC=F1301043 FD80541A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [371620871660767900FC00F72681E1FD]
 GoodName=Wayne Gretzky's 3D Hockey (J) [b1]
@@ -17236,7 +19824,10 @@ GoodName=Wayne Gretzky's 3D Hockey (U) (V1.0) [!]
 CRC=6B45223F F00E5C56
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [EDBDB55AD58554C48B25A47D7E178513]
 GoodName=Wayne Gretzky's 3D Hockey (U) (V1.0) [b1]
@@ -17253,7 +19844,10 @@ GoodName=Wayne Gretzky's 3D Hockey (U) (V1.1) [!]
 CRC=DC3BAA59 0ABB456A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [98C20A229170CF393BBF442D44FFC5B1]
 GoodName=Wet Dreams Can Beta Demo by Immortal (POM '99) (PD)
@@ -17280,7 +19874,10 @@ GoodName=Wetrix (E) (M6) [!]
 CRC=CEA8B54F 7F21D503
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [15F425829D54DD290451D2F3EBAF953F]
@@ -17298,6 +19895,10 @@ GoodName=Wetrix (J) [!]
 CRC=DCB6EAFA C6BBCFA3
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [08826E96F3FB022A1C6351774198BA9D]
@@ -17310,7 +19911,10 @@ GoodName=Wetrix (U) (M6) [!]
 CRC=CEA8B54F 7F21D503
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=3
 
 [2ABE36754E866B9B6C4BDCFFC1D11ABF]
@@ -17318,7 +19922,10 @@ GoodName=Wheel of Fortune (U) [!]
 CRC=E896092B DC244D4E
 SaveType=None
 Players=4
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [CC75D0771DBC825AC9F499400443A6A0]
 GoodName=Wheel of Fortune (U) [b1]
@@ -17348,7 +19955,10 @@ GoodName=Wild Choppers (J) [!]
 CRC=0CEBC4C7 0C9CE932
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [BA538CBF43471B3522C4D08BAD0797A7]
 GoodName=Wild Choppers (J) [b1]
@@ -17384,8 +19994,10 @@ GoodName=WinBack (J) (V1.0) [!]
 CRC=1FA056E0 A4B9946A
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1B94D98F509F467F9BC541102F6EBDFC]
 GoodName=WinBack (J) (V1.0) [b1]
@@ -17397,16 +20009,20 @@ GoodName=WinBack (J) (V1.1) [!]
 CRC=C52E0BC6 56BC6556
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [48DA6CDCAB838153CAA2ECC3DD592A65]
 GoodName=WinBack - Covert Operations (U) [!]
 CRC=ED98957E 8242DCAC
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [ACC6FD4E26D360D1BED54C316D7E33B9]
 GoodName=WinBack - Covert Operations (U) [b1]
@@ -17428,8 +20044,10 @@ GoodName=Wipeout 64 (E) [!]
 CRC=54310E7D 6B5430D8
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [7260DA1CECD0D8844C5E29AA63476DEF]
@@ -17437,16 +20055,20 @@ GoodName=Wipeout 64 (E) (Beta) [!]
 CRC=136EBEE3 35B7229E
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [73C6D87DBE50F73F3B44E0F237A546D7]
 GoodName=Wipeout 64 (U) [!]
 CRC=132D2732 C70E9118
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 Players=4
 CountPerOp=1
 
@@ -17470,7 +20092,10 @@ GoodName=Wonder Project J2 - Koruro no Mori no Jozet (J) [!]
 CRC=E43C9765 05B1C1BE
 Players=1
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [D6E56B92EC7DBFB8B14DD5D8CFF6492E]
@@ -17493,7 +20118,10 @@ GoodName=World Cup 98 (E) (M8) [!]
 CRC=F9FC3090 FF014EC2
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [E3DB1863E138B3AD5685A16029D0A44C]
 GoodName=World Cup 98 (E) (M8) [f1] (NTSC)
@@ -17505,15 +20133,20 @@ GoodName=World Cup 98 (U) (M8) [!]
 CRC=BD636D6A 5D1F54BA
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [431DE8F6611A8131B536F0EDE1F330D9]
 GoodName=World Driver Championship (E) (M5) [!]
 CRC=AC062778 DFADFCB8
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [9A2B0F3226FB8D129BEB7509C169476A]
@@ -17526,8 +20159,10 @@ GoodName=World Driver Championship (U) [!]
 CRC=308DFEC8 CE2EB5F6
 Players=2
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [4B86C373533D015860467C5DC1F1C662]
@@ -17555,6 +20190,10 @@ GoodName=Worms - Armageddon (E) (M6) [!]
 CRC=2D21C57B 8FE4C58C
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [35FDA68C8481F7C3419CCD91EDBB6A9E]
 GoodName=Worms - Armageddon (E) (M6) [f1] (NTSC)
@@ -17566,6 +20205,10 @@ GoodName=Worms - Armageddon (U) (M3) [!]
 CRC=13E959A0 0E93CAB0
 Players=4
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [EC2BCB1B7FC7D068BE1F39E79E49A842]
 GoodName=Xena Warrior Princess - The Talisman of Fate (E) [!]
@@ -17573,8 +20216,10 @@ CRC=0A1667C7 293346A6
 CountPerOp=3
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [1AC234649D28F09E82C0D11ABB17F03B]
 GoodName=Xena Warrior Princess - The Talisman of Fate (U) [!]
@@ -17582,8 +20227,10 @@ CRC=0553AE9D EAD8E0C1
 CountPerOp=3
 Players=4
 SaveType=None
+Biopak=No
 Mempak=Yes
 Rumble=Yes
+Transferpak=No
 
 [687AF471A5A16D665E16AC1E9069D16B]
 GoodName=Xena Warrior Princess - The Talisman of Fate (U) [f1] (PAL)
@@ -17619,27 +20266,49 @@ CRC=83F9F2CB E7BC4744
 GoodName=Yakouchuu II - Satsujin Kouru (J) [!]
 CRC=9F8B96C3 A01194DC
 Players=1
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 CountPerOp=1
 
 [F7AA4F819F41CB4236792A8145684627]
 GoodName=Yoshi's Story (Ch) (iQue) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [DF8164DA753C9EF0B7C2611F584E81A9]
 GoodName=Yoshi's Story (Ch) (V2) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [D6778D9D560DEC35D8C05AF4738E27AA]
 GoodName=Yoshi's Story (Ch) (V4) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [85A90C61B65B56334E00950210C6CFC4]
 GoodName=Yoshi's Story (Ch) (V6) (iQue) (Manual) [!]
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 
 [DD8A0E5472F13EA87B176F0155FA0C66]
 GoodName=Yoshi Story (J) [!]
 CRC=2DCFCA60 8354B147
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [B7B236051E4347428288F8D840BFD2E4]
 GoodName=Yoshi Story (J) [b1]
@@ -17681,7 +20350,10 @@ GoodName=Yoshi's Story (E) (M3) [!]
 CRC=D3F97D49 6924135B
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [6E5E919D0FA292B97AAD08E9200E8C9C]
 GoodName=Yoshi's Story (E) (M3) [b1]
@@ -17713,7 +20385,10 @@ GoodName=Yoshi's Story (U) (M2) [!]
 CRC=2337D8E8 6B8E7CEC
 Players=1
 SaveType=Eeprom 16KB
+Biopak=No
+Mempak=No
 Rumble=Yes
+Transferpak=No
 
 [B907C051F1D7D0D15DE65EA87CF3F922]
 GoodName=Yoshi's Story (U) (M2) [b1]
@@ -17764,6 +20439,10 @@ GoodName=Yuke Yuke!! Trouble Makers (J) [!]
 CRC=9FE6162D E97E4037
 Players=1
 SaveType=Eeprom 4KB
+Biopak=No
+Mempak=No
+Rumble=No
+Transferpak=No
 CountPerOp=1
 
 [6F9E56C8A2B6BA5F6DBE5214E352590D]
@@ -17913,7 +20592,10 @@ CRC=60005D15 65727EFF
 GoodName=Zool - Majou Tsukai Densetsu (J) [!]
 CRC=1C010CCD 22D3B7FA
 Players=1
+Biopak=No
 Mempak=Yes
+Rumble=No
+Transferpak=No
 
 [4F8E5341B89E6C2069A319EF2FB58B16]
 GoodName=Zool - Majou Tsukai Densetsu (J) [f1] (PAL)
@@ -18003,18 +20685,24 @@ CRC=00000000 00005053
 [D3929AADF7640F8C5B4CE8321AD4393A]
 GoodName=Zelda no Densetsu - Mujura no Kamen (J) (GC) [!]
 CRC=8473D0C1 23120666
+Players=1
 SaveType=Flash RAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [15D1A2217CAD61C39CFECBFFA0703E25]
 GoodName=Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [!]
 CRC=EC417312 EB31DE5F
+Players=1
 SaveType=Flash RAM
 Status=4
+Biopak=No
+Mempak=No
 Rumble=Yes
-Players=1
+Transferpak=No
 
 [3E60CA693BABFF1F62CF8C0AEC338556]
 GoodName=Zelda no Densetsu - Mujura no Kamen (J) (V1.0) [b1]
@@ -18039,5 +20727,11 @@ RefMD5=15D1A2217CAD61C39CFECBFFA0703E25
 [C38A7F6F6B61862EA383A75CDF888279]
 GoodName=Zelda no Densetsu - Mujura no Kamen (J) (V1.1) [!]
 CRC=69AE0438 2C63F3F3
-RefMD5=15D1A2217CAD61C39CFECBFFA0703E25
+Players=1
+SaveType=Flash RAM
+Status=4
+Biopak=No
+Mempak=No
+Rumble=Yes
+Transferpak=No
 


### PR DESCRIPTION
Since there are a lot of fixes, I thought it's best to make two separate commits for (a bit) easier review.

The first one commit is very large and the reason for this is that currently, according to the database, official and licensed games advertise their support for Pak accessories when they actually don't. For example, Super Mario 64 (U) [!] doesn't support any of available accessories for N64, but here on mupen64plus the game appears to advertise Rumble Pak support, which is false. So, to correct this lie, we must specify also what Paks it doesn't support, and the end result is that for all games we add some thousand of new lines to database. 

The second commit just adds new prototypes and betas, and it also specify what Paks they support. There are also minor fixes, correcting good names to reflect more those in No-Intro. I have also moved Japanese OoT entries at the bottom of the list, for which it can make the PR appearing confusing to whose have to review it, and I apologize for that.

I have tested this new version of the database and it hasn't given any errors so far.