### PR TITLE
Add support for new PIF ROM and reset PIF

### DIFF
--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -221,7 +221,7 @@ EXPORT m64p_error CALL CoreDoCommand(m64p_command Command, int ParamInt, void *P
         case M64CMD_PIF_OPEN:
             if (g_EmulatorRunning)
                 return M64ERR_INVALID_STATE;
-            if (ParamPtr == NULL || ParamInt != 2048)
+            if (ParamPtr == NULL || ParamInt < 1984 || ParamInt > 2048 || ParamInt % 4 != 0)
                 return M64ERR_INPUT_ASSERT;
             return open_pif((const unsigned char *) ParamPtr, ParamInt);
         case M64CMD_ROM_GET_HEADER:

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1998,6 +1998,9 @@ m64p_error main_run(void)
     close_file_storage(&mpk);
     close_dd_disk(&dd_disk);
 
+    /* reset pif */
+    close_pif();
+
     if (ConfigGetParamBool(g_CoreConfig, "OnScreenDisplay"))
     {
         osd_exit();
@@ -2040,6 +2043,9 @@ on_gfx_open_failure:
     close_file_storage(&eep);
     close_file_storage(&mpk);
     close_dd_disk(&dd_disk);
+
+    /* reset pif */
+    close_pif();
 
     return failure_rval;
 }
@@ -2085,8 +2091,11 @@ void main_stop(void)
 
 m64p_error open_pif(const unsigned char* pifimage, unsigned int size)
 {
-    md5_byte_t pif_ntsc_md5[] = {0x49, 0x21, 0xD5, 0xF2, 0x16, 0x5D, 0xEE, 0x6E, 0x24, 0x96, 0xF4, 0x38, 0x8C, 0x4C, 0x81, 0xDA};
-    md5_byte_t pif_pal_md5[]  = {0x2B, 0x6E, 0xEC, 0x58, 0x6F, 0xAA, 0x43, 0xF3, 0x46, 0x23, 0x33, 0xB8, 0x44, 0x83, 0x45, 0x54};
+    md5_byte_t old_pif_ntsc_md5[] = {0x49, 0x21, 0xD5, 0xF2, 0x16, 0x5D, 0xEE, 0x6E, 0x24, 0x96, 0xF4, 0x38, 0x8C, 0x4C, 0x81, 0xDA};
+    md5_byte_t old_pif_pal_md5[]  = {0x2B, 0x6E, 0xEC, 0x58, 0x6F, 0xAA, 0x43, 0xF3, 0x46, 0x23, 0x33, 0xB8, 0x44, 0x83, 0x45, 0x54};
+
+    md5_byte_t pif_ntsc_md5[] = {0x5C, 0x12, 0x4E, 0x79, 0x48, 0xAD, 0xA8, 0x5D, 0xA6, 0x03, 0xA5, 0x22, 0x78, 0x29, 0x40, 0xD0};
+    md5_byte_t pif_pal_md5[]  = {0xD4, 0x23, 0x2D, 0xC9, 0x35, 0xCA, 0xD0, 0x65, 0x0A, 0xC2, 0x66, 0x4D, 0x52, 0x28, 0x1F, 0x3A};
 
     uint32_t *dst32 = mem_base_u32(g_mem_base, MM_PIF_MEM);
     uint32_t *src32 = (uint32_t*) pifimage;
@@ -2097,10 +2106,16 @@ m64p_error open_pif(const unsigned char* pifimage, unsigned int size)
     md5_append(&state, (const md5_byte_t*)pifimage, size);
     md5_finish(&state, digest);
 
-    if (memcmp(digest, pif_ntsc_md5, 16) == 0)
+    if (memcmp(digest, old_pif_ntsc_md5, 16) == 0 ||
+        memcmp(digest, pif_ntsc_md5, 16) == 0)
+    {
         DebugMessage(M64MSG_INFO, "Using NTSC PIF ROM");
-    else if (memcmp(digest, pif_pal_md5, 16) == 0)
+    }
+    else if (memcmp(digest, old_pif_pal_md5, 16) == 0 ||
+             memcmp(digest, pif_pal_md5, 16) == 0)
+    {
         DebugMessage(M64MSG_INFO, "Using PAL PIF ROM");
+    }
     else
     {
         DebugMessage(M64MSG_ERROR, "Invalid PIF ROM");
@@ -2111,5 +2126,11 @@ m64p_error open_pif(const unsigned char* pifimage, unsigned int size)
         *dst32++ = big32(*src32++);
 
     g_start_address = UINT32_C(0xbfc00000);
+    return M64ERR_SUCCESS;
+}
+
+m64p_error close_pif(void)
+{
+    g_start_address = UINT32_C(0xa4000040);
     return M64ERR_SUCCESS;
 }

--- a/src/main/main.h
+++ b/src/main/main.h
@@ -102,6 +102,7 @@ int        main_volume_get_muted(void);
 m64p_error main_reset(int do_hard_reset);
 
 m64p_error open_pif(const unsigned char* pifimage, unsigned int size);
+m64p_error close_pif(void);
 
 #endif /* __MAIN_H__ */
 


### PR DESCRIPTION
This adds support for the PIF ROMs provided by Ares, and this resets the PIF by resetting `g_start_address` after emulation, so a front-end can toggle the PIF ROM without having to shutdown & startup the core.