### PR TITLE
Increase maximum allowed overclocking factor to 20

### DIFF
--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1640,8 +1640,8 @@ m64p_error main_run(void)
     if (count_per_op <= 0)
         count_per_op = ROM_SETTINGS.countperop;
 
-    if (count_per_op_denom_pot > 11)
-        count_per_op_denom_pot = 11;
+    if (count_per_op_denom_pot > 20)
+        count_per_op_denom_pot = 20;
 
     si_dma_duration = ConfigGetParamInt(g_CoreConfig, "SiDmaDuration");
     if (si_dma_duration < 0)


### PR DESCRIPTION
This can be used for particularly demanding game sections when coupled with 60 FPS cheats to ensure greater framerate stability, at the cost of increased CPU utilization.

For reference, 1964GEPD supports values up to 18. Even with an overclock factor of 18, there is still ample room to run above fullspeed on an i9-13900K on Perfect Dark, so a value of 20 should run well on today's high-end CPUs.

This limit of 20 also matches the value used in Project64: https://github.com/project64/project64/blob/dafa1fb24d50e4e8de09fe14a98696a4f71f4c1b/Source/Project64-core/N64System/Enhancement/Enhancement.cpp#L358-L370

PS: Is there a way to test custom ViRefresh without having to modify the ROM database? https://github.com/mupen64plus/mupen64plus-core/pull/204 seems to only source ViRefresh from the ROM database, with no way to specify it for a specific game in `mupen64plus.cfg`.
