### PR TITLE
IS Viewer support

### DIFF
--- a/projects/msvc/mupen64plus-core.vcxproj
+++ b/projects/msvc/mupen64plus-core.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="..\..\src\device\cart\cart_rom.c" />
     <ClCompile Include="..\..\src\device\cart\eeprom.c" />
     <ClCompile Include="..\..\src\device\cart\flashram.c" />
+    <ClCompile Include="..\..\src\device\cart\is_viewer.c" />
     <ClCompile Include="..\..\src\device\cart\sram.c" />
     <ClCompile Include="..\..\src\device\controllers\game_controller.c" />
     <ClCompile Include="..\..\src\device\controllers\paks\biopak.c" />
@@ -436,6 +437,7 @@
     <ClInclude Include="..\..\src\device\cart\cart_rom.h" />
     <ClInclude Include="..\..\src\device\cart\eeprom.h" />
     <ClInclude Include="..\..\src\device\cart\flashram.h" />
+    <ClInclude Include="..\..\src\device\cart\is_viewer.h" />
     <ClInclude Include="..\..\src\device\cart\sram.h" />
     <ClInclude Include="..\..\src\device\controllers\game_controller.h" />
     <ClInclude Include="..\..\src\device\controllers\paks\biopak.h" />

--- a/projects/msvc/mupen64plus-core.vcxproj.filters
+++ b/projects/msvc/mupen64plus-core.vcxproj.filters
@@ -339,6 +339,9 @@
     <ClCompile Include="..\..\src\device\cart\flashram.c">
       <Filter>device\cart</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\device\cart\is_viewer.c">
+      <Filter>device\cart</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\device\cart\sram.c">
       <Filter>device\cart</Filter>
     </ClCompile>
@@ -678,6 +681,9 @@
       <Filter>device\cart</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\device\cart\flashram.h">
+      <Filter>device\cart</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\device\cart\is_viewer.h">
       <Filter>device\cart</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\device\cart\sram.h">

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -504,6 +504,7 @@ SOURCE = \
     $(SRCDIR)/device/cart/cart_rom.c \
     $(SRCDIR)/device/cart/eeprom.c \
     $(SRCDIR)/device/cart/flashram.c \
+    $(SRCDIR)/device/cart/is_viewer.c \
     $(SRCDIR)/device/cart/sram.c \
     $(SRCDIR)/device/controllers/game_controller.c \
     $(SRCDIR)/device/controllers/paks/biopak.c \

--- a/src/device/cart/is_viewer.c
+++ b/src/device/cart/is_viewer.c
@@ -1,0 +1,75 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - is_viewer.c                                             *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
+ *   Copyright (C) 2021 loganmc10                                          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "is_viewer.h"
+
+#define M64P_CORE_PROTOTYPES 1
+#include "api/callbacks.h"
+#include "main/util.h"
+
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <string.h>
+
+#define IS_ADDR_MASK UINT32_C(0x00000fff)
+
+void poweron_is_viewer(struct is_viewer* is_viewer)
+{
+    memset(is_viewer->data, 0, 0x1000);
+    memset(is_viewer->output_buffer, 0, 0x200);
+    is_viewer->buffer_pos = 0;
+}
+
+void read_is_viewer(void* opaque, uint32_t address, uint32_t* value)
+{
+    struct is_viewer* is_viewer = (struct is_viewer*)opaque;
+    address &= IS_ADDR_MASK;
+    memcpy(value, &is_viewer->data[address], 4);
+    *value = m64p_swap32(*value);
+}
+
+void write_is_viewer(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
+{
+    struct is_viewer* is_viewer = (struct is_viewer*)opaque;
+    address &= IS_ADDR_MASK;
+    uint32_t word = value & mask;
+    if (address == 0x14)
+    {
+        if (word > 0)
+        {
+            memcpy(&is_viewer->output_buffer[is_viewer->buffer_pos], &is_viewer->data[0x20], word);
+            is_viewer->buffer_pos += word;
+            char* newline = memchr(is_viewer->output_buffer, '\n', is_viewer->buffer_pos);
+            if (newline)
+            {
+                *newline = '\0';
+                DebugMessage(M64MSG_INFO, "IS64: %s", is_viewer->output_buffer);
+                memset(is_viewer->output_buffer, 0, is_viewer->buffer_pos);
+                is_viewer->buffer_pos = 0;
+            }
+        }
+    }
+    else
+    {
+        word = m64p_swap32(word);
+        memcpy(&is_viewer->data[address], &word, sizeof(word));
+    }
+}

--- a/src/device/cart/is_viewer.h
+++ b/src/device/cart/is_viewer.h
@@ -1,0 +1,40 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - is_viewer.h                                             *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
+ *   Copyright (C) 2021 loganmc10                                          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef M64P_DEVICE_PI_IS_VIEWER_H
+#define M64P_DEVICE_PI_IS_VIEWER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct is_viewer
+{
+    char data[0x1000];
+    char output_buffer[0x200];
+    uint32_t buffer_pos;
+};
+
+void poweron_is_viewer(struct is_viewer* is_viewer);
+
+void read_is_viewer(void* opaque, uint32_t address, uint32_t* value);
+void write_is_viewer(void* opaque, uint32_t address, uint32_t value, uint32_t mask);
+
+#endif

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -150,6 +150,7 @@ void init_device(struct device* dev,
         { A(MM_DOM2_ADDR1, 0xffffff), M64P_MEM_NOTHING, { NULL, RW(open_bus) } },
         { A(MM_DD_ROM, 0x1ffffff), M64P_MEM_NOTHING, { NULL, RW(open_bus) } },
         { A(MM_DOM2_ADDR2, 0x1ffff), M64P_MEM_FLASHRAMSTAT, { &dev->cart, RW(cart_dom2)  } },
+        { A(MM_IS_VIEWER, 0xfff), M64P_MEM_NOTHING, { &dev->is, RW(is_viewer) } },
         { A(MM_CART_ROM, rom_size-1), M64P_MEM_ROM, { &dev->cart.cart_rom, RW(cart_rom) } },
         { A(MM_PIF_MEM, 0xffff), M64P_MEM_PIF, { &dev->pif, RW(pif_mem) } }
     };
@@ -235,6 +236,8 @@ void poweron_device(struct device* dev)
     poweron_pif(&dev->pif);
 
     poweron_cart(&dev->cart);
+
+    poweron_is_viewer(&dev->is);
 
     /* poweron for controllers */
     for(i = 0; i < GAME_CONTROLLERS_COUNT; ++i) {

--- a/src/device/device.h
+++ b/src/device/device.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 
 #include "cart/cart.h"
+#include "cart/is_viewer.h"
 #include "controllers/game_controller.h"
 #include "controllers/paks/biopak.h"
 #include "controllers/paks/mempak.h"
@@ -79,6 +80,7 @@ enum { GAME_CONTROLLERS_COUNT = 4 };
 #define MM_DOM2_ADDR2       UINT32_C(0x08000000)
 
 #define MM_CART_ROM         UINT32_C(0x10000000) /* dom1 addr2 */
+#define MM_IS_VIEWER        UINT32_C(0x13ff0000) /* IS-Viewer */
 #define MM_PIF_MEM          UINT32_C(0x1fc00000)
 #define MM_CART_DOM3        UINT32_C(0x1fd00000) /* dom2 addr2 */
 
@@ -98,6 +100,7 @@ struct device
     struct pif pif;
     struct rdram rdram;
     struct memory mem;
+    struct is_viewer is;
 
     struct game_controller controllers[GAME_CONTROLLERS_COUNT];
     struct biopak biopaks[GAME_CONTROLLERS_COUNT];


### PR DESCRIPTION
IS-Viewer 64 was a physical debugging tool (https://n64squid.com/homebrew/n64-sdk/development-hardware/). CEN64 has had support for a while (https://github.com/n64dev/cen64/blob/master/pi/is_viewer.c). I referenced/copied their implementation for mupen64plus.

When a ROM has IS64 support, the output is printed as a DebugMessage:

![image](https://user-images.githubusercontent.com/848146/123033969-e5005180-d3a5-11eb-8524-338d1c066a19.png)

This is used today by homebrew ROM developers to debug their games.

I don't think this should interfere with any existing games. The address space is inside ```dom1 addr2``` (cart ROM), but I map the IS Viewer before the cart ROM. As I understand it, if the current ROM includes that address space, it'll overwrite the IS Viewer mapping. @bsmiles32 