### PR TITLE
Update RSP alignment code as per CEN64

### DIFF
--- a/src/device/rcp/rsp/rsp_core.c
+++ b/src/device/rcp/rsp/rsp_core.c
@@ -46,8 +46,8 @@ static void do_sp_dma(struct rsp_core* sp, const struct sp_dma* dma)
     unsigned int count = ((l >> 12) & 0xff) + 1;
     unsigned int skip = ((l >> 20) & 0xfff);
 
-    unsigned int memaddr = dma->memaddr & 0xfff;
-    unsigned int dramaddr = dma->dramaddr & 0xffffff;
+    unsigned int memaddr = dma->memaddr & 0xff8;
+    unsigned int dramaddr = dma->dramaddr & 0xfffff8;
 
     unsigned char *spmem = (unsigned char*)sp->mem + (dma->memaddr & 0x1000);
     unsigned char *dram = (unsigned char*)sp->ri->rdram->dram;


### PR DESCRIPTION
Taken from: https://github.com/n64dev/cen64/blob/master/rsp/interface.c

Tested using: https://github.com/PeterLemon/N64/tree/master/RSPTest/DMAAlignment-SP

Before:
![dma_alignment_(sp_- -001](https://user-images.githubusercontent.com/848146/121744150-b342dd00-cabf-11eb-95b7-ef625eb8648b.png)

After:
![dma_alignment_(sp_- -000](https://user-images.githubusercontent.com/848146/121744162-b6d66400-cabf-11eb-8674-528484d13cb0.png)

With these changes, we achieve the same compatibility as CEN64