### PR TITLE
Add missing ROM file size checks

### DIFF
--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -180,7 +180,8 @@ EXPORT m64p_error CALL CoreDoCommand(m64p_command Command, int ParamInt, void *P
         case M64CMD_ROM_OPEN:
             if (g_EmulatorRunning || l_DiskOpen || l_ROMOpen)
                 return M64ERR_INVALID_STATE;
-            if (ParamPtr == NULL || ParamInt < 4096)
+            // ROM buffer size must be divisible by 4 to avoid out-of-bounds read in swap_copy_rom (v64/n64 formats)
+            if (ParamPtr == NULL || ParamInt < 4096 || ParamInt > CART_ROM_MAX_SIZE || ParamInt % 4 != 0)
                 return M64ERR_INPUT_ASSERT;
             rval = open_rom((const unsigned char *) ParamPtr, ParamInt);
             if (rval == M64ERR_SUCCESS)


### PR DESCRIPTION
Fix for https://github.com/mupen64plus/mupen64plus-core/issues/1049.

Issue 2 could be fixed like this:
```plaintext
if Z64 format:
    no divisibility requirements
else if V64 format:
    ROM size must be divisible by 2
else if N64 format:
    ROM size must be divisible by 4
```
but in `CoreDoCommand` we don't have any information regarding file format (magic bytes are read in `open_rom`, after `ParamInt` validation). Because of that I just assumed that all ROMs sizes must be divisible by 4. If there are valid ROMs not meeting this criteria then either:
- some padding could be added to these ROM files (to make their size divisible by 4), or
- emulator utilizing m64p-core (such as RMG) could calculate ROM buffer size like this: `buffer_size = (rom_file_size + 3) & -4` (ROM size rounded up to the nearest 32-bit alignment)