### PR TITLE
new_dynarec: fix FPU crashes

### DIFF
--- a/src/device/r4300/new_dynarec/arm/assem_arm.c
+++ b/src/device/r4300/new_dynarec/arm/assem_arm.c
@@ -3125,69 +3125,63 @@ static void fconv_assemble_arm(int i,struct regstat *i_regs)
   save_regs(reglist);
 
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_s_w);
   }
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x21) {
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
     emit_call((int)cvt_d_w);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_s_l);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x21) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_d_l);
   }
 
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x21) {
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
     emit_call((int)cvt_d_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x24) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_w_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x25) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_l_s);
   }
 
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_s_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x24) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_w_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x25) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm(FP,fp_fcr31,ARG1_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((int)cvt_l_d);
@@ -3568,19 +3562,18 @@ static void float_assemble(int i,struct regstat *i_regs)
     switch(source[i]&0x3f)
     {
       case 0x00: case 0x01: case 0x02: case 0x03:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_addimm(FP,fp_fcr31,ARG1_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>16)&0x1f],ARG3_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG4_REG);
         break;
      case 0x04:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_addimm(FP,fp_fcr31,ARG1_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
         break;
      case 0x05: case 0x06: case 0x07:
+        emit_addimm(FP,fp_fcr31,ARG1_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
         break;
@@ -3604,19 +3597,18 @@ static void float_assemble(int i,struct regstat *i_regs)
     switch(source[i]&0x3f)
     {
       case 0x00: case 0x01: case 0x02: case 0x03:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_addimm(FP,fp_fcr31,ARG1_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>16)&0x1f],ARG3_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG4_REG);
         break;
      case 0x04:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_addimm(FP,fp_fcr31,ARG1_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
         break;
      case 0x05: case 0x06: case 0x07:
+        emit_addimm(FP,fp_fcr31,ARG1_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
         emit_readptr((u_int)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
         break;

--- a/src/device/r4300/new_dynarec/arm64/assem_arm64.c
+++ b/src/device/r4300/new_dynarec/arm64/assem_arm64.c
@@ -3740,69 +3740,63 @@ static void fconv_assemble_arm64(int i,struct regstat *i_regs)
   save_regs(reglist);
 
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_s_w);
   }
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x21) {
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
     emit_call((intptr_t)cvt_d_w);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_s_l);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x21) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_d_l);
   }
 
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x21) {
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
     emit_call((intptr_t)cvt_d_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x24) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_w_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x25) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_l_s);
   }
 
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_s_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x24) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_w_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x25) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_addimm64(FP,fp_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_l_d);
@@ -4179,19 +4173,18 @@ static void float_assemble(int i,struct regstat *i_regs)
     switch(source[i]&0x3f)
     {
       case 0x00: case 0x01: case 0x02: case 0x03:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_addimm64(FP,fp_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>16)&0x1f],ARG3_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG4_REG);
         break;
      case 0x04:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_addimm64(FP,fp_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
         break;
      case 0x05: case 0x06: case 0x07:
+        emit_addimm64(FP,fp_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
         break;
@@ -4214,19 +4207,18 @@ static void float_assemble(int i,struct regstat *i_regs)
     switch(source[i]&0x3f)
     {
       case 0x00: case 0x01: case 0x02: case 0x03:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_addimm64(FP,fp_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>16)&0x1f],ARG3_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG4_REG);
         break;
      case 0x04:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_addimm64(FP,fp_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
         break;
      case 0x05: case 0x06: case 0x07:
+        emit_addimm64(FP,fp_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
         break;

--- a/src/device/r4300/new_dynarec/x64/assem_x64.c
+++ b/src/device/r4300/new_dynarec/x64/assem_x64.c
@@ -3617,69 +3617,63 @@ static void fconv_assemble_x64(int i,struct regstat *i_regs)
   save_regs(reglist);
 
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_s_w);
   }
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x21) {
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
     emit_call((intptr_t)cvt_d_w);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_s_l);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x21) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_d_l);
   }
 
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x21) {
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
     emit_call((intptr_t)cvt_d_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x24) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_w_s);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x25) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_l_s);
   }
 
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x20) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_s_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x24) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_w_d);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x25) {
-    if(fs>=0) emit_mov(fs,ARG1_REG);
-    else emit_loadreg(FSREG,ARG1_REG);
+    emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
     emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
     emit_call((intptr_t)cvt_l_d);
@@ -4030,19 +4024,18 @@ static void float_assemble(int i,struct regstat *i_regs)
     switch(source[i]&0x3f)
     {
       case 0x00: case 0x01: case 0x02: case 0x03:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>16)&0x1f],ARG3_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG4_REG);
         break;
      case 0x04:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG3_REG);
         break;
      case 0x05: case 0x06: case 0x07:
+        emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f],ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f],ARG2_REG);
         break;
@@ -4066,19 +4059,18 @@ static void float_assemble(int i,struct regstat *i_regs)
     switch(source[i]&0x3f)
     {
       case 0x00: case 0x01: case 0x02: case 0x03:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>16)&0x1f],ARG3_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG4_REG);
         break;
      case 0x04:
-        if(fs>=0) emit_mov(fs,ARG1_REG);
-        else emit_loadreg(FSREG,ARG1_REG);
+        emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG2_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG3_REG);
         break;
      case 0x05: case 0x06: case 0x07:
+        emit_lea_rip((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31,ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f],ARG1_REG);
         emit_readptr((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f],ARG2_REG);
         break;

--- a/src/device/r4300/new_dynarec/x86/assem_x86.c
+++ b/src/device/r4300/new_dynarec/x86/assem_x86.c
@@ -3196,8 +3196,7 @@ static void fconv_assemble_x86(int i,struct regstat *i_regs)
   if(opcode2[i]==0x14&&(source[i]&0x3f)==0x20) {
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f]);
-    if(fs>=0) emit_pushreg(fs);
-    else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     emit_call((int)cvt_s_w);
     emit_addimm(ESP,12,ESP);
   }
@@ -3210,16 +3209,14 @@ static void fconv_assemble_x86(int i,struct regstat *i_regs)
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x20) {
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f]);
-    if(fs>=0) emit_pushreg(fs);
-    else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     emit_call((int)cvt_s_l);
     emit_addimm(ESP,12,ESP);
   }
   if(opcode2[i]==0x15&&(source[i]&0x3f)==0x21) {
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f]);
-    if(fs>=0) emit_pushreg(fs);
-    else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     emit_call((int)cvt_d_l);
     emit_addimm(ESP,12,ESP);
   }
@@ -3233,16 +3230,14 @@ static void fconv_assemble_x86(int i,struct regstat *i_regs)
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x24) {
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f]);
-    if(fs>=0) emit_pushreg(fs);
-    else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     emit_call((int)cvt_w_s);
     emit_addimm(ESP,12,ESP);
   }
   if(opcode2[i]==0x10&&(source[i]&0x3f)==0x25) {
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f]);
-    if(fs>=0) emit_pushreg(fs);
-    else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     emit_call((int)cvt_l_s);
     emit_addimm(ESP,12,ESP);
   }
@@ -3250,24 +3245,21 @@ static void fconv_assemble_x86(int i,struct regstat *i_regs)
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x20) {
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f]);
-    if(fs>=0) emit_pushreg(fs);
-    else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     emit_call((int)cvt_s_d);
     emit_addimm(ESP,12,ESP);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x24) {
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>> 6)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f]);
-    if(fs>=0) emit_pushreg(fs);
-    else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     emit_call((int)cvt_w_d);
     emit_addimm(ESP,12,ESP);
   }
   if(opcode2[i]==0x11&&(source[i]&0x3f)==0x25) {
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>> 6)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f]);
-    if(fs>=0) emit_pushreg(fs);
-    else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     emit_call((int)cvt_l_d);
     emit_addimm(ESP,12,ESP);
   }
@@ -3626,10 +3618,7 @@ static void float_assemble(int i,struct regstat *i_regs)
     if((source[i]&0x3f)<4)
       emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>16)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_simple[(source[i]>>11)&0x1f]);
-    if((source[i]&0x3f)<=4) {
-      if(fs>=0) emit_pushreg(fs);
-      else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
-    }
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     switch(source[i]&0x3f)
     {
       case 0x00:
@@ -3673,11 +3662,7 @@ static void float_assemble(int i,struct regstat *i_regs)
     if((source[i]&0x3f)<4)
       emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>16)&0x1f]);
     emit_pushmem((intptr_t)&g_dev.r4300.new_dynarec_hot_state.cp1_regs_double[(source[i]>>11)&0x1f]);
-    if((source[i]&0x3f)<=4)
-    {
-      if(fs>=0) emit_pushreg(fs);
-      else emit_pushmem((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
-    }
+    emit_pushimm((int)&g_dev.r4300.new_dynarec_hot_state.cp1_fcr31);
     switch(source[i]&0x3f)
     {
       case 0x00:


### PR DESCRIPTION
This patch fix the new dynarec crashes on ARM and ARM64 platforms since the interpreter accuracy improvements, a RMG user reported it a while back and I made this experimental patch for it which fixes it (tested it on my pinebook pro aswell).

I had no idea the new dynarec called the FPU functions from `fpu.h`, and for some reason it kept working fine on x86_64, so I didn't notice it at all until the report came in from a RMG user, after some discussion with @m4xw, he said that we could best wait for @Gillou68310 to come up with a proper patch, but that was a while ago already, so to correct my mistake, I'm offering my patch, which could be improved later by Gillou if he wants to, but it fixes the crashes *now* instead of later, so users who are trying the latest git version of mupen64plus won't be hit by this bug anymore, but it's upto you (the maintainers) whether you agree with my thoughts on that or not.

This code was written by looking at other FPU functions which already had fcr31 pointer as first argument before my changes, so I copied that dynarec code and placed it everywhere where needed, which solves the crashes.

Fixes https://github.com/mupen64plus/mupen64plus-core/issues/1026

