### PR TITLE
Get Xena (E) to boot

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -17575,7 +17575,7 @@ SaveType=Eeprom 4KB
 [EC2BCB1B7FC7D068BE1F39E79E49A842]
 GoodName=Xena Warrior Princess - The Talisman of Fate (E) [!]
 CRC=0A1667C7 293346A6
-CountPerOp=3
+CountPerOp=4
 Players=4
 SaveType=None
 Mempak=Yes


### PR DESCRIPTION
Xena (E) doesn't boot currently, needs CountPerOp=4. Obviously it's not the best solution, but the game seems to run OK and the in-game count down timer seems to be fairly accurate