### PR TITLE
CI/CD: Integrate scheduled builds and other...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,10 @@ on:
       - '**/*.md'
       - '.{gitattributes,gitignore,travis.yml}'
       - 'appveyor.yml,README'
+  schedule:
+    - cron: '55 14 21 * *'
   workflow_dispatch:
+
 jobs:
 
   Linux:
@@ -33,14 +36,16 @@ jobs:
             bits: 32
     name: Linux / ${{ matrix.cc }} / ${{ matrix.platform }}
     runs-on: ubuntu-22.04
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-core') || (github.event_name != 'schedule')
     steps:
       - uses: actions/checkout@v3
       - name: Get build dependencies and arrange the environment
         run: |
-          if [[ "${{ matrix.platform }}" == "x86" ]]; then sudo dpkg --add-architecture i386; fi
+          echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then sudo dpkg --add-architecture i386; fi
           sudo apt-get update
           sudo apt-get -y install libfreetype6-dev libgl1-mesa-dev libglu1-mesa-dev libpng-dev libsdl1.2-dev libsdl2-dev nasm zlib1g-dev
-          if [[ "${{ matrix.platform }}" == "x86" ]]; then
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then
             sudo apt-get --reinstall -y install gcc-multilib g++-multilib libc6 libc6-dev-i386 libfreetype6:i386 libgl1-mesa-glx:i386 libglu1-mesa:i386 libpng16-16:i386 libsdl1.2debian:i386 libsdl2-2.0-0:i386 zlib1g:i386
             LINK="sudo ln -s -T"
             cd /usr/lib/i386-linux-gnu
@@ -55,32 +60,24 @@ jobs:
             if ! [[ -f _real_SDL_config.h ]]; then ${LINK} ../x86_64-linux-gnu/SDL2/_real_SDL_config.h _real_SDL_config.h; fi
           fi
           sudo ldconfig
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
-          G_REV=$(git rev-parse --short HEAD)
-          echo "G_REV=${G_REV}" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1" CPU_TUNE="-msse2 -mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
-          if [[ "${{ matrix.cc }}" == "GCC" ]]; then
-            CC="gcc"
-            CXX="g++"
-          else
+          CC="gcc"
+          CXX="g++"
+          if [[ "${{ matrix.cc }}" != "GCC" ]]; then
             CC="clang"
             CXX="clang++"
           fi
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1"; fi
           ${CC} --version
           SDL="sdl"
           MSG="1.2"
-          mkdir tmp
-          for DYN in 0 1 0 1
-          do
-            if [[ ${DYN} -eq 0 ]]; then
-              export POSTFIX="-old"
-            else
-              unset POSTFIX
-              MSG="${MSG} / NEW_DYNAREC"
-            fi
+          mkdir pkg
+          for DYN in 0 1 0 1; do
+            unset POSTFIX
+            if [[ ${DYN} -eq 0 ]]; then export POSTFIX="-old"; else MSG="${MSG} / NEW_DYNAREC"; fi
             echo ""
             echo ":: ${{ matrix.cc }} ${{ matrix.platform }} / SDL${MSG} ::"
             echo ""
@@ -88,25 +85,23 @@ jobs:
             echo ""
             make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" SDL_CONFIG="${SDL}-config" NEW_DYNAREC="${DYN}" -C projects/unix all -j4
             echo ""
-            make BITS="${{ matrix.bits }}" NEW_DYNAREC="${DYN}" -C projects/unix install DESTDIR="${ORIG}/tmp"
+            make BITS="${{ matrix.bits }}" NEW_DYNAREC="${DYN}" -C projects/unix install DESTDIR="${ORIG}/pkg/"
             echo ""
-            cd tmp/usr/local/lib
-            ls -gG libmupen64plus${POSTFIX}.so*
-            ldd libmupen64plus${POSTFIX}.so.2.0.0
+            ls -gG pkg/usr/local/lib/libmupen64plus${POSTFIX}.so*
+            echo ""
+            ldd pkg/usr/local/lib/libmupen64plus${POSTFIX}.so.2.0.0
             if [[ ${DYN} -eq 1 ]]; then
               SDL="sdl2"
               MSG="2"
             fi
-            cd "${ORIG}"
           done
-          mkdir pkg
-          if [[ "${CC}" == "gcc" ]]; then tar cvzf pkg/mupen64plus-core-${{ matrix.platform }}-g${G_REV}.tar.gz -C tmp/ "usr"; fi
+          tar cvzf pkg/mupen64plus-core-linux-${{ matrix.platform }}-g${{ env.G_REV }}.tar.gz -C pkg/ "usr"
       - name: Upload artifact
+        if: matrix.cc == 'GCC'
         uses: actions/upload-artifact@v3
         with:
-          name: mupen64plus-core-${{ matrix.platform }}-g${{ env.G_REV }}
-          path: pkg/*
-          if-no-files-found: ignore
+          name: mupen64plus-core-linux-${{ matrix.platform }}-g${{ env.G_REV }}
+          path: pkg/*.tar.gz
 
   MSYS2:
     strategy:
@@ -122,7 +117,8 @@ jobs:
             cross: i686
             bits: 32
     name: Windows / MSYS2 ${{ matrix.cc }} / ${{ matrix.platform }}
-    runs-on: windows-2019
+    runs-on: windows-2022
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-core') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: msys2 {0}
@@ -143,18 +139,18 @@ jobs:
             mingw-w64-${{ matrix.cross }}-nasm
             mingw-w64-${{ matrix.cross }}-SDL2
             mingw-w64-${{ matrix.cross }}-zlib
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
           echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then CPU_TUNE="-msse2 -mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
           CC="gcc"
           CXX="g++"
           ${CC} --version
-          mkdir tmp
+          mkdir pkg
           export POSTFIX="-old"
-          for DYN in 0 1
-          do
+          for DYN in 0 1; do
             echo ""
             echo ":: ${{ matrix.cc }} ${{ matrix.platform }} / SDL2${MSG} ::"
             echo ""
@@ -162,35 +158,20 @@ jobs:
             echo ""
             make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" NEW_DYNAREC="${DYN}" -C projects/unix all -j4
             echo ""
-            make BITS="${{ matrix.bits }}" NEW_DYNAREC="${DYN}" -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/tmp"
+            make BITS="${{ matrix.bits }}" NEW_DYNAREC="${DYN}" -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/pkg/"
             echo ""
-            ls -gG tmp/mupen64plus${POSTFIX}.dll
-            ldd tmp/mupen64plus${POSTFIX}.dll
+            ls -gG pkg/mupen64plus${POSTFIX}.dll
+            echo ""
+            ldd pkg/mupen64plus${POSTFIX}.dll
             unset POSTFIX
             MSG=" / NEW_DYNAREC"
           done
-      - name: Copy binaries, dependencies, etc...
+      - name: Backup dependencies, etc...
         run: |
-          mkdir pkg
           if [[ ${{ matrix.bits }} -eq 32 ]]; then LIBGCC="libgcc_s_dw2-1"; else LIBGCC="libgcc_s_seh-1"; fi
-          for LIB in libbrotlicommon libbrotlidec libbz2-1 libfreetype-6 ${LIBGCC} libglib-2.0-0 libgraphite2 libharfbuzz-0 libiconv-2 libintl-8 libpcre2-8-0 libpng16-16 libstdc++-6 libwinpthread-1 SDL2 zlib1
-          do
+          for LIB in libbrotlicommon libbrotlidec libbz2-1 libfreetype-6 ${LIBGCC} libglib-2.0-0 libgraphite2 libharfbuzz-0 libiconv-2 libintl-8 libpcre2-8-0 libpng16-16 libstdc++-6 libwinpthread-1 SDL2 zlib1; do
             echo ":: Copying ${LIB}.dll"
             cp "/mingw${{ matrix.bits }}/bin/${LIB}.dll" pkg/
-          done
-          if [ -d data ]; then
-            cd data
-            for DAT in *
-            do
-              echo ":: Copying ${DAT}"
-              cp -r "${DAT}" ../pkg/
-            done
-          fi
-          cd ../tmp
-          for BIN in *.dll
-          do
-            echo ":: Copying ${BIN}"
-            cp "${BIN}" ../pkg/
           done
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -209,48 +190,43 @@ jobs:
           - toolset: v141_xp
             platform: x86
             vs: 2019
-    name: Windows / MSVC ${{ matrix.toolset }} / ${{ matrix.platform }}
+    name: Windows / MSVC with ${{ matrix.toolset }} / ${{ matrix.platform }}
     runs-on: windows-${{ matrix.vs }}
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-core') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: cmd
     steps:
       - uses: actions/checkout@v3
       - uses: microsoft/setup-msbuild@v1
-    #  with:
-    #    vs-version: 16.11
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          for /f "tokens=1" %%R in ('git rev-parse --short HEAD') do set "G_REV=%%R"
-          echo G_REV=%G_REV%>> "%GITHUB_ENV%"
+          for /f "tokens=1" %%R in ('git rev-parse --short HEAD') do echo G_REV=%%R>> "%GITHUB_ENV%"
           set "ARCH=${{ matrix.platform }}"
           if [%ARCH%] == [x86] set "ARCH=Win32"
           echo.
           msbuild --version
           echo.
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-win32-deps.git ..\mupen64plus-win32-deps
-          md backup
+          md pkg
           for %%B in (Release New_Dynarec_Release) do (
             echo.
-            msbuild "projects\msvc\mupen64plus-core.vcxproj" /p:Configuration=%%B;Platform=%ARCH%;PlatformToolset=${{ matrix.toolset }} /t:Rebuild
+            msbuild projects\msvc\mupen64plus-core.vcxproj /p:Configuration=%%B;Platform=%ARCH%;PlatformToolset=${{ matrix.toolset }} /t:Rebuild
             echo.
-            copy "projects\msvc\%ARCH%\%%B\mupen64plus.dll" backup\
-            if not exist "backup\mupen64plus-old.dll" (
-              ren "backup\mupen64plus.dll" "mupen64plus-old.dll"
-              dir "backup\mupen64plus-old.dll"
-            ) else dir "backup\mupen64plus.dll"
+            copy "projects\msvc\%ARCH%\%%B\mupen64plus.dll" pkg\
+            if not exist "pkg\mupen64plus-old.dll" (
+              ren "pkg\mupen64plus.dll" mupen64plus-old.dll
+              dir pkg\mupen64plus-old.dll
+            ) else dir pkg\mupen64plus.dll
           )
-      - name: Copy binaries, dependencies, etc...
+      - name: Backup dependencies, etc...
         run: |
-          md pkg
-          cd pkg
-          xcopy "..\backup" .
-          xcopy "..\data" .
-          copy "..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\${{ matrix.platform }}\*.dll" .
-          copy "..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\${{ matrix.platform }}\*.dll" .
-          copy "..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\${{ matrix.platform }}\*.dll" .
-          copy "..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\${{ matrix.platform }}\*.dll" .
-          copy "..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\${{ matrix.platform }}\*.dll" .
+          xcopy data pkg
+          copy "..\mupen64plus-win32-deps\freetype-2.13.0\lib\${{ matrix.platform }}\*.dll" pkg\
+          copy "..\mupen64plus-win32-deps\libpng-1.6.39\lib\${{ matrix.platform }}\*.dll" pkg\
+          copy "..\mupen64plus-win32-deps\SDL2-2.26.3\lib\${{ matrix.platform }}\*.dll" pkg\
+          copy "..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\${{ matrix.platform }}\*.dll" pkg\
+          copy "..\mupen64plus-win32-deps\zlib-1.2.13\lib\${{ matrix.platform }}\*.dll" pkg\
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -259,8 +235,8 @@ jobs:
 
   Nightly-build:
     runs-on: ubuntu-latest
+    if: github.ref_name == 'master'
     needs: [Linux, MSYS2, MSVC]
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
       - name: Download artifacts
@@ -275,8 +251,7 @@ jobs:
         run: |
           mkdir pkg
           cd binaries
-          for BIN in *
-          do
+          for BIN in *; do
             cd "${BIN}"
             if [[ "${BIN:17:4}" == "msys" ]]; then
               echo ":: Creating ${BIN}.zip"
@@ -292,10 +267,9 @@ jobs:
           done
           cd ../pkg
           echo ""
-          for BIN in *
-          do
+          for BIN in *; do
             ls -gG ${BIN}
-            tigerdeep -l ${BIN} >> ../${BIN:0:16}.tiger.txt
+            tigerdeep -lz ${BIN} >> ../${BIN:0:16}.tiger.txt
             sha256sum ${BIN} >> ../${BIN:0:16}.sha256.txt
             sha512sum ${BIN} >> ../${BIN:0:16}.sha512.txt
           done

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 1.0.{build}
 
 image: Visual Studio 2022
 
+skip_tags: true
+
 skip_commits:
   files:
     - '**/*.md'
@@ -11,10 +13,6 @@ skip_commits:
     - .gitignore
     - .travis.yml
     - README
-
-branches:
-  except:
-    - nightly-build
 
 configuration:
   - New_Dynarec_Release

--- a/projects/msvc/mupen64plus-core.vcxproj
+++ b/projects/msvc/mupen64plus-core.vcxproj
@@ -684,13 +684,13 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|x64'">false</ExcludedFromBuild>
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x64.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x64.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|x64'">$(IntDir)linkage_x64.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x64.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x64.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|x64'">$(IntDir)linkage_x64.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='ARM64_New_Dynarec_Debug|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x64.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='ARM64_New_Dynarec_Debug|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x64.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='ARM64_New_Dynarec_Debug|x64'">$(IntDir)linkage_x64.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='x64_New_Dynarec_Debug|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x64.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='x64_New_Dynarec_Debug|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x64.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='x64_New_Dynarec_Debug|x64'">$(IntDir)linkage_x64.obj</Outputs>
     </CustomBuild>
     <None Include="..\..\src\device\r4300\new_dynarec\arm64\linkage_arm64.S">
@@ -736,13 +736,13 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|x64'">true</ExcludedFromBuild>
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x86.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x86.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">$(IntDir)linkage_x86.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x86.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x86.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">$(IntDir)linkage_x86.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='ARM_New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x86.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='ARM_New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x86.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='ARM_New_Dynarec_Debug|Win32'">$(IntDir)linkage_x86.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='x86_New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x86.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='x86_New_Dynarec_Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)linkage_x86.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='x86_New_Dynarec_Debug|Win32'">$(IntDir)linkage_x86.obj</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\..\src\device\r4300\x86_64\dyna_start.asm">
@@ -759,9 +759,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ARM_New_Dynarec_Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)dyna_start.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)dyna_start.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)dyna_start.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)dyna_start.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x64\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)dyna_start.obj" -f win64 -d WIN64 "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)dyna_start.obj</Outputs>
     </CustomBuild>
     <CustomBuild Include="..\..\src\device\r4300\x86\dyna_start.asm">
@@ -778,9 +778,9 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)dyna_start.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)dyna_start.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)dyna_start.obj</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.15.05\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)dyna_start.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"..\..\..\mupen64plus-win32-deps\nasm-2.16.01\x86\nasm.exe" -i ..\..\src\ -i ..\..\src\asm_defines\ -o "$(IntDir)dyna_start.obj" -f win32 -d LEADING_UNDERSCORE "%(FullPath)"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)dyna_start.obj</Outputs>
     </CustomBuild>
   </ItemGroup>
@@ -928,14 +928,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_NETPLAY;M64P_PARALLEL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x86\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x86\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -946,14 +946,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_PARALLEL;M64P_OSD;M64P_NETPLAY;__x86_64__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x64\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x64\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -964,14 +964,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_NETPLAY;M64P_PARALLEL;NEW_DYNAREC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x86\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x86\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -982,14 +982,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='x86_New_Dynarec_Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;..\..\..\mupen64plus-win32-deps\capstone\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;..\..\..\mupen64plus-win32-deps\capstone\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_NETPLAY;M64P_PARALLEL;NEW_DYNAREC=1;RECOMPILER_DEBUG=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x86\freetype.lib;..\..\..\mupen64plus-win32-deps\capstone\lib\x86\capstone_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x86\freetype.lib;..\..\..\mupen64plus-win32-deps\capstone\lib\x86\capstone_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -1000,14 +1000,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ARM_New_Dynarec_Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;..\..\..\mupen64plus-win32-deps\capstone\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;..\..\..\mupen64plus-win32-deps\capstone\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_NETPLAY;M64P_PARALLEL;NEW_DYNAREC=1;RECOMPILER_DEBUG=3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x86\freetype.lib;..\..\..\mupen64plus-win32-deps\capstone\lib\x86\capstone_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x86\freetype.lib;..\..\..\mupen64plus-win32-deps\capstone\lib\x86\capstone_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -1018,14 +1018,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_PARALLEL;M64P_OSD;M64P_NETPLAY;NEW_DYNAREC=2;__x86_64__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x64\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x64\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -1036,14 +1036,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ARM64_New_Dynarec_Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;..\..\..\mupen64plus-win32-deps\capstone\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;..\..\..\mupen64plus-win32-deps\capstone\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_PARALLEL;M64P_OSD;M64P_NETPLAY;NEW_DYNAREC=2;__x86_64__;RECOMPILER_DEBUG=4;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x64\freetype.lib;..\..\..\mupen64plus-win32-deps\capstone\lib\x64\capstone_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x64\freetype.lib;..\..\..\mupen64plus-win32-deps\capstone\lib\x64\capstone_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -1054,14 +1054,14 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='x64_New_Dynarec_Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;..\..\..\mupen64plus-win32-deps\capstone\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;..\..\..\mupen64plus-win32-deps\capstone\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_PARALLEL;M64P_OSD;M64P_NETPLAY;NEW_DYNAREC=2;__x86_64__;RECOMPILER_DEBUG=2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x64\freetype.lib;..\..\..\mupen64plus-win32-deps\capstone\lib\x64\capstone_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x64\freetype.lib;..\..\..\mupen64plus-win32-deps\capstone\lib\x64\capstone_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -1071,7 +1071,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_NETPLAY;M64P_PARALLEL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -1080,7 +1080,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x86\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x86\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -1092,7 +1092,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_PARALLEL;M64P_OSD;M64P_NETPLAY;__x86_64__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -1101,7 +1101,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x64\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x64\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -1113,7 +1113,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_OSD;M64P_NETPLAY;M64P_PARALLEL;NEW_DYNAREC=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -1122,7 +1122,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x86\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x86\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x86\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x86\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -1134,7 +1134,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='New_Dynarec_Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\subprojects\md5;..\..\subprojects\minizip;..\..\subprojects\oglft;..\..\subprojects\xxhash;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\include;..\..\..\mupen64plus-win32-deps\opencv-3.0.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_DEPRECATE;DYNAREC;M64P_PARALLEL;M64P_OSD;M64P_NETPLAY;NEW_DYNAREC=2;__x86_64__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -1143,7 +1143,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.12.1\lib\x64\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>shell32.lib;opengl32.lib;glu32.lib;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64\SDL2.lib;..\..\..\mupen64plus-win32-deps\SDL2_net-2.2.0\lib\x64\SDL2_net.lib;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x64\zlib.lib;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64\libpng16.lib;..\..\..\mupen64plus-win32-deps\freetype-2.13.0\lib\x64\freetype.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
Depends on: mupen64plus/mupen64plus-win32-deps#13

Relevant changes:

- Schedule builds at least once a month (upstream only)
- Update some GitHub Actions values
- Bash code simplification and corrections
- Optimize x86 builds with SSE2 on Linux and MSYS2 (sometimes not effective)
- Tag to Linux binaries
- Add file size to tiger hashfile
- AppVeyor: Avoid duplicated jobs as a result of the `nightly-build` tag update