### PR TITLE
netplay fixes from simple64

### DIFF
--- a/src/backends/plugins_compat/input_plugin_compat.c
+++ b/src/backends/plugins_compat/input_plugin_compat.c
@@ -78,11 +78,11 @@ static m64p_error input_plugin_get_input(void* opaque, uint32_t* input_)
             if (input.getKeys)
                 input.getKeys(netplay_controller, &keys);
 
-            netplay_set_plugin(cin_compat->control_id, Controls[netplay_controller].Plugin);
             Controls[netplay_controller].Plugin = plugin;
             Controls[netplay_controller].Present = present;
-            cin_compat->last_input = keys.Value; //disable pak switching for netplay
         }
+        cin_compat->last_input = keys.Value; //disable pak switching for netplay
+        cin_compat->last_pak_type = Controls[cin_compat->control_id].Plugin; //disable pak switching for netplay
     }
 
     /* return an error if controller is not plugged */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -545,6 +545,9 @@ static void main_set_speedlimiter(int enable)
 
 void main_speedlimiter_toggle(void)
 {
+    if (netplay_is_init())
+        return;
+
     l_MainSpeedLimit = !l_MainSpeedLimit;
     main_set_speedlimiter(l_MainSpeedLimit);
 
@@ -1634,9 +1637,6 @@ m64p_error main_run(void)
     else
         disable_extra_mem = ConfigGetParamInt(g_CoreConfig, "DisableExtraMem");
 
-
-    rdram_size = (disable_extra_mem == 0) ? 0x800000 : 0x400000;
-
     if (count_per_op <= 0)
         count_per_op = ROM_SETTINGS.countperop;
 
@@ -1649,6 +1649,8 @@ m64p_error main_run(void)
 
     //During netplay, player 1 is the source of truth for these settings
     netplay_sync_settings(&count_per_op, &count_per_op_denom_pot, &disable_extra_mem, &si_dma_duration, &emumode, &no_compiled_jump);
+
+    rdram_size = (disable_extra_mem == 0) ? 0x800000 : 0x400000;
 
     cheat_add_hacks(&g_cheat_ctx, ROM_PARAMS.cheats);
 

--- a/src/main/netplay.c
+++ b/src/main/netplay.c
@@ -19,6 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#define SETTINGS_SIZE 24
+
 #define M64P_CORE_PROTOTYPES 1
 #include "api/callbacks.h"
 #include "main.h"
@@ -53,6 +55,7 @@ static uint8_t l_player_lag[4];
 #define UDP_SEND_KEY_INFO 0
 #define UDP_RECEIVE_KEY_INFO 1
 #define UDP_REQUEST_KEY_INFO 2
+#define UDP_RECEIVE_KEY_INFO_GRATUITOUS 3
 #define UDP_SYNC_DATA 4
 
 //TCP packet formats
@@ -246,11 +249,13 @@ static void netplay_process()
         switch (packet->data[0])
         {
             case UDP_RECEIVE_KEY_INFO:
+            case UDP_RECEIVE_KEY_INFO_GRATUITOUS:
                 player = packet->data[1];
                 //current_status is a status update from the server
                 //it will let us know if another player has disconnected, or the games have desynced
                 current_status = packet->data[2];
-                l_player_lag[player] = packet->data[3];
+                if (packet->data[0] == UDP_RECEIVE_KEY_INFO)
+                    l_player_lag[player] = packet->data[3];
                 if (current_status != l_status)
                 {
                     if (((current_status & 0x1) ^ (l_status & 0x1)) != 0)
@@ -501,7 +506,7 @@ void netplay_sync_settings(uint32_t *count_per_op, uint32_t *count_per_op_denom_
     if (!netplay_is_init())
         return;
 
-    char output_data[25];
+    char output_data[SETTINGS_SIZE + 1];
     uint8_t request;
     if (l_netplay_control[0] != -1) //player 1 is the source of truth for settings
     {
@@ -513,7 +518,7 @@ void netplay_sync_settings(uint32_t *count_per_op, uint32_t *count_per_op_denom_
         SDLNet_Write32(*si_dma_duration, &output_data[13]);
         SDLNet_Write32(*emumode, &output_data[17]);
         SDLNet_Write32(*no_compiled_jump, &output_data[21]);
-        SDLNet_TCP_Send(l_tcpSocket, &output_data[0], 25);
+        SDLNet_TCP_Send(l_tcpSocket, &output_data[0], SETTINGS_SIZE + 1);
     }
     else
     {
@@ -521,8 +526,8 @@ void netplay_sync_settings(uint32_t *count_per_op, uint32_t *count_per_op_denom_
         memcpy(&output_data[0], &request, 1);
         SDLNet_TCP_Send(l_tcpSocket, &output_data[0], 1);
         int32_t recv = 0;
-        while (recv < 24)
-            recv += SDLNet_TCP_Recv(l_tcpSocket, &output_data[recv], 24 - recv);
+        while (recv < SETTINGS_SIZE)
+            recv += SDLNet_TCP_Recv(l_tcpSocket, &output_data[recv], SETTINGS_SIZE - recv);
         *count_per_op = SDLNet_Read32(&output_data[0]);
         *count_per_op_denom_pot = SDLNet_Read32(&output_data[4]);
         *disable_extra_mem = SDLNet_Read32(&output_data[8]);
@@ -535,14 +540,14 @@ void netplay_sync_settings(uint32_t *count_per_op, uint32_t *count_per_op_denom_
 void netplay_check_sync(struct cp0* cp0)
 {
     //This function is used to check if games have desynced
-    //Every 60 VIs, it sends the value of the CP0 registers to the server
+    //Every 600 VIs, it sends the value of the CP0 registers to the server
     //The server will compare the values, and update the status byte if it detects a desync
     if (!netplay_is_init())
         return;
 
     const uint32_t* cp0_regs = r4300_cp0_regs(cp0);
 
-    if (l_vi_counter % 60 == 0)
+    if (l_vi_counter % 600 == 0)
     {
         uint32_t packet_len = (CP0_REGS_COUNT * 4) + 5;
         UDPpacket *packet = SDLNet_AllocPacket(packet_len);
@@ -583,14 +588,19 @@ void netplay_read_registration(struct controller_input_compat* cin_compats)
         if (reg_id == 0) //No one registered to control this player
         {
             Controls[i].Present = 0;
-            Controls[i].Plugin = 1;
+            Controls[i].Plugin = PLUGIN_NONE;
             Controls[i].RawData = 0;
             curr += 2;
         }
         else
         {
             Controls[i].Present = 1;
-            Controls[i].Plugin = input_data[curr];
+            if (i > 0 && input_data[curr] == PLUGIN_MEMPAK) // only P1 can use mempak
+                Controls[i].Plugin = PLUGIN_NONE;
+            else if (input_data[curr] == PLUGIN_TRANSFER_PAK) // Transferpak not supported during netplay
+                Controls[i].Plugin = PLUGIN_NONE;
+            else
+                Controls[i].Plugin = input_data[curr];
             l_plugin[i] = Controls[i].Plugin;
             ++curr;
             Controls[i].RawData = input_data[curr];
@@ -655,12 +665,6 @@ void netplay_update_input(struct pif* pif)
         netplay_send_raw_input(pif);
         netplay_get_raw_input(pif);
     }
-}
-
-void netplay_set_plugin(uint8_t control_id, uint8_t plugin)
-{
-    if (!(control_id > 0 && plugin == 2)) //Only P1 can use mempak
-        l_plugin[control_id] = plugin;
 }
 
 m64p_error netplay_send_config(char* data, int size)

--- a/src/main/netplay.h
+++ b/src/main/netplay.h
@@ -52,7 +52,6 @@ void netplay_check_sync(struct cp0* cp0);
 int netplay_next_controller();
 void netplay_read_registration(struct controller_input_compat* cin_compats);
 void netplay_update_input(struct pif* pif);
-void netplay_set_plugin(uint8_t control_id, uint8_t plugin);
 m64p_error netplay_send_config(char* data, int size);
 m64p_error netplay_receive_config(char* data, int size);
 


### PR DESCRIPTION
This is an upstreaming of the netplay code in simple64.

Notably:
* rdram_size needs to be set after `netplay_sync_settings`, so that it has the proper value for `disable_extra_mem`
* `main_speedlimiter_toggle` should be disabled when netplay is active
* A new packet type is added, `UDP_RECEIVE_KEY_INFO_GRATUITOUS`, which is when the server sends input data without being asked by the player. 
* Currently, the system checks for desyncs every second. Now, it is every 10 seconds (done in order to reduce network traffic, it's not really important to detect desyncs that quickly)