### PR TITLE
vidext.c: Fix DPI scaling issues on Windows

### DIFF
--- a/src/api/vidext.c
+++ b/src/api/vidext.c
@@ -110,6 +110,11 @@ EXPORT m64p_error CALL VidExt_Init(void)
     l_SwapControl = SDL_GL_GetSwapInterval();
 #endif
 
+#if SDL_VERSION_ATLEAST(2,24,0)
+    /* fix DPI scaling issues on Windows */
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
+#endif
+
     if (SDL_InitSubSystem(SDL_INIT_VIDEO) == -1)
     {
         DebugMessage(M64MSG_ERROR, "SDL video subsystem init failed: %s", SDL_GetError());


### PR DESCRIPTION
Adds an SDL hint to address DPI scaling issues on Windows using mupen64plus-ui-console, rendering windowed resolutions larger than intended. Requires SDL2 v2.24 or newer to work.

No changes made to the high DPI settings for mupen64plus.exe running at 1280x960 windowed resolution.
Using a Desktop resolution of 3840x2160 with 200% scaling.

Upstream:
![image](https://user-images.githubusercontent.com/31742919/232232660-4018fce9-fd21-4b41-bf49-9867aa87c93a.png)

PR:
![image](https://user-images.githubusercontent.com/31742919/232232641-b9e98f65-1249-4a1b-b3ad-341cac5089ee.png)

