### PR TITLE
Fix IS64 Truncating Lines

### DIFF
--- a/src/device/cart/is_viewer.c
+++ b/src/device/cart/is_viewer.c
@@ -67,13 +67,17 @@ void write_is_viewer(void* opaque, uint32_t address, uint32_t value, uint32_t ma
 
             memcpy(&is_viewer->output_buffer[is_viewer->buffer_pos], &is_viewer->data[0x20], word);
             is_viewer->buffer_pos += word;
-            char* newline = strpbrk_reverse("\n", is_viewer->output_buffer, is_viewer->buffer_pos);
-            if (newline)
+            
+            /* process new lines in buffer to prevent empty debug messages without losing data */
+            char* newline = strchr(is_viewer->output_buffer, '\n');
+            while (newline)
             {
+                size_t index = (newline - is_viewer->output_buffer) + 1;
                 *newline = '\0';
                 DebugMessage(M64MSG_INFO, "IS64: %s", is_viewer->output_buffer);
-                memset(is_viewer->output_buffer, 0, is_viewer->buffer_pos);
-                is_viewer->buffer_pos = 0;
+                memcpy(&is_viewer->output_buffer, &is_viewer->output_buffer[index], IS_BUFFER_SIZE - index);
+                is_viewer->buffer_pos -= index;
+                newline = strchr(is_viewer->output_buffer, '\n');
             }
         }
     }


### PR DESCRIPTION
Process new lines in buffer to prevent empty debug messages without losing data.

Current method wipes out everything after a new line if a new line is not placed at the end of the string. The OoT debug build has many of these so this is very annoying when working with the decomp code of it.

No idea if it would be accurate to how the IS64 actually works, but fixes the broken functionality at least.