### PR TITLE
Use a predictable seed when using netplay

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1486,7 +1486,8 @@ m64p_error main_run(void)
     }
 
     /* Seed MPK ID gen using current time */
-    l_mpk_idgen = xoshiro256pp_seed((uint64_t)time(NULL));
+    uint64_t mpk_seed = !netplay_is_init() ? (uint64_t)time(NULL) : 0;
+    l_mpk_idgen = xoshiro256pp_seed(mpk_seed);
 
     /* take the r4300 emulator mode from the config file at this point and cache it in a global variable */
     emumode = ConfigGetParamInt(g_CoreConfig, "R4300Emulator");


### PR DESCRIPTION
I hadn't thought of this for the mempak PR, but I think there is a small possibility of netplay desyncs because of the randomized mempak IDs.

If the mempak save file already exists, it won't be a problem, because netplay will sync P1's mempak with the other players, but if no mempak save file exists, netplay will just let each player create their own file.

Because of this randomization, each mempak will be slightly different. I don't know if this would cause desyncs, because I can't say for sure if a game reads a mempak to create some RNG or something.

This PR uses a constant seed for generating the mempak ID when netplay is active.

@bsmiles32 