### PR TITLE
Fix operator precedence in some big-endian code.

### DIFF
--- a/src/device/r4300/cp1.c
+++ b/src/device/r4300/cp1.c
@@ -110,7 +110,7 @@ void set_fpr_pointers(struct cp1* cp1, uint32_t newStatus)
     {
         for (i = 0; i < 32; i++)
         {
-            (r4300_cp1_regs_simple(cp1))[i] = &cp1->regs[i & ~1].float32[i & 1 ^ DOUBLE_HALF_XOR];
+            (r4300_cp1_regs_simple(cp1))[i] = &cp1->regs[i & ~1].float32[(i & 1) ^ DOUBLE_HALF_XOR];
             (r4300_cp1_regs_double(cp1))[i] = &cp1->regs[i & ~1].float64;
         }
     }


### PR DESCRIPTION
This matches the original version of the code (9644b14f96ddddf34c9cdfedc9d11fc61dc8ffab). In C, the '&' operator occurs after the '^' operator, meaning that the result of `i & 1 ^ 1` is always 0.