### PR TITLE
Fix Pokemon Puzzle League saving

### DIFF
--- a/src/device/cart/flashram.c
+++ b/src/device/cart/flashram.c
@@ -106,6 +106,7 @@ static void flashram_command(struct flashram* flashram, uint32_t command)
     case 0xe1000000:
         /* set silicon_id mode */
         flashram->mode = FLASHRAM_MODE_READ_SILICON_ID;
+        flashram->status |= 0x01; /* Needed for Pokemon Puzzle League */
         break;
 
     case 0xf0000000:


### PR DESCRIPTION
Saving in Pokemon Puzzle League is currently broken. No .fla file is created at all.

It was broken by: https://github.com/mupen64plus/mupen64plus-core/commit/6049618def04148ae8c6ab3146fd87882231df71

This commit restores this line (using the new logic):
https://github.com/mupen64plus/mupen64plus-core/commit/6049618def04148ae8c6ab3146fd87882231df71#diff-af6d71b286c633a07adc8703bbbb9f229f697dcd1c913aafad1a592d61492205L90

This makes Pokemon Puzzle League saving work again.

I checked a few other Flash RAM games (Command & Conquer, Pokemon Stadium, JFG, Paper Mario) and they are all still working normally. @bsmiles32 I'd really like to hear your feedback on this if possible