### PR TITLE
Add KEYBINDINGS=0 option to Makefile

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -665,6 +665,10 @@ ifeq ($(LIRC), 1)
   LDLIBS += -llirc_client
 endif
 
+ifeq ($(KEYBINDINGS), 0)
+	CFLAGS += -DNO_KEYBINDINGS
+endif
+
 ifeq ($(DEBUGGER), 1)
   SOURCE += \
     $(SRCDIR)/debugger/dbg_debugger.c \
@@ -727,6 +731,7 @@ targets:
 	@echo "    OSD=(1|0)      == Enable/disable build of OpenGL On-screen display"
 	@echo "    NETPLAY=1      == Enable netplay functionality, requires SDL2_net"
 	@echo "    NEW_DYNAREC=1  == Replace dynamic recompiler with Ari64's experimental dynarec"
+	@echo "    KEYBINDINGS=0  == Disables the default keybindings"
 	@echo "    OPENCV=1       == Enable OpenCV support"
 	@echo "    POSTFIX=name   == String added to the name of the the build (default: '')"
 	@echo "  Install Options:"

--- a/src/main/eventloop.c
+++ b/src/main/eventloop.c
@@ -539,6 +539,7 @@ int event_set_core_defaults(void)
 
     ConfigSetDefaultFloat(l_CoreEventsConfig, "Version", CONFIG_PARAM_VERSION,  "Mupen64Plus CoreEvents config parameter set version number.  Please don't change this version number.");
     /* Keyboard presses mapped to core functions */
+#ifndef NO_KEYBINDINGS
     char kbdSaveSlotStr[sizeof(kbdSaveSlot)+1];
     char kbdSaveSlotHelpStr[27];
     int key = SDL_SCANCODE_UNKNOWN;
@@ -586,10 +587,11 @@ int event_set_core_defaults(void)
     ConfigSetDefaultString(l_CoreEventsConfig, JoyCmdName[joyForward], "",    "Joystick event string for fast-forward");
     ConfigSetDefaultString(l_CoreEventsConfig, JoyCmdName[joyAdvance], "",    "Joystick event string for advancing by one frame when paused");
     ConfigSetDefaultString(l_CoreEventsConfig, JoyCmdName[joyGameshark], "",  "Joystick event string for pressing the game shark button");
-
+#endif /* NO_KEYBINDINGS */
     return 1;
 }
 
+#ifndef NO_KEYBINDINGS
 static int get_saveslot_from_keysym(int keysym)
 {
     char kbdSaveSlotStr[sizeof(kbdSaveSlot)+1];
@@ -604,6 +606,7 @@ static int get_saveslot_from_keysym(int keysym)
 
     return -1;
 }
+#endif /* NO_KEYBINDINGS */
 
 /*********************************************************************************************************
 * sdl keyup/keydown handlers
@@ -611,6 +614,7 @@ static int get_saveslot_from_keysym(int keysym)
 
 void event_sdl_keydown(int keysym, int keymod)
 {
+#ifndef NO_KEYBINDINGS
     int slot;
 
     /* check for the only hard-coded key command: Alt-enter for fullscreen */
@@ -653,6 +657,7 @@ void event_sdl_keydown(int keysym, int keymod)
         event_set_gameshark(1);
     }
     else
+#endif /* NO_KEYBINDINGS */
     {
         /* pass all other keypresses to the input plugin */
         input.keyDown(keymod, keysym);
@@ -662,6 +667,7 @@ void event_sdl_keydown(int keysym, int keymod)
 
 void event_sdl_keyup(int keysym, int keymod)
 {
+#ifndef NO_KEYBINDINGS
     if (keysym == sdl_keysym2native(ConfigGetParamInt(l_CoreEventsConfig, kbdStop)))
     {
         return;
@@ -674,8 +680,11 @@ void event_sdl_keyup(int keysym, int keymod)
     {
         event_set_gameshark(0);
     }
-    else input.keyUp(keymod, keysym);
-
+    else
+#endif /* NO_KEYBINDINGS */
+    {
+        input.keyUp(keymod, keysym);
+    }
 }
 
 int event_gameshark_active(void)


### PR DESCRIPTION
This adds an option to allow a front-end to ship a mupen64plus build without any keybindings.