### PR TITLE
Fix screenshots when compiling with OSD=0

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -878,25 +878,31 @@ m64p_error main_reset(int do_hard_reset)
 
 static void video_plugin_render_callback(int bScreenRedrawn)
 {
+#ifdef M64P_OSD
     int bOSD = ConfigGetParamBool(g_CoreConfig, "OnScreenDisplay");
+#endif /* M64P_OSD */
 
     // if the flag is set to take a screenshot, then grab it now
     if (l_TakeScreenshot != 0)
     {
         // if the OSD is enabled, and the screen has not been recently redrawn, then we cannot take a screenshot now because
         // it contains the OSD text.  Wait until the next redraw
+#ifdef M64P_OSD
         if (!bOSD || bScreenRedrawn)
+#endif /* M64P_OSD */
         {
             TakeScreenshot(l_TakeScreenshot - 1);  // current frame number +1 is in l_TakeScreenshot
             l_TakeScreenshot = 0; // reset flag
         }
     }
 
+#ifdef M64P_OSD
     // if the OSD is enabled, then draw it now
     if (bOSD)
     {
         osd_render();
     }
+#endif /* M64P_OSD */
 
     // if the input plugin specified a render callback, call it now
     if(input.renderCallback)


### PR DESCRIPTION
When compiling with `OSD=0`, `OnScreenDisplay` is `True` in the configuration file and `video_plugin_render_callback` is called with `0`, then taking a screenshot will fail.

This patch fixes that issue, I do wonder if I should extend this patch to guard every OSD function call with a `#ifdef M64P_OSD` to prevent it having to access the `OnScreenDisplay` option in the configuration file?