### PR TITLE
Backport mupen64plus-libretro-nx dynarec fix for OoTMM randomizer

### DIFF
--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -2338,7 +2338,9 @@ static void tlb_speed_hacks()
 u_int verify_dirty(struct ll_entry * head)
 {
   void *source;
-  if((int)head->start>=0xa4000000&&(int)head->start<0xa4001000) {
+  if((int)head->start>=0xa0000000&&(int)head->start<0xa07fffff) {
+    source=(void *)((uintptr_t)g_dev.rdram.dram+head->start-0xa0000000);
+  }else if((int)head->start>=0xa4000000&&(int)head->start<0xa4001000) {
     source=(void *)((uintptr_t)g_dev.sp.mem+head->start-0xa4000000);
   }else if((int)head->start>=0x80000000&&(int)head->start<0x80800000) {
     source=(void *)((uintptr_t)g_dev.rdram.dram+head->start-(uintptr_t)0x80000000);
@@ -8769,7 +8771,11 @@ int new_recompile_block(int addr)
 #endif
   start = (u_int)addr&~3;
   //assert(((u_int)addr&1)==0);
-  if ((int)addr >= 0xa4000000 && (int)addr < 0xa4001000) {
+  if ((int)addr >= 0xa0000000 && (int)addr < 0xa07fffff) {
+    source = (u_int *)((uintptr_t)g_dev.rdram.dram+start-0xa0000000);
+    pagelimit = 0xa07fffff;
+  }
+  else if ((int)addr >= 0xa4000000 && (int)addr < 0xa4001000) {
     source = (u_int *)((uintptr_t)g_dev.sp.mem+start-0xa4000000);
     pagelimit = 0xa4001000;
   }


### PR DESCRIPTION
So, currently https://ootmm.com/ works with said libretro core but crashes when transitioning between games with upstream m64p. I narrowed it down to this commit: https://github.com/libretro/mupen64plus-libretro-nx/commit/9cbe0fedf18ee13874ac3361ad013c41806fe4c7

With this change I can confirm it switches without crashes:

[Screencast from 2024-07-05 18-26-14.webm](https://github.com/mupen64plus/mupen64plus-core/assets/1510457/b0db0a13-9d51-4df9-ae49-5f02cd9bd0d2)

Disclaimer: I don't know if it makes sense, this is their commit unchanged (except for code style fixes)