### PR TITLE
build: remove -fno-strict-aliasing

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -159,7 +159,7 @@ SUBDIR = ../../subprojects
 # base CFLAGS, LDLIBS, and LDFLAGS
 OPTFLAGS ?= -O3 -flto
 WARNFLAGS ?= -Wall
-CFLAGS += -fno-strict-aliasing -fvisibility=hidden -I$(SRCDIR) -I$(SRCDIR)/asm_defines -DM64P_PARALLEL
+CFLAGS += -fvisibility=hidden -I$(SRCDIR) -I$(SRCDIR)/asm_defines -DM64P_PARALLEL
 CXXFLAGS += -fvisibility-inlines-hidden
 LDLIBS +=  -lm
 


### PR DESCRIPTION
It builds with -Werror=strict-aliasing so this should be unneeded.

I'll check the other plugins based on the results of this PR.