### PR TITLE
Fix incorrect OSAL_DIR_SEPARATORS when compiling using mingw

### DIFF
--- a/src/osal/files.h
+++ b/src/osal/files.h
@@ -29,14 +29,17 @@
 #include <zlib.h>
 
 /* some file-related preprocessor definitions */
-#if defined(WIN32) && !defined(__MINGW32__)
+#if defined(WIN32)
   #include <io.h> // For _unlink()
 
   #define unlink _unlink
 
   #define OSAL_DIR_SEPARATORS           "\\/"
   #define WIDE_OSAL_DIR_SEPARATORS     L"\\/"
-  #define PATH_MAX _MAX_PATH
+
+  #ifndef PATH_MAX
+    #define PATH_MAX _MAX_PATH
+  #endif
 #else  /* Not WIN32 */
   #include <limits.h>  // for PATH_MAX
   #include <unistd.h>  // for unlink()


### PR DESCRIPTION
Fixes https://github.com/mupen64plus/mupen64plus-core/issues/937