### PR TITLE
Introduce SaveFilenameFormat parameter

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -164,12 +164,18 @@ static char *get_save_filename(void)
 {
     static char filename[256];
 
-    if (strstr(ROM_SETTINGS.goodname, "(unknown rom)") == NULL) {
-        snprintf(filename, 256, "%.32s-%.8s", ROM_SETTINGS.goodname, ROM_SETTINGS.MD5);
-    } else if (ROM_HEADER.Name[0] != 0) {
-        snprintf(filename, 256, "%s-%.8s", ROM_PARAMS.headername, ROM_SETTINGS.MD5);
-    } else {
-        snprintf(filename, 256, "unknown-%.8s", ROM_SETTINGS.MD5);
+    int format = ConfigGetParamInt(g_CoreConfig, "SaveFilenameFormat");
+
+    if (format == 0) {
+        snprintf(filename, 256, "%s", ROM_PARAMS.headername);
+    } else /* if (format == 1) */ {
+        if (strstr(ROM_SETTINGS.goodname, "(unknown rom)") == NULL) {
+            snprintf(filename, 256, "%.32s-%.8s", ROM_SETTINGS.goodname, ROM_SETTINGS.MD5);
+        } else if (ROM_HEADER.Name[0] != 0) {
+            snprintf(filename, 256, "%s-%.8s", ROM_PARAMS.headername, ROM_SETTINGS.MD5);
+        } else {
+            snprintf(filename, 256, "unknown-%.8s", ROM_SETTINGS.MD5);
+        }
     }
 
     /* sanitize filename */
@@ -428,6 +434,7 @@ int main_set_core_defaults(void)
     ConfigSetDefaultInt(g_CoreConfig, "SiDmaDuration", -1, "Duration of SI DMA (-1: use per game settings)");
     ConfigSetDefaultString(g_CoreConfig, "GbCameraVideoCaptureBackend1", DEFAULT_VIDEO_CAPTURE_BACKEND, "Gameboy Camera Video Capture backend");
     ConfigSetDefaultInt(g_CoreConfig, "SaveDiskFormat", 1, "Disk Save Format (0: Full Disk Copy (*.ndr/*.d6r), 1: RAM Area Only (*.ram))");
+    ConfigSetDefaultInt(g_CoreConfig, "SaveFilenameFormat", 1, "Save (SRAM/State) Filename Format (0: ROM Header Name, 1: Automatic (including partial MD5 hash))");
 
     /* handle upgrades */
     if (bUpgrade)


### PR DESCRIPTION
This introduces a new setting called `SaveFilenameFormat`, allowing users to choose what filename format they'd like their save games/states in, the 2 options are ROM header name and the Automatic option, this feature has been requested by GhostlyDark and another RMG user (see https://github.com/Rosalie241/RMG/issues/122) due to them creating ROM hacks and it's handy for them to be able to disable the hash appended to the save state/game filenames so saves are available through development without them having to rename it constantly.