### PR TITLE
Update "libmd5-rfc" code to the one used in CPython v2.7 repository…

### DIFF
--- a/subprojects/md5/md5.c
+++ b/subprojects/md5/md5.c
@@ -27,7 +27,7 @@
 
   This code implements the MD5 Algorithm defined in RFC 1321, whose
   text is available at
-    http://www.ietf.org/rfc/rfc1321.txt
+        http://www.ietf.org/rfc/rfc1321.txt
   The code is derived from the text of the RFC, including the test suite
   (section A.5) but excluding the rest of Appendix A.  It does not include
   any code or documentation that is identified in the RFC as being
@@ -38,24 +38,24 @@
   that follows (in reverse chronological order):
 
   2002-04-13 lpd Clarified derivation from RFC 1321; now handles byte order
-    either statically or dynamically; added missing #include <string.h>
-    in library.
+        either statically or dynamically; added missing #include <string.h>
+        in library.
   2002-03-11 lpd Corrected argument list for main(), and added int return
-    type, in test program and T value program.
+        type, in test program and T value program.
   2002-02-21 lpd Added missing #include <stdio.h> in test program.
   2000-07-03 lpd Patched to eliminate warnings about "constant is
-    unsigned in ANSI C, signed in traditional"; made test program
-    self-checking.
+        unsigned in ANSI C, signed in traditional"; made test program
+        self-checking.
   1999-11-04 lpd Edited comments slightly for automatic TOC extraction.
   1999-10-18 lpd Fixed typo in header comment (ansi2knr rather than md5).
   1999-05-03 lpd Original version.
  */
 
 #include "md5.h"
-
 #include <string.h>
+#include <limits.h>
 
-#undef BYTE_ORDER   /* 1 = big-endian, -1 = little-endian, 0 = unknown */
+#undef BYTE_ORDER       /* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN
 #  define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)
 #else
@@ -133,8 +133,8 @@ static void
 md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 {
     md5_word_t
-    a = pms->abcd[0], b = pms->abcd[1],
-    c = pms->abcd[2], d = pms->abcd[3];
+        a = pms->abcd[0], b = pms->abcd[1],
+        c = pms->abcd[2], d = pms->abcd[3];
     md5_word_t t;
 #if BYTE_ORDER > 0
     /* Define storage only for big-endian CPUs. */
@@ -147,51 +147,51 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 
     {
 #if BYTE_ORDER == 0
-    /*
-     * Determine dynamically whether this is a big-endian or
-     * little-endian machine, since we can use a more efficient
-     * algorithm on the latter.
-     */
-    static const int w = 1;
-
-    if (*((const md5_byte_t *)&w)) /* dynamic little-endian */
-#endif
-#if BYTE_ORDER <= 0     /* little-endian */
-    {
         /*
-         * On little-endian machines, we can process properly aligned
-         * data without copying it.
+         * Determine dynamically whether this is a big-endian or
+         * little-endian machine, since we can use a more efficient
+         * algorithm on the latter.
          */
-        if (!((data - (const md5_byte_t *)0) & 3)) {
-        /* data are properly aligned */
-        X = (const md5_word_t *)data;
-        } else {
-        /* not aligned */
-        memcpy(xbuf, data, 64);
-        X = xbuf;
+        static const int w = 1;
+
+        if (*((const md5_byte_t *)&w)) /* dynamic little-endian */
+#endif
+#if BYTE_ORDER <= 0             /* little-endian */
+        {
+            /*
+             * On little-endian machines, we can process properly aligned
+             * data without copying it.
+             */
+            if (!((data - (const md5_byte_t *)0) & 3)) {
+                /* data are properly aligned */
+                X = (const md5_word_t *)data;
+            } else {
+                /* not aligned */
+                memcpy(xbuf, data, 64);
+                X = xbuf;
+            }
         }
-    }
 #endif
 #if BYTE_ORDER == 0
-    else            /* dynamic big-endian */
+        else                    /* dynamic big-endian */
 #endif
-#if BYTE_ORDER >= 0     /* big-endian */
-    {
-        /*
-         * On big-endian machines, we must arrange the bytes in the
-         * right order.
-         */
-        const md5_byte_t *xp = data;
-        int i;
+#if BYTE_ORDER >= 0             /* big-endian */
+        {
+            /*
+             * On big-endian machines, we must arrange the bytes in the
+             * right order.
+             */
+            const md5_byte_t *xp = data;
+            int i;
 
 #  if BYTE_ORDER == 0
-        X = xbuf;       /* (dynamic only) */
+            X = xbuf;           /* (dynamic only) */
 #  else
-#    define xbuf X      /* (static only) */
+#    define xbuf X              /* (static only) */
 #  endif
-        for (i = 0; i < 16; ++i, xp += 4)
-        xbuf[i] = xp[0] + (xp[1] << 8) + (xp[2] << 16) + (xp[3] << 24);
-    }
+            for (i = 0; i < 16; ++i, xp += 4)
+                xbuf[i] = xp[0] + (xp[1] << 8) + (xp[2] << 16) + (xp[3] << 24);
+        }
 #endif
     }
 
@@ -321,63 +321,74 @@ md5_init(md5_state_t *pms)
 }
 
 void
-md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes)
+md5_append(md5_state_t *pms, const md5_byte_t *data, unsigned int nbytes)
 {
     const md5_byte_t *p = data;
-    int left = nbytes;
-    int offset = (pms->count[0] >> 3) & 63;
+    unsigned int left = nbytes;
+    unsigned int offset = (pms->count[0] >> 3) & 63;
     md5_word_t nbits = (md5_word_t)(nbytes << 3);
 
     if (nbytes <= 0)
-    return;
+        return;
+
+    /* this special case is handled recursively */
+    if (nbytes > INT_MAX - offset) {
+        unsigned int overlap;
+
+        /* handle the append in two steps to prevent overflow */
+        overlap = 64 - offset;
+
+        md5_append(pms, data, overlap);
+        md5_append(pms, data + overlap, nbytes - overlap);
+        return;
+    }
 
     /* Update the message length. */
     pms->count[1] += nbytes >> 29;
     pms->count[0] += nbits;
     if (pms->count[0] < nbits)
-    pms->count[1]++;
+        pms->count[1]++;
 
     /* Process an initial partial block. */
     if (offset) {
-    int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
+        unsigned int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
 
-    memcpy(pms->buf + offset, p, copy);
-    if (offset + copy < 64)
-        return;
-    p += copy;
-    left -= copy;
-    md5_process(pms, pms->buf);
+        memcpy(pms->buf + offset, p, copy);
+        if (offset + copy < 64)
+            return;
+        p += copy;
+        left -= copy;
+        md5_process(pms, pms->buf);
     }
 
     /* Process full blocks. */
     for (; left >= 64; p += 64, left -= 64)
-    md5_process(pms, p);
+        md5_process(pms, p);
 
     /* Process a final partial block. */
     if (left)
-    memcpy(pms->buf, p, left);
+        memcpy(pms->buf, p, left);
 }
 
 void
 md5_finish(md5_state_t *pms, md5_byte_t digest[16])
 {
     static const md5_byte_t pad[64] = {
-    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
     md5_byte_t data[8];
     int i;
 
     /* Save the length before padding. */
     for (i = 0; i < 8; ++i)
-    data[i] = (md5_byte_t)(pms->count[i >> 2] >> ((i & 3) << 3));
+        data[i] = (md5_byte_t)(pms->count[i >> 2] >> ((i & 3) << 3));
     /* Pad to 56 bytes mod 64. */
     md5_append(pms, pad, ((55 - (pms->count[0] >> 3)) & 63) + 1);
     /* Append the length. */
     md5_append(pms, data, 8);
     for (i = 0; i < 16; ++i)
-    digest[i] = (md5_byte_t)(pms->abcd[i >> 2] >> ((i & 3) << 3));
+        digest[i] = (md5_byte_t)(pms->abcd[i >> 2] >> ((i & 3) << 3));
 }
-

--- a/subprojects/md5/md5.h
+++ b/subprojects/md5/md5.h
@@ -21,13 +21,13 @@
   ghost@aladdin.com
 
  */
-/* $Id: md5.h,v 1.4 2002/04/13 19:20:28 lpd Exp $ */
+/* $Id$ */
 /*
   Independent implementation of MD5 (RFC 1321).
 
   This code implements the MD5 Algorithm defined in RFC 1321, whose
   text is available at
-    http://www.ietf.org/rfc/rfc1321.txt
+	http://www.ietf.org/rfc/rfc1321.txt
   The code is derived from the text of the RFC, including the test suite
   (section A.5) but excluding the rest of Appendix A.  It does not include
   any code or documentation that is identified in the RFC as being
@@ -38,12 +38,12 @@
   that follows (in reverse chronological order):
 
   2002-04-13 lpd Removed support for non-ANSI compilers; removed
-    references to Ghostscript; clarified derivation from RFC 1321;
-    now handles byte order either statically or dynamically.
+	references to Ghostscript; clarified derivation from RFC 1321;
+	now handles byte order either statically or dynamically.
   1999-11-04 lpd Edited comments slightly for automatic TOC extraction.
   1999-10-18 lpd Fixed typo in header comment (ansi2knr rather than md5);
-    added conditionalization for C++ compilation from Martin
-    Purschke <purschke@bnl.gov>.
+	added conditionalization for C++ compilation from Martin
+	Purschke <purschke@bnl.gov>.
   1999-05-03 lpd Original version.
  */
 
@@ -65,9 +65,9 @@ typedef unsigned int md5_word_t; /* 32-bit word */
 
 /* Define the state of the MD5 Algorithm. */
 typedef struct md5_state_s {
-    md5_word_t count[2];    /* message length in bits, lsw first */
-    md5_word_t abcd[4];     /* digest buffer */
-    md5_byte_t buf[64];     /* accumulate block */
+    md5_word_t count[2];	/* message length in bits, lsw first */
+    md5_word_t abcd[4];		/* digest buffer */
+    md5_byte_t buf[64];		/* accumulate block */
 } md5_state_t;
 
 #ifdef __cplusplus
@@ -79,7 +79,7 @@ extern "C"
 void md5_init(md5_state_t *pms);
 
 /* Append a string to the message. */
-void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes);
+void md5_append(md5_state_t *pms, const md5_byte_t *data, unsigned int nbytes);
 
 /* Finish the message and return the digest. */
 void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
@@ -89,4 +89,3 @@ void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
 #endif
 
 #endif /* md5_INCLUDED */
-


### PR DESCRIPTION
Source code: https://github.com/python/cpython/tree/v2.7/Modules

In reality, this vulnerability is irrelevant due to the current size limit of the supported ROMs... but it exists.