### PR TITLE
invalidate alternate address on write

### DIFF
--- a/src/device/r4300/r4300_core.c
+++ b/src/device/r4300/r4300_core.c
@@ -360,6 +360,7 @@ int r4300_write_aligned_word(struct r4300_core* r4300, uint32_t address, uint32_
     }
 
     invalidate_r4300_cached_code(r4300, address, 4);
+    invalidate_r4300_cached_code(r4300, address ^ UINT32_C(0x20000000), 4);
 
     address &= UINT32_C(0x1ffffffc);
 
@@ -389,6 +390,7 @@ int r4300_write_aligned_dword(struct r4300_core* r4300, uint32_t address, uint64
     }
 
     invalidate_r4300_cached_code(r4300, address, 8);
+    invalidate_r4300_cached_code(r4300, address ^ UINT32_C(0x20000000), 8);
 
     address &= UINT32_C(0x1ffffffc);
 


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-core/issues/738

@Gillou68310 @bsmiles32 @richard42 

I'd appreciate some feedback to ensure I've done the right thing here (I think I have).

libdragon seems to have a habit of accessing memory using the 0x8.... address and the 0xa.... address interchangeably.

In the other calls to ```invalidate_r4300_cached_code```, both addresses are invalidated, but not in ```r4300_write_aligned_(d)word```.

This allows libdragon software like Flappy Bird to function. I didn't see any negative side affects with other games.