### PR TITLE
Add SAVETYPE_AUTO

### DIFF
--- a/src/api/m64p_types.h
+++ b/src/api/m64p_types.h
@@ -239,6 +239,7 @@ typedef enum
     SAVETYPE_CONTROLLER_PAK  = 4,
     SAVETYPE_CONTROLLER_PACK = 4, // Preserve inaccurate/off-brand name
     SAVETYPE_NONE            = 5,
+    SAVETYPE_AUTO            = 6,
 } m64p_rom_save_type;
 
 typedef enum

--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -219,8 +219,8 @@ m64p_error open_rom(const unsigned char* romimage, unsigned int size)
         }
         else
         {
-            /* There's no way to guess the save type, but 4K EEPROM is better than nothing */
-            ROM_SETTINGS.savetype = SAVETYPE_EEPROM_4K;
+            /* Use first used savetype */
+            ROM_SETTINGS.savetype = SAVETYPE_AUTO;
         }
     }
 


### PR DESCRIPTION
This works in the same way as the Project64 option 'Use first used save type', this is handy for ROMs that aren't in the RDB (i.e romhacks, patched ROMs) and will allow those games to be able to save properly.