### PR TITLE
Implement unused RDRAM address range 0x0800000-0x03EFFFFF

### DIFF
--- a/src/device/device.c
+++ b/src/device/device.c
@@ -138,7 +138,7 @@ void init_device(struct device* dev,
         /* clear mappings */
         { 0x00000000, 0xffffffff, M64P_MEM_NOTHING, { NULL, RW(open_bus) } },
         /* memory map */
-        { A(MM_RDRAM_DRAM, dram_size-1), M64P_MEM_RDRAM, { &dev->rdram, RW(rdram_dram) } },
+        { A(MM_RDRAM_DRAM, 0x3efffff), M64P_MEM_RDRAM, { &dev->rdram, RW(rdram_dram) } },
         { A(MM_RDRAM_REGS, 0xfffff), M64P_MEM_RDRAMREG, { &dev->rdram, RW(rdram_regs) } },
         { A(MM_RSP_MEM, 0xffff), M64P_MEM_RSPMEM, { &dev->sp, RW(rsp_mem) } },
         { A(MM_RSP_REGS, 0xffff), M64P_MEM_RSPREG, { &dev->sp, RW(rsp_regs) } },

--- a/src/device/rdram/rdram.c
+++ b/src/device/rdram/rdram.c
@@ -231,7 +231,10 @@ void read_rdram_dram(void* opaque, uint32_t address, uint32_t* value)
     struct rdram* rdram = (struct rdram*)opaque;
     uint32_t addr = rdram_dram_address(address);
 
-    *value = rdram->dram[addr];
+    if (address < rdram->dram_size)
+    {
+        *value = rdram->dram[addr];
+    }
 }
 
 void write_rdram_dram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
@@ -239,5 +242,8 @@ void write_rdram_dram(void* opaque, uint32_t address, uint32_t value, uint32_t m
     struct rdram* rdram = (struct rdram*)opaque;
     uint32_t addr = rdram_dram_address(address);
 
-    masked_write(&rdram->dram[addr], value, mask);
+    if (address < rdram->dram_size)
+    {
+        masked_write(&rdram->dram[addr], value, mask);
+    }
 }


### PR DESCRIPTION
Fixes an in-game crash in Paper Mario when hitting a specific tree with a hammer.

You can reproduce it with this save state (just hit B on the tree):  

[paper_mario_crash.zip](https://github.com/mupen64plus/mupen64plus-core/files/11782215/paper_mario_crash.zip)


on the N64, `0x0800000-0x03EFFFFF` are mapped, but reads/writes are ignored, see the n64brew documentation: https://n64brew.dev/wiki/RDRAM_Interface#Memory_addressing

