### PR TITLE
Improve 64DD emulation

### DIFF
--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -550,6 +550,11 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
             dd->regs[DD_ASIC_DATA] = time2data(tm->tm_min, tm->tm_sec);
             break;
 
+        /* LED On/Off Timing */
+        case 0x15:
+            DebugMessage(M64MSG_VERBOSE, "LED ON Time %02x, LED OFF Time %02x", (dd->regs[DD_ASIC_DATA] & 0xff000000) >> 24, (dd->regs[DD_ASIC_DATA] & 0x00ff0000) >> 16);
+            break;
+
         /* Feature inquiry */
         case 0x1b:
             dd->regs[DD_ASIC_DATA] = 0x00030000;

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -129,6 +129,18 @@ static void clear_dd_interrupt(struct dd_controller* dd, uint32_t bm_int)
     r4300_check_interrupt(dd->r4300, CP0_CAUSE_IP3, 0);
 }
 
+void dd_mecha_int_handler(void* opaque)
+{
+    struct dd_controller* dd = (struct dd_controller*)opaque;
+    signal_dd_interrupt(dd, DD_STATUS_MECHA_INT);
+}
+
+void dd_bm_int_handler(void* opaque)
+{
+    struct dd_controller* dd = (struct dd_controller*)opaque;
+    signal_dd_interrupt(dd, DD_STATUS_BM_INT);
+}
+
 static void read_C2(struct dd_controller* dd)
 {
     size_t i;

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -530,7 +530,12 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         /* Set Disk type */
         case 0x0b:
             dd->disk_type = (dd->regs[DD_ASIC_DATA] >> 16) & 0xf;
-            DebugMessage(M64MSG_VERBOSE, "Setting disk type %u", dd->disk_type);
+            if (dd->disk_type > 6) {
+                DebugMessage(M64MSG_VERBOSE, "Setting invalid disk type %u, set to fallback disk type 6", dd->disk_type);
+                dd->disk_type = 6;
+            } else {
+                DebugMessage(M64MSG_VERBOSE, "Setting disk type %u", dd->disk_type);
+            }
             break;
 
         /* Request controller status */

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -447,7 +447,7 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
             /* if write seek command, check if the track is writable */
             dd->regs[DD_ASIC_CMD_STATUS] &= ~DD_STATUS_WR_PR_ERR;
             if (dd->bm_write) {
-                if (track < startTrackZones[(dd->disk_type & 0xf) + head + 3]) {
+                if (track < startTrackZones[(dd->disk_type & 0xf) - head + 3]) {
                     dd->regs[DD_ASIC_CMD_STATUS] |= DD_STATUS_WR_PR_ERR;
                 }
             }

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -622,6 +622,15 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         if (value != 0xaaaa0000) {
             DebugMessage(M64MSG_WARNING, "Unexpected hard reset value %08x", value);
         }
+        remove_event(&dd->r4300->cp0.q, DD_MC_INT);
+        remove_event(&dd->r4300->cp0.q, DD_BM_INT);
+        dd->regs[DD_ASIC_CMD_STATUS] &= ~(DD_STATUS_DATA_RQ
+                                        | DD_STATUS_C2_XFER
+                                        | DD_STATUS_BM_ERR
+                                        | DD_STATUS_BM_INT);
+        dd->regs[DD_ASIC_BM_STATUS_CTL] = 0;
+        dd->regs[DD_ASIC_CUR_SECTOR] = 0;
+        clear_dd_interrupt(dd, DD_STATUS_MECHA_INT);
         dd->regs[DD_ASIC_CMD_STATUS] |= DD_STATUS_RST_STATE;
         break;
 

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -528,6 +528,17 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
             DebugMessage(M64MSG_VERBOSE, "Retry disk track lock");
             break;
 
+        /* Write RTC from ASIC_DATA (BCD format) */
+        case 0x0f:
+            DebugMessage(M64MSG_VERBOSE, "Write 64DD RTC Year %02x, Month %02x", (dd->regs[DD_ASIC_DATA] & 0xff000000) >> 24, (dd->regs[DD_ASIC_DATA] & 0x00ff0000) >> 16);
+            break;
+        case 0x10:
+            DebugMessage(M64MSG_VERBOSE, "Write 64DD RTC Day %02x, Hour %02x", (dd->regs[DD_ASIC_DATA] & 0xff000000) >> 24, (dd->regs[DD_ASIC_DATA] & 0x00ff0000) >> 16);
+            break;
+        case 0x11:
+            DebugMessage(M64MSG_VERBOSE, "Write 64DD RTC Minute %02x, Second %02x", (dd->regs[DD_ASIC_DATA] & 0xff000000) >> 24, (dd->regs[DD_ASIC_DATA] & 0x00ff0000) >> 16);
+            break;
+
         /* Read RTC in ASIC_DATA (BCD format) */
         case 0x12:
             dd->regs[DD_ASIC_DATA] = time2data(tm->tm_year, tm->tm_mon + 1);

--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -369,7 +369,7 @@ void read_dd_regs(void* opaque, uint32_t address, uint32_t* value)
             /* acknowledge BM interrupt */
             if (dd->regs[DD_ASIC_CMD_STATUS] & DD_STATUS_BM_INT) {
                 clear_dd_interrupt(dd, DD_STATUS_BM_INT);
-                add_interrupt_event(&dd->r4300->cp0, DD_BM_INT, (16040 + (((dd->regs[DD_ASIC_CUR_TK] & 0x0fff0000) >> 16) / 35)) / dd->r4300->cp0.count_per_op);
+                add_interrupt_event(&dd->r4300->cp0, DD_BM_INT, 8020 + (((dd->regs[DD_ASIC_CUR_TK] & 0x0fff0000) >> 16) / 56));
             }
         } break;
     }
@@ -402,7 +402,7 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         const struct tm* tm = localtime(&dd->rtc.now);
 
         /* base cycle count */
-        cycles = 4000;
+        cycles = 2000;
 
         switch ((value >> 16) & 0xff)
         {
@@ -414,7 +414,7 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         case 0x01:
         case 0x02:
             /* base timing cycle count for Seek track CMD */
-            cycles = 496500;
+            cycles = 248250;
             /* get old track for calculating extra cycles */
             old_track = (dd->regs[DD_ASIC_CUR_TK] & 0x0fff0000) >> 16;
             /* update track */
@@ -427,7 +427,7 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
             track = (dd->regs[DD_ASIC_CUR_TK] & 0x0fff0000) >> 16;
             dd->bm_zone = (get_zone_from_head_track(head, track) - head) + 8*head;
             /* calculate track to track head movement timing */
-            cycles += 9650 * abs(track - old_track);
+            cycles += 4825 * abs(track - old_track);
             break;
 
         /* Clear Disk change flag */
@@ -468,7 +468,7 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
 
         /* Signal a MECHA interrupt */
         cp0_update_count(dd->r4300);
-        add_interrupt_event(&dd->r4300->cp0, DD_MC_INT, cycles / dd->r4300->cp0.count_per_op);
+        add_interrupt_event(&dd->r4300->cp0, DD_MC_INT, cycles);
         break;
 
     case DD_ASIC_BM_STATUS_CTL:
@@ -515,7 +515,7 @@ void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
                 DebugMessage(M64MSG_WARNING, "Attempt to read disk with BM mode 0");
             }
             dd->regs[DD_ASIC_BM_STATUS_CTL] |= DD_BM_STATUS_RUNNING;
-            add_interrupt_event(&dd->r4300->cp0, DD_BM_INT, 25000 / dd->r4300->cp0.count_per_op);
+            add_interrupt_event(&dd->r4300->cp0, DD_BM_INT, 12500);
         }
         break;
 

--- a/src/device/dd/dd_controller.h
+++ b/src/device/dd/dd_controller.h
@@ -123,4 +123,7 @@ unsigned int dd_dom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, u
 void dd_on_pi_cart_addr_write(struct dd_controller* dd, uint32_t address);
 void dd_update_bm(void* opaque);
 
+void dd_mecha_int_handler(void* opaque);
+void dd_bm_int_handler(void* opaque);
+
 #endif

--- a/src/device/dd/dd_controller.h
+++ b/src/device/dd/dd_controller.h
@@ -75,6 +75,8 @@ struct dd_controller
 
     /* drive controller */
     unsigned char disk_type;        /* [0-6] */
+    short timer_standby;            /* -1 = Disabled, in seconds */
+    short timer_sleep;              /* -1 = Disabled, in seconds */
 
     /* buffer manager */
     unsigned char bm_write;         /* [0-1] */
@@ -127,5 +129,6 @@ void dd_update_bm(void* opaque);
 
 void dd_mecha_int_handler(void* opaque);
 void dd_bm_int_handler(void* opaque);
+void dd_dv_int_handler(void* opaque);
 
 #endif

--- a/src/device/dd/dd_controller.h
+++ b/src/device/dd/dd_controller.h
@@ -120,7 +120,6 @@ void write_dd_rom(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 unsigned int dd_dom_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
 unsigned int dd_dom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
 
-void dd_on_pi_cart_addr_write(struct dd_controller* dd, uint32_t address);
 void dd_update_bm(void* opaque);
 
 void dd_mecha_int_handler(void* opaque);

--- a/src/device/dd/dd_controller.h
+++ b/src/device/dd/dd_controller.h
@@ -73,6 +73,9 @@ struct dd_controller
     uint8_t ds_buf[0x100];              /* 0x400-0x4ff: data buffer */
     uint8_t ms_ram[0x40];               /* 0x580-0x5bf: micro sequencer */
 
+    /* drive controller */
+    unsigned char disk_type;        /* [0-6] */
+
     /* buffer manager */
     unsigned char bm_write;         /* [0-1] */
     unsigned char bm_reset_held;    /* [0-1] */

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -127,6 +127,7 @@ void init_device(struct device* dev,
         { &dev->sp,        rsp_end_of_dma_event        },
         { &dev->dd,        dd_mecha_int_handler        }, /* DD MECHA */
         { &dev->dd,        dd_bm_int_handler           }, /* DD BM */
+        { &dev->dd,        dd_dv_int_handler           }, /* DD DRIVE */
     };
 
 #define R(x) read_ ## x

--- a/src/device/device.c
+++ b/src/device/device.c
@@ -124,7 +124,9 @@ void init_device(struct device* dev,
         { &dev->pif,       hw2_int_handler             }, /* HW2 */
         { dev,             nmi_int_handler             }, /* NMI */
         { dev,             reset_hard_handler          }, /* reset_hard */
-        { &dev->sp,        rsp_end_of_dma_event        }
+        { &dev->sp,        rsp_end_of_dma_event        },
+        { &dev->dd,        dd_mecha_int_handler        }, /* DD MECHA */
+        { &dev->dd,        dd_bm_int_handler           }, /* DD BM */
     };
 
 #define R(x) read_ ## x

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -166,7 +166,7 @@ struct interrupt_handler
     void (*callback)(void*);
 };
 
-enum { CP0_INTERRUPT_HANDLERS_COUNT = 15 };
+enum { CP0_INTERRUPT_HANDLERS_COUNT = 16 };
 
 enum {
     INTR_UNSAFE_R4300 = 0x01,

--- a/src/device/r4300/cp0.h
+++ b/src/device/r4300/cp0.h
@@ -166,7 +166,7 @@ struct interrupt_handler
     void (*callback)(void*);
 };
 
-enum { CP0_INTERRUPT_HANDLERS_COUNT = 13 };
+enum { CP0_INTERRUPT_HANDLERS_COUNT = 15 };
 
 enum {
     INTR_UNSAFE_R4300 = 0x01,

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -641,6 +641,16 @@ void gen_interrupt(struct r4300_core* r4300)
             call_interrupt_handler(&r4300->cp0, 12);
             break;
 
+        case DD_MC_INT:
+            remove_interrupt_event(&r4300->cp0);
+            call_interrupt_handler(&r4300->cp0, 13);
+            break;
+
+        case DD_BM_INT:
+            remove_interrupt_event(&r4300->cp0);
+            call_interrupt_handler(&r4300->cp0, 14);
+            break;
+
         default:
             DebugMessage(M64MSG_ERROR, "Unknown interrupt queue event type %.8X.", r4300->cp0.q.first->data.type);
             remove_interrupt_event(&r4300->cp0);

--- a/src/device/r4300/interrupt.c
+++ b/src/device/r4300/interrupt.c
@@ -651,6 +651,11 @@ void gen_interrupt(struct r4300_core* r4300)
             call_interrupt_handler(&r4300->cp0, 14);
             break;
 
+        case DD_DV_INT:
+            remove_interrupt_event(&r4300->cp0);
+            call_interrupt_handler(&r4300->cp0, 15);
+            break;
+
         default:
             DebugMessage(M64MSG_ERROR, "Unknown interrupt queue event type %.8X.", r4300->cp0.q.first->data.type);
             remove_interrupt_event(&r4300->cp0);

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -54,18 +54,18 @@ void check_int_handler(void* opaque);
 void special_int_handler(void* opaque);
 void nmi_int_handler(void* opaque);
 
-#define VI_INT      0x001
-#define COMPARE_INT 0x002
-#define CHECK_INT   0x004
-#define SI_INT      0x008
-#define PI_INT      0x010
-#define SPECIAL_INT 0x020
-#define AI_INT      0x040
-#define SP_INT      0x080
-#define DP_INT      0x100
-#define HW2_INT     0x200
-#define NMI_INT     0x400
-#define RSP_DMA_EVT 0x800
+#define VI_INT      0x0001
+#define COMPARE_INT 0x0002
+#define CHECK_INT   0x0004
+#define SI_INT      0x0008
+#define PI_INT      0x0010
+#define SPECIAL_INT 0x0020
+#define AI_INT      0x0040
+#define SP_INT      0x0080
+#define DP_INT      0x0100
+#define HW2_INT     0x0200
+#define NMI_INT     0x0400
+#define RSP_DMA_EVT 0x0800
 #define DD_MC_INT   0x1000
 #define DD_BM_INT   0x2000
 

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -68,5 +68,6 @@ void nmi_int_handler(void* opaque);
 #define RSP_DMA_EVT 0x0800
 #define DD_MC_INT   0x1000
 #define DD_BM_INT   0x2000
+#define DD_DV_INT   0x4000
 
 #endif /* M64P_DEVICE_R4300_INTERRUPT_H */

--- a/src/device/r4300/interrupt.h
+++ b/src/device/r4300/interrupt.h
@@ -66,5 +66,7 @@ void nmi_int_handler(void* opaque);
 #define HW2_INT     0x200
 #define NMI_INT     0x400
 #define RSP_DMA_EVT 0x800
+#define DD_MC_INT   0x1000
+#define DD_BM_INT   0x2000
 
 #endif /* M64P_DEVICE_R4300_INTERRUPT_H */

--- a/src/device/rcp/pi/pi_controller.c
+++ b/src/device/rcp/pi/pi_controller.c
@@ -219,12 +219,5 @@ void pi_end_of_dma_event(void* opaque)
     pi->regs[PI_STATUS_REG] &= ~(PI_STATUS_DMA_BUSY | PI_STATUS_IO_BUSY);
     pi->regs[PI_STATUS_REG] |= PI_STATUS_INTERRUPT;
 
-    if (pi->dd != NULL) {
-        if (((pi->regs[PI_CART_ADDR_REG] >= MM_DD_C2S_BUFFER) && (pi->regs[PI_CART_ADDR_REG] < MM_DD_DS_BUFFER)) ||
-            ((pi->regs[PI_CART_ADDR_REG] >= MM_DD_DS_BUFFER) && (pi->regs[PI_CART_ADDR_REG] < MM_DD_REGS))) {
-            dd_update_bm(pi->dd);
-        }
-    }
-
     raise_rcp_interrupt(pi->mi, MI_INTR_PI);
 }

--- a/src/device/rcp/pi/pi_controller.c
+++ b/src/device/rcp/pi/pi_controller.c
@@ -173,7 +173,6 @@ void write_pi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
     case PI_CART_ADDR_REG:
         if (pi->dd != NULL) {
             masked_write(&pi->regs[PI_CART_ADDR_REG], value, mask);
-            dd_on_pi_cart_addr_write(pi->dd, pi->regs[PI_CART_ADDR_REG]);
             return;
         }
         break;


### PR DESCRIPTION
This adds two new interrupt handlers for the two different kinds of interrupts the 64DD can issue (MECHA and BM), then introduces delays based on clock speed (and CountPerOp, kinda to make sure), to every command, but especially the Seek command, and then changes the nature of BM interrupts to work with delays instead of working as fast as possible based on DMAs and other hacky reads.

The timing used is very approximate and is trying to be close to real hardware, but is not quite there, a lot more finetuning will be done eventually, but libleo is very tolerant.

This fixes Gnat Attack in Mario Artist Paint Studio prototype, as the game tries to read the next stage data before unloading the current stage, but since the 64DD responds way too quick it replaces the data before it actually unloads it and crashes.