### PR TITLE
Revert "Prevents game freezing unrelated to dynarecs"

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -6664,7 +6664,6 @@ CRC=AF9DCC15 1A723D88
 Players=1
 SaveType=Eeprom 4KB
 Rumble=Yes
-CountPerOp=1
 
 [63D7AB29BA3DFC5D5B12C1D9C5832355]
 GoodName=Indiana Jones and the Infernal Machine (E) (Unreleased)
@@ -6672,7 +6671,6 @@ CRC=3A6F8C6B 2897BAEB
 Players=1
 SaveType=Eeprom 4KB
 Rumble=Yes
-CountPerOp=1
 
 [A7781D441AF55C4FF8AFC68AB3A59313]
 GoodName=Indy Racing 2000 (U) [!]


### PR DESCRIPTION
Reverts mupen64plus/mupen64plus-core#853. Indiana Jones doesn't boots with CountPerOp=1 if a save file doesn't exist.