### PR TITLE
Support Unicode on Windows

### DIFF
--- a/src/api/config.c
+++ b/src/api/config.c
@@ -382,7 +382,7 @@ static m64p_error write_configlist_file(void)
     if (filepath == NULL)
         return M64ERR_NO_MEMORY;
 
-    fPtr = fopen(filepath, "wb"); 
+    fPtr = osal_file_open(filepath, "wb");
     if (fPtr == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Couldn't open configuration file '%s' for writing.", filepath);
@@ -471,7 +471,7 @@ m64p_error ConfigInit(const char *ConfigDirOverride, const char *DataDirOverride
     if (filepath == NULL)
         return M64ERR_NO_MEMORY;
 
-    fPtr = fopen(filepath, "rb");
+    fPtr = osal_file_open(filepath, "rb");
     if (fPtr == NULL)
     {
         DebugMessage(M64MSG_INFO, "Couldn't open configuration file '%s'.  Using defaults.", filepath);
@@ -635,7 +635,7 @@ EXPORT m64p_error CALL ConfigExternalOpen(const char *FileName, m64p_handle *Han
     struct external_config* ext_config;
     long ftell_result;
     size_t filelen = 0;
-    if (FileName == NULL || (fPtr = fopen(FileName, "rb")) == NULL)
+    if (FileName == NULL || (fPtr = osal_file_open(FileName, "rb")) == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Unable to open config file '%s'.", FileName);
         return M64ERR_INPUT_INVALID;

--- a/src/device/r4300/new_dynarec/arm/arm_cpu_features.c
+++ b/src/device/r4300/new_dynarec/arm/arm_cpu_features.c
@@ -33,7 +33,7 @@ const char procfile[] = "/proc/cpuinfo";
 static unsigned char check_arm_cpu_feature(const char* feature)
 {
     unsigned char status = 0;
-    FILE *pFile = fopen(procfile, "r");
+    FILE *pFile = osal_file_open(procfile, "r");
     
     if (pFile != NULL)
     {
@@ -57,7 +57,7 @@ static unsigned char check_arm_cpu_feature(const char* feature)
 static unsigned char get_arm_cpu_implementer(void)
 {
     unsigned char implementer = 0;
-    FILE *pFile = fopen(procfile, "r");
+    FILE *pFile = osal_file_open(procfile, "r");
     
     if (pFile != NULL)
     {
@@ -80,7 +80,7 @@ static unsigned char get_arm_cpu_implementer(void)
 static unsigned short get_arm_cpu_part(void)
 {
     unsigned short part = 0;
-    FILE *pFile = fopen(procfile, "r");
+    FILE *pFile = osal_file_open(procfile, "r");
     
     if (pFile != NULL)
     {

--- a/src/device/r4300/new_dynarec/recomp_dbg.c
+++ b/src/device/r4300/new_dynarec/recomp_dbg.c
@@ -825,7 +825,7 @@ void recomp_dbg_init(void)
   cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
  #if RECOMPILER_DEBUG >= NEW_DYNAREC_ARM
-  FILE * pFile = fopen ("jump_table.txt","w");
+  FILE * pFile = osal_file_open ("jump_table.txt","w");
   uintptr_t * src = (uintptr_t *)((char *)base_addr+(1<<TARGET_SIZE_2)-JUMP_TABLE_SIZE);
 
   while((char *)src<(char *)base_addr+(1<<TARGET_SIZE_2))
@@ -908,7 +908,7 @@ extern unsigned int using_tlb;
   if((disasm == 0) || (handle == 0)) return;
 
   sprintf(filename, "0x%.8x.txt",addr);
-  pFile = fopen (filename,"w");
+  pFile = osal_file_open (filename,"w");
 
   for(int i=0;i<slen;i++)
     disassemble(i, pFile);
@@ -917,7 +917,7 @@ extern unsigned int using_tlb;
   fclose(pFile);
 
   sprintf(filename, "%s_0x%.8x.txt","debug",addr);
-  pFile = fopen (filename,"w");
+  pFile = osal_file_open (filename,"w");
 
   for(int i=0;i<slen;i++)
     debugging(i, pFile);
@@ -926,7 +926,7 @@ extern unsigned int using_tlb;
   fclose(pFile);
 
   sprintf(filename, "%s_0x%.8x.txt",ARCH_NAME,addr);
-  pFile = fopen (filename,"w");
+  pFile = osal_file_open (filename,"w");
   size = (intptr_t)end - (intptr_t)beginning;
   size = (size < 0) ? (-size) : size;
 

--- a/src/device/r4300/recomp.c
+++ b/src/device/r4300/recomp.c
@@ -524,7 +524,7 @@ void dynarec_init_block(struct r4300_core* r4300, uint32_t address)
     if (!already_exist)
     {
 #if defined(PROFILE_R4300)
-        r4300->recomp.pfProfile = fopen("instructionaddrs.dat", "ab");
+        r4300->recomp.pfProfile = osal_file_open("instructionaddrs.dat", "ab");
         long x86addr = (long) b->code;
         int mipsop = -2; /* -2 == NOTCOMPILED block at beginning of x86 code */
         if (fwrite(&mipsop, 1, 4, r4300->recomp.pfProfile) != 4 || // write 4-byte MIPS opcode
@@ -641,7 +641,7 @@ void dynarec_recompile_block(struct r4300_core* r4300, const uint32_t* iw, struc
     init_cache(r4300, block->block + (func & 0xFFF) / 4);
 
 #if defined(PROFILE_R4300)
-    r4300->recomp.pfProfile = fopen("instructionaddrs.dat", "ab");
+    r4300->recomp.pfProfile = osal_file_open("instructionaddrs.dat", "ab");
 #endif
 
     for (i = (func & 0xFFF) / 4, finished = 0; finished != 2; ++i)
@@ -839,7 +839,7 @@ void profile_write_end_of_code_blocks(struct r4300_core* r4300)
 {
     size_t i;
 
-    r4300->recomp.pfProfile = fopen("instructionaddrs.dat", "ab");
+    r4300->recomp.pfProfile = osal_file_open("instructionaddrs.dat", "ab");
 
     for (i = 0; i < 0x100000; ++i) {
         if (r4300->cached_interp.invalid_code[i] == 0 && r4300->cached_interp.blocks[i] != NULL && r4300->cached_interp.blocks[i]->code != NULL && r4300->cached_interp.blocks[i]->block != NULL)

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -38,6 +38,7 @@
 #include "device/device.h"
 #include "main.h"
 #include "md5.h"
+#include "osal/files.h"
 #include "osal/preproc.h"
 #include "osd/osd.h"
 #include "rom.h"
@@ -411,7 +412,7 @@ void romdatabase_open(void)
         return;
 
     /* Open romdatabase. */
-    if (pathname == NULL || (fPtr = fopen(pathname, "rb")) == NULL)
+    if (pathname == NULL || (fPtr = osal_file_open(pathname, "rb")) == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Unable to open rom database file '%s'.", pathname);
         return;

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -43,6 +43,7 @@
 #include "device/device.h"
 #include "main/list.h"
 #include "main/main.h"
+#include "osal/files.h"
 #include "osal/preproc.h"
 #include "osd/osd.h"
 #include "plugin/plugin.h"
@@ -200,7 +201,7 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
 
     SDL_LockMutex(savestates_lock);
 
-    f = gzopen(filepath, "rb");
+    f = osal_gzopen(filepath, "rb");
     if(f==NULL)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Could not open state file: %s", filepath);
@@ -1338,7 +1339,7 @@ static int savestates_load_pj64_unc(struct device* dev, char *filepath)
     FILE *f;
 
     /* Open the file. */
-    f = fopen(filepath, "rb");
+    f = osal_file_open(filepath, "rb");
     if (f == NULL)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Could not open state file: %s", filepath);
@@ -1359,7 +1360,7 @@ static int savestates_load_pj64_unc(struct device* dev, char *filepath)
 static savestates_type savestates_detect_type(char *filepath)
 {
     unsigned char magic[4];
-    FILE *f = fopen(filepath, "rb");
+    FILE *f = osal_file_open(filepath, "rb");
     if (f == NULL)
     {
         DebugMessage(M64MSG_STATUS, "Could not open state file %s\n", filepath);
@@ -1399,21 +1400,21 @@ int savestates_load(void)
         // try M64P type first
         type = savestates_type_m64p;
         filepath = savestates_generate_path(type);
-        fPtr = fopen(filepath, "rb"); // can I open this?
+        fPtr = osal_file_open(filepath, "rb"); // can I open this?
         if (fPtr == NULL)
         {
             free(filepath);
             // try PJ64 zipped type second
             type = savestates_type_pj64_zip;
             filepath = savestates_generate_path(type);
-            fPtr = fopen(filepath, "rb"); // can I open this?
+            fPtr = osal_file_open(filepath, "rb"); // can I open this?
             if (fPtr == NULL)
             {
                 free(filepath);
                 // finally, try PJ64 uncompressed
                 type = savestates_type_pj64_unc;
                 filepath = savestates_generate_path(type);
-                fPtr = fopen(filepath, "rb"); // can I open this?
+                fPtr = osal_file_open(filepath, "rb"); // can I open this?
                 if (fPtr == NULL)
                 {
                     free(filepath);
@@ -1433,7 +1434,7 @@ int savestates_load(void)
         }
         filepath = savestates_generate_path(type);
         if (filepath != NULL)
-            fPtr = fopen(filepath, "rb"); // can I open this?
+            fPtr = osal_file_open(filepath, "rb"); // can I open this?
         if (fPtr == NULL)
         {
             main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Failed to open savestate file %s", filepath);
@@ -1477,7 +1478,7 @@ static void savestates_save_m64p_work(struct work_struct *work)
     SDL_LockMutex(savestates_lock);
 
     // Write the state to a GZIP file
-    f = gzopen(save->filepath, "wb");
+    f = osal_gzopen(save->filepath, "wb");
 
     if (f==NULL)
     {
@@ -2119,7 +2120,7 @@ static int savestates_save_pj64_unc(const struct device* dev, char *filepath)
 {
     FILE *f;
 
-    f = fopen(filepath, "wb");
+    f = osal_file_open(filepath, "wb");
     if (f == NULL)
     {
         main_message(M64MSG_STATUS, OSD_BOTTOM_LEFT, "Could not create PJ64 state file: %s", filepath);

--- a/src/main/screenshot.c
+++ b/src/main/screenshot.c
@@ -97,7 +97,7 @@ static int SaveRGBBufferToFile(const char *filename, const unsigned char *buf, i
         return 3;
     }
     // open the file to write
-    FILE *savefile = fopen(filename, "wb");
+    FILE *savefile = osal_file_open(filename, "wb");
     if (savefile == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Error opening '%s' to save screenshot.", filename);
@@ -189,7 +189,7 @@ static char *GetNextScreenshotPath(void)
     for (; CurrentShotIndex < 1000; CurrentShotIndex++)
     {
         sprintf(NumberPtr, "%03i.png", CurrentShotIndex);
-        FILE *pFile = fopen(ScreenshotPath, "r");
+        FILE *pFile = osal_file_open(ScreenshotPath, "r");
         if (pFile == NULL)
             break;
         fclose(pFile);

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -49,7 +49,7 @@
 
 file_status_t read_from_file(const char *filename, void *data, size_t size)
 {
-    FILE *f = fopen(filename, "rb");
+    FILE *f = osal_file_open(filename, "rb");
     if (f == NULL)
     {
         return file_open_error;
@@ -67,7 +67,7 @@ file_status_t read_from_file(const char *filename, void *data, size_t size)
 
 file_status_t write_to_file(const char *filename, const void *data, size_t size)
 {
-    FILE *f = fopen(filename, "wb");
+    FILE *f = osal_file_open(filename, "wb");
     if (f == NULL)
     {
         return file_open_error;
@@ -90,8 +90,8 @@ file_status_t write_chunk_to_file(const char *filename, const void *data, size_t
 
     /* first try to open with rb+ to avoid wiping existing content,
      * otherwise create file */
-    if ((f = fopen(filename, "rb+")) == NULL) {
-        if ((f = fopen(filename, "wb")) == NULL) {
+    if ((f = osal_file_open(filename, "rb+")) == NULL) {
+        if ((f = osal_file_open(filename, "wb")) == NULL) {
             return file_open_error;
         }
     }
@@ -126,7 +126,7 @@ file_status_t load_file(const char* filename, void** buffer, size_t* size)
 
     /* open file */
     ret = file_open_error;
-    fd = fopen(filename, "rb");
+    fd = osal_file_open(filename, "rb");
     if (fd == NULL)
     {
         return file_open_error;
@@ -188,7 +188,7 @@ file_status_t get_file_size(const char* filename, size_t* size)
 
     /* open file */
     ret = file_open_error;
-    fd = fopen(filename, "rb");
+    fd = osal_file_open(filename, "rb");
     if (fd == NULL)
     {
         return file_open_error;

--- a/src/osal/files.h
+++ b/src/osal/files.h
@@ -26,6 +26,8 @@
 #if !defined (OSAL_FILES_H)
 #define OSAL_FILES_H
 
+#include <zlib.h>
+
 /* some file-related preprocessor definitions */
 #if defined(WIN32) && !defined(__MINGW32__)
   #include <io.h> // For _unlink()
@@ -33,12 +35,14 @@
   #define unlink _unlink
 
   #define OSAL_DIR_SEPARATORS           "\\/"
+  #define WIDE_OSAL_DIR_SEPARATORS     L"\\/"
   #define PATH_MAX _MAX_PATH
 #else  /* Not WIN32 */
   #include <limits.h>  // for PATH_MAX
   #include <unistd.h>  // for unlink()
 
   #define OSAL_DIR_SEPARATORS           "/"
+  #define WIDE_OSAL_DIR_SEPARATORS     L"/"
 
   /* PATH_MAX only may be defined by limits.h */
   #ifndef PATH_MAX
@@ -56,6 +60,9 @@ extern const char * osal_get_shared_filepath(const char *filename, const char *f
 extern const char * osal_get_user_configpath(void);
 extern const char * osal_get_user_datapath(void);
 extern const char * osal_get_user_cachepath(void);
+
+extern FILE * osal_file_open (const char *filename, const char *mode);
+extern gzFile osal_gzopen(const char *filename, const char *mode);
 
 #endif /* OSAL_FILES_H */
 

--- a/src/osal/files_macos.c
+++ b/src/osal/files_macos.c
@@ -223,3 +223,12 @@ const char * osal_get_user_cachepath(void)
     return osal_get_user_configpath();
 }
 
+FILE * osal_file_open ( const char * filename, const char * mode )
+{
+    return fopen (filename, mode);
+}
+
+gzFile osal_gzopen(const char *filename, const char *mode)
+{
+    return gzopen(filename, mode);
+}

--- a/src/osal/files_unix.c
+++ b/src/osal/files_unix.c
@@ -232,4 +232,12 @@ const char * osal_get_user_cachepath(void)
     return NULL;
 }
 
+FILE * osal_file_open(const char *filename, const char *mode)
+{
+    return fopen (filename, mode);
+}
 
+gzFile osal_gzopen(const char *filename, const char *mode)
+{
+    return gzopen(filename, mode);
+}

--- a/src/osal/files_win32.c
+++ b/src/osal/files_win32.c
@@ -64,8 +64,10 @@ static int search_dir_file(char *destpath, const char *path, const char *filenam
         strcat(destpath, "\\");
     strcat(destpath, filename);
 
+    wchar_t w_destpath[PATH_MAX];
+    MultiByteToWideChar(CP_UTF8, 0, destpath, -1, w_destpath, PATH_MAX);
     /* test for a valid file */
-    if (_stat(destpath, &fileinfo) != 0)
+    if (_wstat(w_destpath, &fileinfo) != 0)
         return 2;
     if ((fileinfo.st_mode & _S_IFREG) == 0)
         return 3;
@@ -78,52 +80,48 @@ static int search_dir_file(char *destpath, const char *path, const char *filenam
 
 int osal_mkdirp(const char *dirpath, int mode)
 {
-    char *mypath, *currpath, *lastchar;
+    wchar_t mypath[MAX_PATH];
+    wchar_t *currpath, *lastchar;
     struct _stat fileinfo;
 
     // Create a copy of the path, so we can modify it
-    mypath = currpath = _strdup(dirpath);
-    if (mypath == NULL)
+    if (MultiByteToWideChar(CP_UTF8, 0, dirpath, -1, mypath, MAX_PATH) == 0)
         return 1;
+    currpath = &mypath[0];
 
     // if the directory path ends with a separator, remove it
-    lastchar = mypath + strlen(mypath) - 1;
-    if (strchr(OSAL_DIR_SEPARATORS, *lastchar) != NULL)
+    lastchar = mypath + wcslen(mypath) - 1;
+    if (wcschr(WIDE_OSAL_DIR_SEPARATORS, *lastchar) != NULL)
         *lastchar = 0;
 
     // Terminate quickly if the path already exists
-    if (_stat(mypath, &fileinfo) == 0 && (fileinfo.st_mode & _S_IFDIR))
-        goto goodexit;
+    if (_wstat(mypath, &fileinfo) == 0 && (fileinfo.st_mode & _S_IFDIR))
+        return 0;
 
-    while ((currpath = strpbrk(currpath + 1, OSAL_DIR_SEPARATORS)) != NULL)
+    while ((currpath = wcspbrk(currpath + 1, WIDE_OSAL_DIR_SEPARATORS)) != NULL)
     {
         // if slash is right after colon, then we are looking at drive name prefix (C:\) and should
         // just skip it, because _stat and _mkdir will both fail for "C:"
-        if (currpath > mypath && currpath[-1] == ':')
+        if (currpath > mypath && currpath[-1] == L':')
             continue;
-        *currpath = '\0';
-        if (_stat(mypath, &fileinfo) != 0)
+        *currpath = L'\0';
+        if (_wstat(mypath, &fileinfo) != 0)
         {
-            if (_mkdir(mypath) != 0)
-                goto errorexit;
+            if (_wmkdir(mypath) != 0)
+                return 1;
         }
         else if (!(fileinfo.st_mode & _S_IFDIR))
         {
-            goto errorexit;
+            return 1;
         }
-        *currpath = OSAL_DIR_SEPARATORS[0];
+        *currpath = WIDE_OSAL_DIR_SEPARATORS[0];
     }
 
     // Create full path
-    if  (_mkdir(mypath) != 0)
-        goto errorexit;
+    if  (_wmkdir(mypath) != 0)
+       return 1;
 
-goodexit:
-    free(mypath);
     return 0;
-errorexit:
-    free(mypath);
-    return 1;
 }
 
 const char * osal_get_shared_filepath(const char *filename, const char *firstsearch, const char *secondsearch)
@@ -152,7 +150,8 @@ const char * osal_get_shared_filepath(const char *filename, const char *firstsea
 
 const char * osal_get_user_configpath(void)
 {
-    static char chHomePath[MAX_PATH];
+    static wchar_t chHomePath[MAX_PATH];
+    static char outString[MAX_PATH];
     LPITEMIDLIST pidl;
     LPMALLOC pMalloc;
     struct _stat fileinfo;
@@ -160,35 +159,37 @@ const char * osal_get_user_configpath(void)
     // Get item ID list for the path of user's personal directory
     SHGetSpecialFolderLocation(NULL, CSIDL_APPDATA, &pidl);
     // get the path in a char string
-    SHGetPathFromIDList(pidl, chHomePath);
+    SHGetPathFromIDListW(pidl, chHomePath);
     // do a bunch of crap just to free some memory
     SHGetMalloc(&pMalloc);
     pMalloc->lpVtbl->Free(pMalloc, pidl);
     pMalloc->lpVtbl->Release(pMalloc);
 
     // tack on 'mupen64plus'
-    if (chHomePath[strlen(chHomePath)-1] != '\\')
-        strcat(chHomePath, "\\");
-    strcat(chHomePath, "Mupen64Plus");
+    if (chHomePath[wcslen(chHomePath)-1] != L'\\')
+        wcscat(chHomePath, L"\\");
+    wcscat(chHomePath, L"Mupen64Plus");
 
     // if this directory doesn't exist, then make it
-    if (_stat(chHomePath, &fileinfo) == 0)
+    if (_wstat(chHomePath, &fileinfo) == 0)
     {
-        strcat(chHomePath, "\\");
-        return chHomePath;
+        wcscat(chHomePath, L"\\");
+        WideCharToMultiByte(CP_UTF8, 0, chHomePath, -1, outString, MAX_PATH, NULL, NULL);
+        return outString;
     }
     else
     {
-        osal_mkdirp(chHomePath, 0);
-        if (_stat(chHomePath, &fileinfo) == 0)
+        WideCharToMultiByte(CP_UTF8, 0, chHomePath, -1, outString, MAX_PATH, NULL, NULL);
+        osal_mkdirp(outString, 0);
+        if (_wstat(chHomePath, &fileinfo) == 0)
         {
-            strcat(chHomePath, "\\");
-            return chHomePath;
+            strcat(outString, "\\");
+            return outString;
         }
     }
 
     /* otherwise we are in trouble */
-    DebugMessage(M64MSG_ERROR, "Failed to open configuration directory '%s'.", chHomePath);
+    DebugMessage(M64MSG_ERROR, "Failed to open configuration directory '%ls'.", chHomePath);
     return NULL;
 }
 
@@ -204,4 +205,18 @@ const char * osal_get_user_cachepath(void)
     return osal_get_user_configpath();
 }
 
+FILE * osal_file_open ( const char * filename, const char * mode )
+{
+    wchar_t wstr_filename[PATH_MAX];
+    wchar_t wstr_mode[64];
+    MultiByteToWideChar(CP_UTF8, 0, filename, -1, wstr_filename, PATH_MAX);
+    MultiByteToWideChar(CP_UTF8, 0, mode, -1, wstr_mode, 64);
+    return _wfopen (wstr_filename, wstr_mode);
+}
 
+gzFile osal_gzopen(const char *filename, const char *mode)
+{
+    wchar_t wstr_filename[PATH_MAX];
+    MultiByteToWideChar(CP_UTF8, 0, filename, -1, wstr_filename, PATH_MAX);
+    return gzopen_w(wstr_filename, mode);
+}

--- a/tools/r4300prof.c
+++ b/tools/r4300prof.c
@@ -119,7 +119,7 @@ int main(int argc, void *argv[])
 
   /* open r4300 opcode/x86 address table generated from emulator run */
   printf("Loading %s...\n", argv[1]);
-  pfIn = fopen(argv[1], "rb");
+  pfIn = osal_file_open(argv[1], "rb");
   if (pfIn == NULL)
   {
     printf("Couldn't open input file: %s\n", argv[1]);
@@ -168,7 +168,7 @@ int main(int argc, void *argv[])
 
   /* open the profiling sample data file */
   printf("Loading %s...\n", argv[2]);
-  pfIn = fopen(argv[2], "rb");
+  pfIn = osal_file_open(argv[2], "rb");
   if (pfIn == NULL)
   {
     printf("Couldn't open input file: %s\n", argv[2]);

--- a/tools/savestate_convert.c
+++ b/tools/savestate_convert.c
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
         return 1;
     }
     filename = argv[1];
-    pfTest = fopen(filename, "rb");
+    pfTest = osal_file_open(filename, "rb");
     if (pfTest == NULL)
     {
         printf("Error: cannot open savestate file '%s' for reading.\n", filename);


### PR DESCRIPTION
In order for Windows to support Unicode characters, it needs to use the _w versions of the functions (_wfopen and gzopen_w for example).

Right now mupen64plus doesn't support referencing files on Windows that are in a path containing non-Latin characters, this PR fixes that problem.