### PR TITLE
Allow frontends to know what DD ROM region they should use

### DIFF
--- a/doc/emuwiki-api-doc/Mupen64Plus-v2.0-headers.mediawiki
+++ b/doc/emuwiki-api-doc/Mupen64Plus-v2.0-headers.mediawiki
@@ -162,6 +162,12 @@
    */
   char* (*get_gb_cart_ram)(void* cb_data, int controller_num);
 
+  /* Allow the frontend to know what DD IPL ROM region file to load
+   * cb_data: points to frontend-defined callback data.
+   * region: a region from m64p_system_type
+   */
+  void (*set_dd_rom_region)(void* cb_data, uint8_t region);
+
   /* Allow the frontend to specify the DD IPL ROM file to load
    * cb_data: points to frontend-defined callback data.
    * Returns a NULL-terminated string owned by the core specifying the DD IPL ROM filename to load

--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -196,6 +196,12 @@ typedef struct {
    */
   char* (*get_gb_cart_ram)(void* cb_data, int controller_num);
 
+  /* Allow the frontend to know what DD IPL ROM region file to load
+   * cb_data: points to frontend-defined callback data.
+   * region: a region from m64p_system_type
+   */
+  void (*set_dd_rom_region)(void* cb_data, uint8_t region);
+
   /* Allow the frontend to specify the DD IPL ROM file to load
    * cb_data: points to frontend-defined callback data.
    * Returns a NULL-terminated string owned by the core specifying the DD IPL ROM filename to load
@@ -234,6 +240,14 @@ typedef enum
     SAVETYPE_CONTROLLER_PACK = 4, // Preserve inaccurate/off-brand name
     SAVETYPE_NONE            = 5,
 } m64p_rom_save_type;
+
+typedef enum
+{
+    DDREGION_JAPAN   = 0,
+    DDREGION_US      = 1,
+    DDREGION_DEV     = 2,
+    DDREGION_UNKNOWN = 3,
+} m64p_disk_region;
 
 typedef struct
 {

--- a/src/device/dd/disk.h
+++ b/src/device/dd/disk.h
@@ -149,6 +149,7 @@ struct dd_disk
     uint16_t lba_phys_table[0x10DC];
     uint8_t format;
     uint8_t development;
+    uint8_t region;
     size_t offset_sys;
     size_t offset_id;
     size_t offset_ram;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1172,7 +1172,7 @@ static int load_dd_disk(struct dd_disk* dd_disk, const struct storage_backend_in
     if (save_format == 0)
     {
         if (open_rom_file_storage(fstorage, save_filename) != file_ok) {
-            DebugMessage(M64MSG_ERROR, "Failed to load DD Disk save: %s.", save_filename);
+            DebugMessage(M64MSG_WARNING, "Failed to load DD Disk save: %s.", save_filename);
 
             /* Try loading regular disk file */
             if (open_rom_file_storage(fstorage, dd_disk_filename) != file_ok) {
@@ -1218,7 +1218,7 @@ static int load_dd_disk(struct dd_disk* dd_disk, const struct storage_backend_in
     {
         if (read_from_file(save_filename, &fstorage->data[offset_ram], size_ram) != file_ok)
         {
-            DebugMessage(M64MSG_ERROR, "Failed to load DD Disk RAM area (*.ram): %s.", save_filename);
+            DebugMessage(M64MSG_WARNING, "Failed to load DD Disk RAM area (*.ram): %s.", save_filename);
         }
     }
 


### PR DESCRIPTION
This adds a function called `set_dd_rom_region` to the media loader, allowing frontends to easily switch 64DD ROM based on DD disk region.