### PR TITLE
Ensure out of bounds RDRAM reads 0

### DIFF
--- a/src/device/rdram/rdram.c
+++ b/src/device/rdram/rdram.c
@@ -235,6 +235,10 @@ void read_rdram_dram(void* opaque, uint32_t address, uint32_t* value)
     {
         *value = rdram->dram[addr];
     }
+    else
+    {
+        *value = 0;
+    }
 }
 
 void write_rdram_dram(void* opaque, uint32_t address, uint32_t value, uint32_t mask)


### PR DESCRIPTION
Fix pulled from Logan's mupen64plus-core fork.