### PR TITLE
Update PI DMA alignment as per CEN64

### DIFF
--- a/src/device/rcp/pi/pi_controller.c
+++ b/src/device/rcp/pi/pi_controller.c
@@ -54,8 +54,8 @@ static void dma_pi_read(struct pi_controller* pi)
         return;
 
     uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] & ~UINT32_C(1);
-    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & 0xffffff;
-    uint32_t length = (pi->regs[PI_RD_LEN_REG] & UINT32_C(0x00fffffe)) + 2;
+    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & 0xfffffe;
+    uint32_t length = (pi->regs[PI_RD_LEN_REG] & UINT32_C(0x00ffffff)) + 1;
     const uint8_t* dram = (uint8_t*)pi->ri->rdram->dram;
 
     const struct pi_dma_handler* handler = NULL;
@@ -70,10 +70,16 @@ static void dma_pi_read(struct pi_controller* pi)
 
     pre_framebuffer_read(&pi->dp->fb, dram_addr);
 
+    /* PI seems to treat the first 128 bytes differently, see https://n64brew.dev/wiki/Peripheral_Interface#Unaligned_DMA_transfer */
+    if (length >= 0x7f && (length & 1))
+        length += 1;
     unsigned int cycles = handler->dma_read(opaque, dram, dram_addr, cart_addr, length);
 
     /* Mark DMA as busy */
     pi->regs[PI_STATUS_REG] |= PI_STATUS_DMA_BUSY;
+    /* Update PI_DRAM_ADDR_REG and PI_CART_ADDR_REG */
+    pi->regs[PI_DRAM_ADDR_REG] = (pi->regs[PI_DRAM_ADDR_REG] + length + 7) & ~7;
+    pi->regs[PI_CART_ADDR_REG] = (pi->regs[PI_CART_ADDR_REG] + length + 1) & ~1;
 
     /* schedule end of dma interrupt event */
     cp0_update_count(pi->mi->r4300);
@@ -86,8 +92,8 @@ static void dma_pi_write(struct pi_controller* pi)
         return;
 
     uint32_t cart_addr = pi->regs[PI_CART_ADDR_REG] & ~UINT32_C(1);
-    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & 0xffffff;
-    uint32_t length = (pi->regs[PI_WR_LEN_REG] & UINT32_C(0x00fffffe)) + 2;
+    uint32_t dram_addr = pi->regs[PI_DRAM_ADDR_REG] & 0xfffffe;
+    uint32_t length = (pi->regs[PI_WR_LEN_REG] & UINT32_C(0x00ffffff)) + 1;
     uint8_t* dram = (uint8_t*)pi->ri->rdram->dram;
 
     const struct pi_dma_handler* handler = NULL;
@@ -100,12 +106,20 @@ static void dma_pi_write(struct pi_controller* pi)
         return;
     }
 
+    /* PI seems to treat the first 128 bytes differently, see https://n64brew.dev/wiki/Peripheral_Interface#Unaligned_DMA_transfer */
+    if (length >= 0x7f && (length & 1))
+        length += 1;
+    if (length <= 0x80)
+        length -= dram_addr & 0x7;
     unsigned int cycles = handler->dma_write(opaque, dram, dram_addr, cart_addr, length);
 
     post_framebuffer_write(&pi->dp->fb, dram_addr, length);
 
     /* Mark DMA as busy */
     pi->regs[PI_STATUS_REG] |= PI_STATUS_DMA_BUSY;
+    /* Update PI_DRAM_ADDR_REG and PI_CART_ADDR_REG */
+    pi->regs[PI_DRAM_ADDR_REG] = (pi->regs[PI_DRAM_ADDR_REG] + length + 7) & ~7;
+    pi->regs[PI_CART_ADDR_REG] = (pi->regs[PI_CART_ADDR_REG] + length + 1) & ~1;
 
     /* schedule end of dma interrupt event */
     cp0_update_count(pi->mi->r4300);
@@ -140,6 +154,13 @@ void read_pi_regs(void* opaque, uint32_t address, uint32_t* value)
     uint32_t reg = pi_reg(address);
 
     *value = pi->regs[reg];
+
+    if (reg == PI_WR_LEN_REG || reg == PI_RD_LEN_REG)
+        *value = 0x7F;
+    else if (reg == PI_CART_ADDR_REG)
+        *value &= 0xFFFFFFFE;
+    else if (reg == PI_DRAM_ADDR_REG)
+        *value &= 0xFFFFFE;
 }
 
 void write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
@@ -168,9 +189,12 @@ void write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         return;
 
     case PI_STATUS_REG:
-        if (value & mask & 2)
+        if (value & mask & PI_STATUS_CLR_INTR)
+        {
+            pi->regs[reg] &= ~PI_STATUS_INTERRUPT;
             clear_rcp_interrupt(pi->mi, MI_INTR_PI);
-        if (value & mask & 1)
+        }
+        if (value & mask & PI_STATUS_RESET)
             pi->regs[PI_STATUS_REG] = 0;
         return;
 
@@ -193,6 +217,7 @@ void pi_end_of_dma_event(void* opaque)
 {
     struct pi_controller* pi = (struct pi_controller*)opaque;
     pi->regs[PI_STATUS_REG] &= ~(PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY);
+    pi->regs[PI_STATUS_REG] |= PI_STATUS_INTERRUPT;
 
     if (pi->dd != NULL) {
         if ((pi->regs[PI_CART_ADDR_REG] == MM_DD_C2S_BUFFER) ||

--- a/src/device/rcp/pi/pi_controller.h
+++ b/src/device/rcp/pi/pi_controller.h
@@ -57,6 +57,7 @@ enum
     PI_STATUS_DMA_BUSY  = 0x01,
     PI_STATUS_IO_BUSY   = 0x02,
     PI_STATUS_ERROR     = 0x04,
+    PI_STATUS_INTERRUPT = 0x08,
 
     /* PI_STATUS - write */
     PI_STATUS_RESET     = 0x01,


### PR DESCRIPTION
Taken from: https://github.com/n64dev/cen64/blob/master/pi/controller.c

Tested using: https://github.com/PeterLemon/N64/tree/master/CPUTest/DMAAlignment-PI-cart

Before:
![dma_alignment_(rom_--000](https://user-images.githubusercontent.com/848146/121725651-ca290580-caa6-11eb-84e7-5393f56b7129.png)

After:
![dma_alignment_(rom_--000](https://user-images.githubusercontent.com/848146/121750504-c064c980-cac9-11eb-9fd9-fbe282d4c6ff.png)

There are still 2 tests that fail here that pass on CEN64: https://github.com/n64dev/cen64/pull/200. However, I couldn't get those tests to pass without breaking the graphics in AI Shougi 3, so I left it at the point where AI Shougi 3 would work. AI Shougi 3 graphics are messed up in CEN64, so I assume there is still more work to be done on their implementation.