### PR TITLE
Proper response when eeprom absent

### DIFF
--- a/src/device/cart/cart.c
+++ b/src/device/cart/cart.c
@@ -51,6 +51,9 @@ static void process_cart_command(void* jbd,
             rx_buf[1] = (uint8_t)(cart->eeprom.type >> 8);
             rx_buf[2] = 0x00;
         }
+        else {
+            *rx |= 0x80;
+        }
     } break;
 
     case JCMD_EEPROM_READ: {


### PR DESCRIPTION
The cartridge should return 0x80 if EEPROM is absent, the same as it does when a controller is absent:

https://github.com/mupen64plus/mupen64plus-core/blob/300cd1e9175d7ab744a64fbf8a7786cefca668a3/src/device/controllers/game_controller.c#L191

This allows Powerpuff Girls, The - Chemical X-Traction to boot. This game doesn't support saving, but seems to specifically ensure that EEPROM is absent before booting.