### PR TITLE
Initialize dd_rom_size to 0 if load_dd_disk fails to fix possible runtime errors during initialization

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1615,6 +1615,10 @@ m64p_error main_run(void)
         dd_rtc_iclock = &g_iclock_ctime_plus_delta;
         load_dd_rom((uint8_t*)mem_base_u32(g_mem_base, MM_DD_ROM), &dd_rom_size, &dd_disk.region);
     }
+    else
+    {
+        dd_rom_size = 0;
+    }
 
     /* setup pif channel devices */
     void* joybus_devices[PIF_CHANNELS_COUNT];


### PR DESCRIPTION
As described in my comment on [PR #920](https://github.com/mupen64plus/mupen64plus-core/pull/920#issuecomment-1159220266).

> This PR seems to have introduced a runtime error where `dd_rom_size` can now be uninitialized in the `main_run` function because `load_dd_rom` has been moved inside the branch and executed only if `load_dd_disk` succeeds.
> It seems `init_device` relies on `dd_rom_size` being correctly initialized later, so this seems to introduce a random chance of incorrect behavior based on whether `dd_rom_size` happens to be 0 or not.
> I haven't actually ran into the error myself, but MSVC's debugger caught this pretty quickly on the Debug configuration and would not allow me to run further until it was fixed.
> The obvious solution to me seems to just handle the else case on the branch mentioned above, but I figured I'd report it first to the original submitter before making a PR myself.

If you'd prefer the default initialization to be handled differently rather than explicitly on the else branch, let me know.