### PR TITLE
Sanitize save filename

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -172,6 +172,9 @@ static char *get_save_filename(void)
         snprintf(filename, 256, "unknown-%.8s", ROM_SETTINGS.MD5);
     }
 
+    /* sanitize filename */
+    string_replace_chars(filename, ":<>\"/\\|?*", '_');
+
     return filename;
 }
 

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -585,6 +585,28 @@ char *trim(char *str)
     return str;
 }
 
+int string_replace_chars(char* str, const char* chars, const char r)
+{
+    int i, y;
+    int str_size, chars_size;
+    int replacements = 0;
+
+    str_size   = strlen(str);
+    chars_size = strlen(chars);
+
+    for (i = 0; i < str_size; i++) {
+        for (y = 0; y < chars_size; y++) {
+            if (str[i] == chars[y]) {
+                str[i] = r;
+                replacements++;
+                break;
+            }
+        }
+    }
+
+    return replacements;
+}
+
 int string_to_int(const char *str, int *result)
 {
     char *endptr;

--- a/src/main/util.h
+++ b/src/main/util.h
@@ -214,6 +214,11 @@ char* combinepath(const char* first, const char *second);
  */
 char *trim(char *str);
 
+ /* Replaces all occurences of any char in chars with r in string.
+  * returns amount of replaced chars
+  */
+int string_replace_chars(char *str, const char *chars, const char r);
+
 /* Converts an string to an integer.
  * Returns 1 on success, 0 on failure. 'result' is undefined on failure.
  *


### PR DESCRIPTION
This patch fixes an issue where i.e on windows, certain characters like `:<>"/\|?*` aren't allowed to be used for filenames, causing mupen64plus to be unable to create a save, this issue mainly occurs when a ROM/ROM hack isn't in the database and it uses the internal ROM name for the filename, I could make this patch windows-only mostly but to make the filenames consistent across platforms I think it makes sense to do it for all platforms.