### PR TITLE
build: drop SDL1 support + use pkg-config for SDL2

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -351,16 +351,18 @@ endif
 
 # test for presence of SDL
 ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
-  SDL_CONFIG = $(CROSS_COMPILE)sdl2-config
-  ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
-    $(error No SDL development libraries found!)
-  else
-    ifeq ($(NETPLAY), 1)
-      SDL_LDLIBS += -lSDL2_net
-    endif
+  ifeq ($(shell $(PKG_CONFIG) --modversion sdl2 2>/dev/null),)
+    $(error No SDL2 development libraries found!)
   endif
-  SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
-  SDL_LDLIBS += $(shell $(SDL_CONFIG) --libs)
+  ifeq ($(NETPLAY), 1)
+    ifeq ($(shell $(PKG_CONFIG) --modversion SDL2_net 2>/dev/null),)
+      $(error No SDL2_net development libraries found!)
+    endif
+    SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_net)
+    SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs SDL2_net)
+  endif
+  SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2)
+  SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl2)
 endif
 CFLAGS += $(SDL_CFLAGS)
 LDLIBS += $(SDL_LDLIBS)

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -353,17 +353,7 @@ endif
 ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
   SDL_CONFIG = $(CROSS_COMPILE)sdl2-config
   ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
-    SDL_CONFIG = $(CROSS_COMPILE)sdl-config
-    ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
-      $(error No SDL development libraries found!)
-    else
-      ifeq ($(NETPLAY), 1)
-        SDL_LDLIBS += -lSDL_net
-      endif
-      # SDL1 doesn't support vulkan
-      VULKAN = 0
-      $(warning Using SDL 1.2 libraries)
-    endif
+    $(error No SDL development libraries found!)
   else
     ifeq ($(NETPLAY), 1)
       SDL_LDLIBS += -lSDL2_net


### PR DESCRIPTION
* Drops SDL1 support for the unix Makefile since it is unmaintained upstream and using it will result in a degraded experience especially when it receives so little testing. It also makes the SDL section of the Makefile far more complicated than it needs to be.
* Use pkg-config for SDl2. Using sdl2-config hasn't been required for a long time and using pkg-config is preferable for distros.

As a benefit this avoids `which(1)` as a dependency when `PKG_CONFIG` is explicitly set by the user as is the case with some distros.