### PR TITLE
Fix 64DD Write Address Check Regression

### DIFF
--- a/src/device/rcp/pi/pi_controller.c
+++ b/src/device/rcp/pi/pi_controller.c
@@ -220,8 +220,8 @@ void pi_end_of_dma_event(void* opaque)
     pi->regs[PI_STATUS_REG] |= PI_STATUS_INTERRUPT;
 
     if (pi->dd != NULL) {
-        if ((pi->regs[PI_CART_ADDR_REG] == (MM_DD_C2S_BUFFER + pi->regs[PI_WR_LEN_REG] + 1)) ||
-            (pi->regs[PI_CART_ADDR_REG] == (MM_DD_DS_BUFFER + pi->regs[PI_WR_LEN_REG] + 1))) {
+        if (((pi->regs[PI_CART_ADDR_REG] >= MM_DD_C2S_BUFFER) && (pi->regs[PI_CART_ADDR_REG] < MM_DD_DS_BUFFER)) ||
+            (pi->regs[PI_CART_ADDR_REG] >= MM_DD_DS_BUFFER) && ((pi->regs[PI_CART_ADDR_REG] < MM_DD_REGS))) {
             dd_update_bm(pi->dd);
         }
     }


### PR DESCRIPTION
The DMA Address check fix only worked for reads but writes did not trigger dd_update_bm, and therefore no interrupts were issued

I made it check the entire buffer space so there's no room for errors: It works.