### PR TITLE
Change IPL3 memory detection error to a warning

### DIFF
--- a/src/device/rdram/rdram.c
+++ b/src/device/rdram/rdram.c
@@ -206,7 +206,7 @@ void write_rdram_regs(void* opaque, uint32_t address, uint32_t value, uint32_t m
          * the amount of detected memory can be found in s4 */
         size_t ipl3_rdram_size = r4300_regs(rdram->r4300)[20] & UINT32_C(0x0fffffff);
         if (ipl3_rdram_size != rdram->dram_size) {
-            DebugMessage(M64MSG_ERROR, "IPL3 detected %u MB of RDRAM != %u MB",
+            DebugMessage(M64MSG_WARNING, "IPL3 detected %u MB of RDRAM != %u MB",
                 (uint32_t) ipl3_rdram_size / (1024*1024), (uint32_t) rdram->dram_size / (1024*1024));
         }
     }


### PR DESCRIPTION
Xeno Crisis has a custom IPL3 so this error should be a warning.