### PR TITLE
Generate unique mempaks ID when formatting them

### DIFF
--- a/src/device/controllers/paks/mempak.c
+++ b/src/device/controllers/paks/mempak.c
@@ -23,61 +23,126 @@
 
 #include "backends/api/storage_backend.h"
 #include "device/controllers/game_controller.h"
+#include "main/util.h"
 
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
+/* Serialized representation of ID Block
+ * Only used to ease offsets/pointers computation
+ * DO NOT DEREFERENCE
+ */
+struct id_block_serialized {
+    uint32_t serial[6];
+    uint16_t device_id;
+    uint8_t  banks;
+    uint8_t  version;
+    uint16_t sum;
+    uint16_t isum;
+} __attribute__((packed));
+_Static_assert(sizeof(struct id_block_serialized) == 32, "id_block_serialized must have a size of 32 bytes");
 
-void format_mempak(uint8_t* mem)
+static void checksum_id_block(unsigned char ptr[static sizeof(struct id_block_serialized)],
+            uint16_t* sum, uint16_t* isum)
+{
+    size_t i;
+    uint16_t accu = 0;
+    for (i = 0; i < offsetof(struct id_block_serialized, sum); i += 2) {
+        accu += load_beu16((void*)&ptr[i]);
+    }
+    *sum  = accu;
+    *isum = UINT16_C(0xfff2) - accu;
+}
+
+static uint8_t checksum_index_table(size_t count, unsigned char ptr[static count])
+{
+    unsigned sum = 0;
+    while (count != 0) {
+        sum += load_beu8((void*)ptr);
+        ++ptr;
+        --count;
+    }
+
+    return (uint8_t)sum;
+}
+
+static void serialize_id_block(unsigned char ptr[static sizeof(struct id_block_serialized)], const uint32_t serial[6], uint16_t device_id, uint8_t banks, uint8_t version) {
+
+    size_t i;
+    /* _ should never be dereferenced - it is only used to ease pointer/offsets computation */
+    struct id_block_serialized* const _ = (struct id_block_serialized*)ptr;
+
+
+    for (i = 0; i < 6; ++i) {
+        store_beu32(serial[i], (void*)&_->serial[i]);
+    }
+    store_beu16(device_id, (void*)&_->device_id);
+    store_beu8(banks, (void*)&_->banks);
+    store_beu8(version, (void*)&_->version);
+
+    uint16_t sum, isum;
+    checksum_id_block(ptr, &sum, &isum);
+
+    store_beu16(sum, (void*)&_->sum);
+    store_beu16(isum, (void*)&_->isum);
+}
+
+
+
+void format_mempak(uint8_t* mem,
+    const uint32_t serial[6],
+    uint16_t device_id,
+    uint8_t banks,
+    uint8_t version)
 {
     enum { MPK_PAGE_SIZE = 256 };
-    size_t i;
 
-    static const uint8_t page_0[MPK_PAGE_SIZE] =
-    {
-        /* Label area */
-        0x81,0x01,0x02,0x03, 0x04,0x05,0x06,0x07, 0x08,0x09,0x0a,0x0b, 0x0c,0x0d,0x0e,0x0f,
-        0x10,0x11,0x12,0x13, 0x14,0x15,0x16,0x17, 0x18,0x19,0x1a,0x1b, 0x1c,0x1d,0x1e,0x1f,
-        /* Main ID area */
-        0xff,0xff,0xff,0xff, 0x05,0x1a,0x5f,0x13, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff, 0xff,0xff,0x01,0xff, 0x66,0x25,0x99,0xcd,
-        /* Unused */
-        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        /* ID area backup #1 */
-        0xff,0xff,0xff,0xff, 0x05,0x1a,0x5f,0x13, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff, 0xff,0xff,0x01,0xff, 0x66,0x25,0x99,0xcd,
-        /* ID area backup #2 */
-        0xff,0xff,0xff,0xff, 0x05,0x1a,0x5f,0x13, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff, 0xff,0xff,0x01,0xff, 0x66,0x25,0x99,0xcd,
-        /* Unused */
-        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        /* ID area backup #3 */
-        0xff,0xff,0xff,0xff, 0x05,0x1a,0x5f,0x13, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        0xff,0xff,0xff,0xff, 0xff,0xff,0xff,0xff, 0xff,0xff,0x01,0xff, 0x66,0x25,0x99,0xcd,
-        /* Unused */
-        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00, 0x00,0x00,0x00,0x00
-    };
+    uint8_t* const page_0 = mem + 0*MPK_PAGE_SIZE;
+    uint8_t* const page_1 = mem + 1*MPK_PAGE_SIZE;
+    uint8_t* const page_2 = mem + 2*MPK_PAGE_SIZE;
+    uint8_t* const page_3 = mem + 3*MPK_PAGE_SIZE;
 
-    /* Fill Page 0 with pre-initialized content */
-    memcpy(mem, page_0, MPK_PAGE_SIZE);
+    /* Page 0 is divided in 8 x 32-byte blocks:
+     * 0. reserved
+     * 1. ID
+     * 2. reserved
+     * 3. ID backup #1
+     * 4. ID backup #2
+     * 5. reserved
+     * 6. ID backup #3
+     * 7. reserved
+     */
+    serialize_id_block(page_0 + 1*32, serial, device_id, banks, version);
 
-    /* Fill INODE page 1 and update it's checkum */
+    memset(page_0 + 0*32, 0, 32);
+    memset(page_0 + 2*32, 0, 32);
+    memset(page_0 + 5*32, 0, 32);
+    memset(page_0 + 7*32, 0, 32);
+
+    memcpy(page_0 + 3*32, page_0 + 1*32, 32);
+    memcpy(page_0 + 4*32, page_0 + 1*32, 32);
+    memcpy(page_0 + 6*32, page_0 + 1*32, 32);
+
+    /* Page 1 holds the index table.
+     * The first 5 inodes are reserved because the first 5 pages are reserved.
+     * The first inode page index holds the checksum of the 123 normal nodes.
+     * The remaining 123 pages are marked empty.
+     */
     size_t start_page = 5;
-    memset(mem + 1*MPK_PAGE_SIZE, 0, 2*start_page);
-    for (i = 1*MPK_PAGE_SIZE+2*start_page; i < 2*MPK_PAGE_SIZE; i += 2) {
-        mem[i+0] = 0x00;
-        mem[i+1] = 0x03;
+    size_t last_page = 128;
+    size_t i;
+    memset(page_1, 0, 2*start_page);
+    for(i = start_page; i < last_page; ++i) {
+        store_beu16(UINT16_C(0x0003), page_1 + 2*i);
     }
-    mem[1*MPK_PAGE_SIZE + 1] = 0x71;
+    page_1[1] = checksum_index_table(2*(last_page-start_page), page_1 + 2*start_page);
 
-    /* Page 2 is identical to page 1 */
-    memcpy(mem + 2*MPK_PAGE_SIZE, mem + 1*MPK_PAGE_SIZE, MPK_PAGE_SIZE);
+    /* Page 2 is a backup of Page 1 */
+    memcpy(page_2, page_1, MPK_PAGE_SIZE);
 
     /* Remaining pages DIR+DATA (3...) are initialized with 0x00 */
-    memset(mem + 3*MPK_PAGE_SIZE, 0, MEMPAK_SIZE - 3*MPK_PAGE_SIZE);
+    memset(page_3, 0, MEMPAK_SIZE - 3*MPK_PAGE_SIZE);
 }
 
 

--- a/src/device/controllers/paks/mempak.c
+++ b/src/device/controllers/paks/mempak.c
@@ -25,6 +25,7 @@
 #include "device/controllers/game_controller.h"
 #include "main/util.h"
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -33,6 +34,7 @@
  * Only used to ease offsets/pointers computation
  * DO NOT DEREFERENCE
  */
+#pragma pack(push, 1)
 struct id_block_serialized {
     uint32_t serial[6];
     uint16_t device_id;
@@ -40,10 +42,13 @@ struct id_block_serialized {
     uint8_t  version;
     uint16_t sum;
     uint16_t isum;
-} __attribute__((packed));
-_Static_assert(sizeof(struct id_block_serialized) == 32, "id_block_serialized must have a size of 32 bytes");
+};
+#pragma pack(pop)
+#if defined(static_assert)
+static_assert(sizeof(struct id_block_serialized) == 32, "id_block_serialized must have a size of 32 bytes");
+#endif
 
-static void checksum_id_block(unsigned char ptr[static sizeof(struct id_block_serialized)],
+static void checksum_id_block(unsigned char* ptr,
             uint16_t* sum, uint16_t* isum)
 {
     size_t i;
@@ -55,7 +60,7 @@ static void checksum_id_block(unsigned char ptr[static sizeof(struct id_block_se
     *isum = UINT16_C(0xfff2) - accu;
 }
 
-static uint8_t checksum_index_table(size_t count, unsigned char ptr[static count])
+static uint8_t checksum_index_table(size_t count, unsigned char* ptr)
 {
     unsigned sum = 0;
     while (count != 0) {
@@ -67,7 +72,7 @@ static uint8_t checksum_index_table(size_t count, unsigned char ptr[static count
     return (uint8_t)sum;
 }
 
-static void serialize_id_block(unsigned char ptr[static sizeof(struct id_block_serialized)], const uint32_t serial[6], uint16_t device_id, uint8_t banks, uint8_t version) {
+static void serialize_id_block(unsigned char *ptr, const uint32_t serial[6], uint16_t device_id, uint8_t banks, uint8_t version) {
 
     size_t i;
     /* _ should never be dereferenced - it is only used to ease pointer/offsets computation */

--- a/src/device/controllers/paks/mempak.h
+++ b/src/device/controllers/paks/mempak.h
@@ -27,6 +27,10 @@
 
 struct storage_backend_interface;
 
+#define DEFAULT_MEMPAK_DEVICEID UINT16_C(0x0001)
+#define DEFAULT_MEMPAK_BANKS    UINT8_C(0x01)
+#define DEFAULT_MEMPAK_VERSION  UINT8_C(0x00)
+
 struct mempak
 {
     void* storage;
@@ -35,7 +39,11 @@ struct mempak
 
 enum { MEMPAK_SIZE = 0x8000 };
 
-void format_mempak(uint8_t* mem);
+void format_mempak(uint8_t* mem,
+    const uint32_t serial[6],
+    uint16_t device_id,
+    uint8_t banks,
+    uint8_t version);
 
 void init_mempak(struct mempak* mpk,
                  void* storage,

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -260,18 +260,18 @@ void to_big_endian_buffer(void *buffer, size_t length, size_t count)
 /* Simple serialization primitives,
  * Use byte access to avoid alignment issues.
  */
-uint8_t load_beu8(const unsigned char ptr[static sizeof(uint8_t)])
+uint8_t load_beu8(const unsigned char *ptr)
 {
     return (uint8_t)ptr[0];
 }
 
-uint16_t load_beu16(const unsigned char ptr[static sizeof(uint16_t)])
+uint16_t load_beu16(const unsigned char *ptr)
 {
     return ((uint16_t)ptr[0] << 8)
          | ((uint16_t)ptr[1] << 0);
 }
 
-uint32_t load_beu32(const unsigned char ptr[static sizeof(uint32_t)])
+uint32_t load_beu32(const unsigned char *ptr)
 {
     return ((uint32_t)ptr[0] << 24)
          | ((uint32_t)ptr[1] << 16)
@@ -279,7 +279,7 @@ uint32_t load_beu32(const unsigned char ptr[static sizeof(uint32_t)])
          | ((uint32_t)ptr[3] <<  0);
 }
 
-uint64_t load_beu64(const unsigned char ptr[static sizeof(uint64_t)])
+uint64_t load_beu64(const unsigned char *ptr)
 {
     return ((uint64_t)ptr[0] << 56)
          | ((uint64_t)ptr[1] << 48)
@@ -292,18 +292,18 @@ uint64_t load_beu64(const unsigned char ptr[static sizeof(uint64_t)])
 }
 
 
-uint8_t load_leu8(const unsigned char ptr[static sizeof(uint8_t)])
+uint8_t load_leu8(const unsigned char *ptr)
 {
     return (uint8_t)ptr[0];
 }
 
-uint16_t load_leu16(const unsigned char ptr[static sizeof(uint16_t)])
+uint16_t load_leu16(const unsigned char *ptr)
 {
     return ((uint16_t)ptr[0] << 0)
          | ((uint16_t)ptr[1] << 8);
 }
 
-uint32_t load_leu32(const unsigned char ptr[static sizeof(uint32_t)])
+uint32_t load_leu32(const unsigned char *ptr)
 {
     return ((uint32_t)ptr[0] <<  0)
          | ((uint32_t)ptr[1] <<  8)
@@ -311,7 +311,7 @@ uint32_t load_leu32(const unsigned char ptr[static sizeof(uint32_t)])
          | ((uint32_t)ptr[3] << 24);
 }
 
-uint64_t load_leu64(const unsigned char ptr[static sizeof(uint64_t)])
+uint64_t load_leu64(const unsigned char *ptr)
 {
     return ((uint64_t)ptr[0] <<  0)
          | ((uint64_t)ptr[1] <<  8)
@@ -325,18 +325,18 @@ uint64_t load_leu64(const unsigned char ptr[static sizeof(uint64_t)])
 
 
 
-void store_beu8(uint8_t value, unsigned char ptr[static sizeof(value)])
+void store_beu8(uint8_t value, unsigned char *ptr)
 {
     ptr[0] = (uint8_t)value;
 }
 
-void store_beu16(uint16_t value, unsigned char ptr[static sizeof(value)])
+void store_beu16(uint16_t value, unsigned char *ptr)
 {
     ptr[0] = (uint8_t)(value >> 8);
     ptr[1] = (uint8_t)(value >> 0);
 }
 
-void store_beu32(uint32_t value, unsigned char ptr[static sizeof(value)])
+void store_beu32(uint32_t value, unsigned char *ptr)
 {
     ptr[0] = (uint8_t)(value >> 24);
     ptr[1] = (uint8_t)(value >> 16);
@@ -344,7 +344,7 @@ void store_beu32(uint32_t value, unsigned char ptr[static sizeof(value)])
     ptr[3] = (uint8_t)(value >>  0);
 }
 
-void store_beu64(uint64_t value, unsigned char ptr[static sizeof(value)])
+void store_beu64(uint64_t value, unsigned char *ptr)
 {
     ptr[0] = (uint8_t)(value >> 56);
     ptr[1] = (uint8_t)(value >> 48);
@@ -357,18 +357,18 @@ void store_beu64(uint64_t value, unsigned char ptr[static sizeof(value)])
 }
 
 
-void store_leu8(uint8_t value, unsigned char ptr[static sizeof(value)])
+void store_leu8(uint8_t value, unsigned char *ptr)
 {
     ptr[0] = (uint8_t)value;
 }
 
-void store_leu16(uint16_t value, unsigned char ptr[static sizeof(value)])
+void store_leu16(uint16_t value, unsigned char *ptr)
 {
     ptr[0] = (uint8_t)(value >> 0);
     ptr[1] = (uint8_t)(value >> 8);
 }
 
-void store_leu32(uint32_t value, unsigned char ptr[static sizeof(value)])
+void store_leu32(uint32_t value, unsigned char *ptr)
 {
     ptr[0] = (uint8_t)(value >>  0);
     ptr[1] = (uint8_t)(value >>  8);
@@ -376,7 +376,7 @@ void store_leu32(uint32_t value, unsigned char ptr[static sizeof(value)])
     ptr[3] = (uint8_t)(value >> 24);
 }
 
-void store_leu64(uint64_t value, unsigned char ptr[static sizeof(value)])
+void store_leu64(uint64_t value, unsigned char *ptr)
 {
     ptr[0] = (uint8_t)(value >>  0);
     ptr[1] = (uint8_t)(value >>  8);

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -257,6 +257,182 @@ void to_big_endian_buffer(void *buffer, size_t length, size_t count)
 #endif
 }
 
+/* Simple serialization primitives,
+ * Use byte access to avoid alignment issues.
+ */
+uint8_t load_beu8(const unsigned char ptr[static sizeof(uint8_t)])
+{
+    return (uint8_t)ptr[0];
+}
+
+uint16_t load_beu16(const unsigned char ptr[static sizeof(uint16_t)])
+{
+    return ((uint16_t)ptr[0] << 8)
+         | ((uint16_t)ptr[1] << 0);
+}
+
+uint32_t load_beu32(const unsigned char ptr[static sizeof(uint32_t)])
+{
+    return ((uint32_t)ptr[0] << 24)
+         | ((uint32_t)ptr[1] << 16)
+         | ((uint32_t)ptr[2] <<  8)
+         | ((uint32_t)ptr[3] <<  0);
+}
+
+uint64_t load_beu64(const unsigned char ptr[static sizeof(uint64_t)])
+{
+    return ((uint64_t)ptr[0] << 56)
+         | ((uint64_t)ptr[1] << 48)
+         | ((uint64_t)ptr[2] << 40)
+         | ((uint64_t)ptr[3] << 32)
+         | ((uint64_t)ptr[4] << 24)
+         | ((uint64_t)ptr[5] << 16)
+         | ((uint64_t)ptr[6] <<  8)
+         | ((uint64_t)ptr[7] <<  0);
+}
+
+
+uint8_t load_leu8(const unsigned char ptr[static sizeof(uint8_t)])
+{
+    return (uint8_t)ptr[0];
+}
+
+uint16_t load_leu16(const unsigned char ptr[static sizeof(uint16_t)])
+{
+    return ((uint16_t)ptr[0] << 0)
+         | ((uint16_t)ptr[1] << 8);
+}
+
+uint32_t load_leu32(const unsigned char ptr[static sizeof(uint32_t)])
+{
+    return ((uint32_t)ptr[0] <<  0)
+         | ((uint32_t)ptr[1] <<  8)
+         | ((uint32_t)ptr[2] << 16)
+         | ((uint32_t)ptr[3] << 24);
+}
+
+uint64_t load_leu64(const unsigned char ptr[static sizeof(uint64_t)])
+{
+    return ((uint64_t)ptr[0] <<  0)
+         | ((uint64_t)ptr[1] <<  8)
+         | ((uint64_t)ptr[2] << 16)
+         | ((uint64_t)ptr[3] << 24)
+         | ((uint64_t)ptr[4] << 32)
+         | ((uint64_t)ptr[5] << 40)
+         | ((uint64_t)ptr[6] << 48)
+         | ((uint64_t)ptr[7] << 56);
+}
+
+
+
+void store_beu8(uint8_t value, unsigned char ptr[static sizeof(value)])
+{
+    ptr[0] = (uint8_t)value;
+}
+
+void store_beu16(uint16_t value, unsigned char ptr[static sizeof(value)])
+{
+    ptr[0] = (uint8_t)(value >> 8);
+    ptr[1] = (uint8_t)(value >> 0);
+}
+
+void store_beu32(uint32_t value, unsigned char ptr[static sizeof(value)])
+{
+    ptr[0] = (uint8_t)(value >> 24);
+    ptr[1] = (uint8_t)(value >> 16);
+    ptr[2] = (uint8_t)(value >>  8);
+    ptr[3] = (uint8_t)(value >>  0);
+}
+
+void store_beu64(uint64_t value, unsigned char ptr[static sizeof(value)])
+{
+    ptr[0] = (uint8_t)(value >> 56);
+    ptr[1] = (uint8_t)(value >> 48);
+    ptr[2] = (uint8_t)(value >> 40);
+    ptr[3] = (uint8_t)(value >> 32);
+    ptr[4] = (uint8_t)(value >> 24);
+    ptr[5] = (uint8_t)(value >> 16);
+    ptr[6] = (uint8_t)(value >>  8);
+    ptr[7] = (uint8_t)(value >>  0);
+}
+
+
+void store_leu8(uint8_t value, unsigned char ptr[static sizeof(value)])
+{
+    ptr[0] = (uint8_t)value;
+}
+
+void store_leu16(uint16_t value, unsigned char ptr[static sizeof(value)])
+{
+    ptr[0] = (uint8_t)(value >> 0);
+    ptr[1] = (uint8_t)(value >> 8);
+}
+
+void store_leu32(uint32_t value, unsigned char ptr[static sizeof(value)])
+{
+    ptr[0] = (uint8_t)(value >>  0);
+    ptr[1] = (uint8_t)(value >>  8);
+    ptr[2] = (uint8_t)(value >> 16);
+    ptr[3] = (uint8_t)(value >> 24);
+}
+
+void store_leu64(uint64_t value, unsigned char ptr[static sizeof(value)])
+{
+    ptr[0] = (uint8_t)(value >>  0);
+    ptr[1] = (uint8_t)(value >>  8);
+    ptr[2] = (uint8_t)(value >> 16);
+    ptr[3] = (uint8_t)(value >> 24);
+    ptr[4] = (uint8_t)(value >> 32);
+    ptr[5] = (uint8_t)(value >> 40);
+    ptr[6] = (uint8_t)(value >> 48);
+    ptr[7] = (uint8_t)(value >> 56);
+}
+
+
+/**********************
+    Random utilities
+ **********************/
+
+static inline uint64_t rotl(uint64_t x, int k) {
+	return (x << k) | (x >> (64 - k));
+}
+
+struct splitmix64_state { uint64_t x; };
+
+static uint64_t splitmix64_next(struct splitmix64_state* s) {
+	uint64_t z = (s->x += 0x9e3779b97f4a7c15);
+	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+	z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+	return z ^ (z >> 31);
+}
+
+struct xoshiro256pp_state xoshiro256pp_seed(uint64_t seed)
+{
+    struct xoshiro256pp_state xs;
+    struct splitmix64_state ss = { seed };
+
+    size_t i;
+    for (i = 0; i < 4; ++i) {
+        xs.s[i] = splitmix64_next(&ss);
+    }
+
+    return xs;
+}
+
+uint64_t xoshiro256pp_next(struct xoshiro256pp_state* s) {
+    uint64_t result = rotl(s->s[0] + s->s[3], 23) + s->s[0];
+
+    uint64_t t = s->s[1] << 17;
+    s->s[2] ^= s->s[0];
+    s->s[3] ^= s->s[1];
+    s->s[1] ^= s->s[2];
+    s->s[0] ^= s->s[3];
+    s->s[2] ^= t;
+    s->s[3] = rotl(s->s[3], 45);
+
+    return result;
+}
+
 /**********************
      GUI utilities
  **********************/

--- a/src/main/util.h
+++ b/src/main/util.h
@@ -150,6 +150,41 @@ void swap_buffer(void *buffer, size_t length, size_t count);
 void to_little_endian_buffer(void *buffer, size_t length, size_t count);
 void to_big_endian_buffer(void *buffer, size_t length, size_t count);
 
+
+/* Simple serialization primitives,
+ * Loosely modeled after N2827 <stdbit.h> proposal.
+ */
+uint8_t load_beu8(const unsigned char ptr[static sizeof(uint8_t)]);
+uint16_t load_beu16(const unsigned char ptr[static sizeof(uint16_t)]);
+uint32_t load_beu32(const unsigned char ptr[static sizeof(uint32_t)]);
+uint64_t load_beu64(const unsigned char ptr[static sizeof(uint64_t)]);
+
+uint8_t load_leu8(const unsigned char ptr[static sizeof(uint8_t)]);
+uint16_t load_leu16(const unsigned char ptr[static sizeof(uint16_t)]);
+uint32_t load_leu32(const unsigned char ptr[static sizeof(uint32_t)]);
+uint64_t load_leu64(const unsigned char ptr[static sizeof(uint64_t)]);
+
+void store_beu8(uint8_t value, unsigned char ptr[static sizeof(value)]);
+void store_beu16(uint16_t value, unsigned char ptr[static sizeof(value)]);
+void store_beu32(uint32_t value, unsigned char ptr[static sizeof(value)]);
+void store_beu64(uint64_t value, unsigned char ptr[static sizeof(value)]);
+
+void store_leu8(uint8_t value, unsigned char ptr[static sizeof(value)]);
+void store_leu16(uint16_t value, unsigned char ptr[static sizeof(value)]);
+void store_leu32(uint32_t value, unsigned char ptr[static sizeof(value)]);
+void store_leu64(uint64_t value, unsigned char ptr[static sizeof(value)]);
+
+
+/**********************
+    Random utilities
+ **********************/
+
+struct xoshiro256pp_state { uint64_t s[4]; };
+
+struct xoshiro256pp_state xoshiro256pp_seed(uint64_t seed);
+
+uint64_t xoshiro256pp_next(struct xoshiro256pp_state* s);
+
 /**********************
      GUI utilities
  **********************/

--- a/src/main/util.h
+++ b/src/main/util.h
@@ -154,25 +154,25 @@ void to_big_endian_buffer(void *buffer, size_t length, size_t count);
 /* Simple serialization primitives,
  * Loosely modeled after N2827 <stdbit.h> proposal.
  */
-uint8_t load_beu8(const unsigned char ptr[static sizeof(uint8_t)]);
-uint16_t load_beu16(const unsigned char ptr[static sizeof(uint16_t)]);
-uint32_t load_beu32(const unsigned char ptr[static sizeof(uint32_t)]);
-uint64_t load_beu64(const unsigned char ptr[static sizeof(uint64_t)]);
+uint8_t load_beu8(const unsigned char *ptr);
+uint16_t load_beu16(const unsigned char *ptr);
+uint32_t load_beu32(const unsigned char *ptr);
+uint64_t load_beu64(const unsigned char *ptr);
 
-uint8_t load_leu8(const unsigned char ptr[static sizeof(uint8_t)]);
-uint16_t load_leu16(const unsigned char ptr[static sizeof(uint16_t)]);
-uint32_t load_leu32(const unsigned char ptr[static sizeof(uint32_t)]);
-uint64_t load_leu64(const unsigned char ptr[static sizeof(uint64_t)]);
+uint8_t load_leu8(const unsigned char *ptr);
+uint16_t load_leu16(const unsigned char *ptr);
+uint32_t load_leu32(const unsigned char *ptr);
+uint64_t load_leu64(const unsigned char *ptr);
 
-void store_beu8(uint8_t value, unsigned char ptr[static sizeof(value)]);
-void store_beu16(uint16_t value, unsigned char ptr[static sizeof(value)]);
-void store_beu32(uint32_t value, unsigned char ptr[static sizeof(value)]);
-void store_beu64(uint64_t value, unsigned char ptr[static sizeof(value)]);
+void store_beu8(uint8_t value, unsigned char *ptr);
+void store_beu16(uint16_t value, unsigned char *ptr);
+void store_beu32(uint32_t value, unsigned char *ptr);
+void store_beu64(uint64_t value, unsigned char *ptr);
 
-void store_leu8(uint8_t value, unsigned char ptr[static sizeof(value)]);
-void store_leu16(uint16_t value, unsigned char ptr[static sizeof(value)]);
-void store_leu32(uint32_t value, unsigned char ptr[static sizeof(value)]);
-void store_leu64(uint64_t value, unsigned char ptr[static sizeof(value)]);
+void store_leu8(uint8_t value, unsigned char *ptr);
+void store_leu16(uint16_t value, unsigned char *ptr);
+void store_leu32(uint32_t value, unsigned char *ptr);
+void store_leu64(uint64_t value, unsigned char *ptr);
 
 
 /**********************


### PR DESCRIPTION
- also better conform to expected factory formatted state
according to @bryc research
- unique mempak ID is based on xoshiro256++ PRNG seeded with current
  time. This should prove good enough for our purpose, while still being
  simple to implement.
- added endian aware serialization primitives (loosely modeled after http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2827.htm)
- added xoshiro256++ PRNG functions