### PR TITLE
Add missing VRU dummyinput function definitions

### DIFF
--- a/src/plugin/dummy_input.c
+++ b/src/plugin/dummy_input.c
@@ -85,3 +85,23 @@ void dummyinput_SDL_KeyUp(int keymod, int keysym)
 void dummyinput_RenderCallback(void)
 {
 }
+
+void dummyinput_SendVRUWord(uint16_t length, uint16_t *word, uint8_t lang)
+{
+}
+
+void dummyinput_SetMicState(int state)
+{
+}
+
+void dummyinput_ReadVRUResults(uint16_t *error_flags, uint16_t *num_results, uint16_t *mic_level, uint16_t *voice_level, uint16_t *voice_length, uint16_t *matches)
+{
+}
+
+void dummyinput_ClearVRUWords(uint8_t lenght)
+{
+}
+
+void dummyinput_SetVRUWordMask(uint8_t length, uint8_t *mask)
+{
+}

--- a/src/plugin/dummy_input.h
+++ b/src/plugin/dummy_input.h
@@ -38,6 +38,11 @@ extern void dummyinput_RomClosed(void);
 extern void dummyinput_SDL_KeyDown(int keymod, int keysym);
 extern void dummyinput_SDL_KeyUp(int keymod, int keysym);
 extern void dummyinput_RenderCallback(void);
+extern void dummyinput_SendVRUWord(uint16_t length, uint16_t *word, uint8_t lang);
+extern void dummyinput_SetMicState(int state);
+extern void dummyinput_ReadVRUResults(uint16_t *error_flags, uint16_t *num_results, uint16_t *mic_level, uint16_t *voice_level, uint16_t *voice_length, uint16_t *matches);
+extern void dummyinput_ClearVRUWords(uint8_t lenght);
+extern void dummyinput_SetVRUWordMask(uint8_t length, uint8_t *mask);
 
 #endif /* DUMMY_INPUT_H */
 

--- a/src/plugin/plugin.c
+++ b/src/plugin/plugin.c
@@ -101,7 +101,12 @@ static const input_plugin_functions dummy_input = {
     dummyinput_RomOpen,
     dummyinput_SDL_KeyDown,
     dummyinput_SDL_KeyUp,
-    dummyinput_RenderCallback
+    dummyinput_RenderCallback,
+    dummyinput_SendVRUWord,
+    dummyinput_SetMicState,
+    dummyinput_ReadVRUResults,
+    dummyinput_ClearVRUWords,
+    dummyinput_SetVRUWordMask
 };
 
 static const rsp_plugin_functions dummy_rsp = {


### PR DESCRIPTION
Fixes a compiler warning when building with `-Wall -Wextra`