### PR TITLE
use MD5 for save filename

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -343,6 +343,12 @@ const char *get_savesrampath(void)
     return get_savepathdefault(ConfigGetParamString(g_CoreConfig, "SaveSRAMPath"));
 }
 
+const char *get_savestatefilename(void)
+{
+    /* return same file name as save files */
+    return get_save_filename();
+}
+
 void main_message(m64p_msg_level level, unsigned int corner, const char *format, ...)
 {
     va_list ap;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -160,24 +160,83 @@ static const char *get_savepathdefault(const char *configpath)
     return path;
 }
 
+static char *get_save_filename(void)
+{
+    static char filename[256];
+
+    if (strstr(ROM_SETTINGS.goodname, "(unknown rom)") == NULL) {
+        snprintf(filename, 256, "%.32s-%.8s", ROM_SETTINGS.goodname, ROM_SETTINGS.MD5);
+    } else if (ROM_HEADER.Name[0] != 0) {
+        snprintf(filename, 256, "%s-%.8s", ROM_PARAMS.headername, ROM_SETTINGS.MD5);
+    } else {
+        snprintf(filename, 256, "unknown-%.8s", ROM_SETTINGS.MD5);
+    }
+
+    return filename;
+}
+
 static char *get_mempaks_path(void)
 {
-    return formatstr("%s%s.mpk", get_savesrampath(), ROM_SETTINGS.goodname);
+    char *path;
+    size_t size = 0;
+
+    /* check if old file path exists, if it does then use that */
+    path = formatstr("%s%s.mpk", get_savesrampath(), ROM_SETTINGS.goodname);
+    if (get_file_size(path, &size) == file_ok && size > 0)
+    {
+        return path;
+    }
+
+    /* else use new path */
+    return formatstr("%s%s.mpk", get_savesrampath(), get_save_filename());
 }
 
 static char *get_eeprom_path(void)
 {
-    return formatstr("%s%s.eep", get_savesrampath(), ROM_SETTINGS.goodname);
+    char *path;
+    size_t size = 0;
+
+    /* check if old file path exists, if it does then use that */
+    path = formatstr("%s%s.eep", get_savesrampath(), ROM_SETTINGS.goodname);
+    if (get_file_size(path, &size) == file_ok && size > 0)
+    {
+        return path;
+    }
+
+    /* else use new path */
+    return formatstr("%s%s.eep", get_savesrampath(), get_save_filename());
 }
 
 static char *get_sram_path(void)
 {
-    return formatstr("%s%s.sra", get_savesrampath(), ROM_SETTINGS.goodname);
+    char *path;
+    size_t size = 0;
+
+    /* check if old file path exists, if it does then use that */
+    path = formatstr("%s%s.sra", get_savesrampath(), ROM_SETTINGS.goodname);
+    if (get_file_size(path, &size) == file_ok && size > 0)
+    {
+        return path;
+    }
+
+    /* else use new path */
+    return formatstr("%s%s.sra", get_savesrampath(), get_save_filename());
 }
 
 static char *get_flashram_path(void)
 {
-    return formatstr("%s%s.fla", get_savesrampath(), ROM_SETTINGS.goodname);
+    char *path;
+    size_t size = 0;
+
+    /* check if old file path exists, if it does then use that */
+    path = formatstr("%s%s.fla", get_savesrampath(), ROM_SETTINGS.goodname);
+    if (get_file_size(path, &size) == file_ok && size > 0)
+    {
+        return path;
+    }
+
+    /* else use new path */
+    return formatstr("%s%s.fla", get_savesrampath(), get_save_filename());
 }
 
 static char *get_gb_ram_path(const char* gbrom, unsigned int control_id)

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -57,6 +57,7 @@ extern int g_gs_vi_counter;
 
 const char* get_savestatepath(void);
 const char* get_savesrampath(void);
+const char* get_savestatefilename(void);
 
 void new_frame(void);
 void new_vi(void);

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -86,31 +86,32 @@ static char *savestates_generate_path(savestates_type type)
     }
     else /* Use the selected savestate slot */
     {
-        char *filename;
+        char *filepath;
+        size_t size = 0;
+
         switch (type)
         {
             case savestates_type_m64p:
-                filename = formatstr("%s.st%d", ROM_SETTINGS.goodname, slot);
+                /* check if old file path exists, if it does then use that */
+                filepath = formatstr("%s%s.st%d", get_savestatepath(), ROM_SETTINGS.goodname, slot);
+                if (get_file_size(filepath, &size) != file_ok || size == 0)
+                {
+                    /* else use new path */
+                    filepath = formatstr("%s%s.st%d", get_savestatepath(), get_savestatefilename(), slot);
+                }
                 break;
             case savestates_type_pj64_zip:
-                filename = formatstr("%s.pj%d.zip", ROM_PARAMS.headername, slot);
+                filepath = formatstr("%s%s.pj%d.zip", get_savestatepath(), ROM_PARAMS.headername, slot);
                 break;
             case savestates_type_pj64_unc:
-                filename = formatstr("%s.pj%d", ROM_PARAMS.headername, slot);
+                filepath = formatstr("%s%s.pj%d", get_savestatepath(), ROM_PARAMS.headername, slot);
                 break;
             default:
-                filename = NULL;
+                filepath = NULL;
                 break;
         }
 
-        if (filename != NULL)
-        {
-            char *filepath = formatstr("%s%s", get_savestatepath(), filename);
-            free(filename);
-            return filepath;
-        }
-        else
-            return NULL;
+        return filepath;
     }
 }
 


### PR DESCRIPTION
This makes mupen64plus-core use the ROM's MD5 for the save filename, this makes more sense because let's assume you have a patched ROM, the GoodName will be `Game (Unknown ROM)`, now let's assume you have another patched ROM that uses the same base game, then the saves of patched ROM 1 will show up in patched ROM 2, which is undesired and will most likely break stuff.