### PR TITLE
Native Apple Silicon (darwin-arm64) Support

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -99,25 +99,30 @@ endif
 ifneq ("$(filter arm%,$(HOST_CPU))","")
   ifeq ("$(filter arm%b,$(HOST_CPU))","")
     CPU := ARM
-    ARCH_DETECTED := 32BITS
     PIC ?= 1
     NEW_DYNAREC := 1
-    CFLAGS += -marm
-    ifneq ("$(filter armv5%,$(HOST_CPU))","")
-        CFLAGS += -DARMv5_ONLY
-        $(warning Using ARMv5_ONLY)
-    endif
-    ifneq ("$(filter armv6%,$(HOST_CPU))","")
-        CFLAGS += -DARMv5_ONLY
-        $(warning Using ARMv5_ONLY)
-    endif
-    ifeq ($(NEON), 1)
-        CFLAGS += -mfpu=neon -mfloat-abi=hard
+    ifneq ("$(filter arm64,$(HOST_CPU))","")
+      ARCH_DETECTED := 64BITS
+      $(warning Architecture "$(HOST_CPU)" not officially supported.)
     else
-      ifeq ($(VFP_HARD), 1)
-        CFLAGS += -mfpu=vfp -mfloat-abi=hard
+      ARCH_DETECTED := 32BITS
+      CFLAGS += -marm
+      ifneq ("$(filter armv5%,$(HOST_CPU))","")
+          CFLAGS += -DARMv5_ONLY
+          $(warning Using ARMv5_ONLY)
+      endif
+      ifneq ("$(filter armv6%,$(HOST_CPU))","")
+          CFLAGS += -DARMv5_ONLY
+          $(warning Using ARMv5_ONLY)
+      endif
+      ifeq ($(NEON), 1)
+          CFLAGS += -mfpu=neon -mfloat-abi=hard
       else
-        CFLAGS += -mfpu=vfp -mfloat-abi=softfp
+        ifeq ($(VFP_HARD), 1)
+          CFLAGS += -mfpu=vfp -mfloat-abi=hard
+        else
+          CFLAGS += -mfpu=vfp -mfloat-abi=softfp
+        endif
       endif
     endif
   endif
@@ -229,6 +234,11 @@ ifeq ($(OS), OSX)
       endif
 	  LDFLAGS += -read_only_relocs suppress
     endif
+  endif
+  ifeq ($(CPU), ARM)
+    # assembly compilation not yet supported on macOS with Apple Silicon
+    NO_ASM = 1
+    CFLAGS += -pipe -arch arm64 -mmacosx-version-min=10.16 -isysroot $(OSX_SDK_PATH)
   endif
 endif
 ifeq ($(OS), MINGW)


### PR DESCRIPTION
Re-do of #908 with squashed commits.

I made some basic switches in the Makefile so now it's possible to build and run on macOS without Rosetta 2.

Without knowing maintainer plans, I have it display a warning that arm64 (not aarch64) is not officially supported. If project leadership wishes to officially support this configuration, recommended as this is Apple's architecture going forward, we can remove the warning.

I made an effort to support assembly functionality for the new dynarec as part of #831, but it is either beyond my abilities or not feasible at this time. Regardless, the emulator passes the tests without this element, so I am presuming there is no drawback to releasing with NO_ASM for darwin-arm64.