### PR TITLE
Fix abs() warning in dd_controller.c

### DIFF
--- a/src/device/dd/dd_controller.c
+++ b/src/device/dd/dd_controller.c
@@ -448,7 +448,8 @@ void read_dd_regs(void* opaque, uint32_t address, uint32_t* value)
 
 void write_dd_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask)
 {
-    unsigned int head, track, old_track, cycles;
+    uint32_t head, cycles;
+    int32_t  track, old_track;
     const uint16_t startTrackZones[9] = { 0x000, 0x09E, 0x13C, 0x1D1, 0x266, 0x2FB, 0x390, 0x425, 0x497 };
     struct dd_controller* dd = (struct dd_controller*)opaque;
 


### PR DESCRIPTION
This fixes the following compiler warning:
```
    CC  _obj/device/dd/dd_controller.o
../../src/device/dd/dd_controller.c: In function ‘write_dd_regs’:
../../src/device/dd/dd_controller.c:512:30: warning: taking the absolute value of unsigned type ‘unsigned int’ has no effect [-Wabsolute-value]
  512 |             cycles += 4825 * abs(track - old_track);
      |                              ^~~
../../src/device/dd/dd_controller.c:547:30: warning: taking the absolute value of unsigned type ‘unsigned int’ has no effect [-Wabsolute-value]
  547 |             cycles += 4825 * abs(track - old_track);
      |               
```

I've asked @LuigiBlood for advice on what to change and this is the result of that.