### PR TITLE
Fix crash due to SDL_SetVideoMode in SDL 2 compatibility code.

### DIFF
--- a/src/api/vidext_sdl2_compat.h
+++ b/src/api/vidext_sdl2_compat.h
@@ -474,8 +474,14 @@ SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags)
         if (SDL_GL_MakeCurrent(SDL_VideoWindow, SDL_VideoContext) < 0) {
             return NULL;
         }
+
+        /* Pitch: size of of line in bytes */
+        /* Add 7 to bpp before division, to ensure correct rounding towards infinity
+         * in cases where bits per pixel do not cleanly divide by 8 (such as 15)
+         */
+        int pitch = (bpp + 7) / 8 * width;
         SDL_VideoSurface =
-            SDL_CreateRGBSurfaceFrom(NULL, width, height, bpp, 0, 0, 0, 0, 0);
+            SDL_CreateRGBSurfaceFrom(NULL, width, height, bpp, pitch, 0, 0, 0, 0);
         if (!SDL_VideoSurface) {
             return NULL;
         }


### PR DESCRIPTION
Fix wrong pitch argument in call to `SDL_CreateRGBSurfaceFrom` in SDL 1.2 compatibility code for `SDL_SetVideoMode`.

`SDL_CreateRGBSurfaceFrom` wants an argument `pitch` that is the number of bytes per scan line in the surface. Previously, 0 was passed as the pitch and it worked. However, as of SDL 2.24, this is not accepted anymore, which results in a crash of the emulator.   