### PR TITLE
Add support for clang/mingw targets

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -255,9 +255,13 @@ ifeq ($(OS), OSX)
 endif
 ifeq ($(OS), MINGW)
   TARGET = mupen64plus$(POSTFIX).dll
-  LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-all-symbols
-  # only export api symbols
-  LDFLAGS += -Wl,-version-script,$(SRCDIR)/api/api_export.ver
+  ifeq ($(CC), clang)
+    LDFLAGS += -shared -Wl,-export-all-symbols
+  else
+    LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-all-symbols
+    # only export api symbols
+    LDFLAGS += -Wl,-version-script,$(SRCDIR)/api/api_export.ver
+  endif
   LDLIBS += -lpthread
   ifeq ($(ARCH_DETECTED), 64BITS)
     ASFLAGS = -f win64 -d WIN64


### PR DESCRIPTION
clang built mingw doesn't support -Bsymbolic
or version scripts unfortunetly

Signed-off-by: Zach Bacon <zachbacon@vba-m.com>