### PR TITLE
3 LSBs of AI Length must be 0

### DIFF
--- a/src/device/rcp/ai/ai_controller.c
+++ b/src/device/rcp/ai/ai_controller.c
@@ -105,14 +105,14 @@ static void fifo_push(struct ai_controller* ai)
     if (ai->regs[AI_STATUS_REG] & AI_STATUS_BUSY)
     {
         ai->fifo[1].address = ai->regs[AI_DRAM_ADDR_REG];
-        ai->fifo[1].length = ai->regs[AI_LEN_REG];
+        ai->fifo[1].length = ai->regs[AI_LEN_REG] & ~UINT32_C(7);
         ai->fifo[1].duration = duration;
         ai->regs[AI_STATUS_REG] |= AI_STATUS_FULL;
     }
     else
     {
         ai->fifo[0].address = ai->regs[AI_DRAM_ADDR_REG];
-        ai->fifo[0].length = ai->regs[AI_LEN_REG];
+        ai->fifo[0].length = ai->regs[AI_LEN_REG] & ~UINT32_C(7);
         ai->fifo[0].duration = duration;
         ai->regs[AI_STATUS_REG] |= AI_STATUS_BUSY;
 


### PR DESCRIPTION
The 3 least significant bits of the AI_LEN register are expected to be 0.

See this test ROM:
https://www.dropbox.com/sh/am52g0hpfqh71ll/AACKhhfaijdnH1gsFAaSjr0ia/lossless?dl=0&subfolder_nav_tracking=1

Audio doesn't work without this fix

Ares: https://github.com/ares-emulator/ares/blob/3767568cdbe0ad7f18782c2bd03e022b8feec841/ares/n64/ai/io.cpp#L36
CEN64: https://github.com/n64dev/cen64/blob/73ad38ca3fe1fcf46362158ac1c088cda52f0cf0/ai/controller.c#L217