### PR TITLE
Add support for SDL3

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -362,17 +362,28 @@ ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
     SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl3)
     SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl3)
   endif
-
-  ifeq ($(NETPLAY), 1)
-    ifeq ($(shell $(PKG_CONFIG) --modversion SDL2_net 2>/dev/null),)
-      $(error No SDL2_net development libraries found!)
-    endif
-    SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_net)
-    SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs SDL2_net)
-  endif
 endif
 CFLAGS += $(SDL_CFLAGS)
 LDLIBS += $(SDL_LDLIBS)
+
+# test for presence of SDL_net
+ifeq ($(NETPLAY), 1)
+  ifeq ($(origin SDLNET_CFLAGS) $(origin SDLNET_LDLIBS), undefined undefined)
+    ifeq ($(shell $(PKG_CONFIG) --modversion sdl3-net 2>/dev/null),)
+      ifeq ($(shell $(PKG_CONFIG) --modversion SDL2_net 2>/dev/null),)
+        $(error No SDL3_net or SDL2_net development libraries found!)
+      endif
+      SDLNET_CFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_net)
+      SDLNET_LDLIBS += $(shell $(PKG_CONFIG) --libs SDL2_net)
+    else
+      SDLNET_CFLAGS += -DUSE_SDL3NET
+      SDLNET_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl3-net)
+      SDLNET_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl3-net)
+    endif
+  endif
+  CFLAGS += $(SDLNET_CFLAGS)
+  LDLIBS += $(SDLNET_LDLIBS)
+endif
 
 ifeq ($(VC), 1)
   CFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/vmcs_host/linux

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -355,9 +355,13 @@ ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
     ifeq ($(shell $(PKG_CONFIG) --modversion sdl2 2>/dev/null),)
       $(error No SDL3 or SDL2 development libraries found!)
     endif
+    ifeq ($(SDL3_CAMERA), 1)
+    	$(error SDL3_CAMERA requires SDL3!)
+    endif
     SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2)
     SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl2)
   else
+    SDL3_CAMERA := 1
     SDL_CFLAGS += -DUSE_SDL3
     SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl3)
     SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl3)
@@ -762,6 +766,10 @@ ifeq ($(OPENCV), 1)
   CFLAGS += -DM64P_OPENCV
 endif
 
+ifeq ($(SDL3_CAMERA), 1)
+  SOURCE += $(SRCDIR)/backends/sdl3_video_capture.cpp
+  CFLAGS += -DSDL3_CAMERA
+endif
 
 # generate a list of object files to build, make a temporary directory for them
 OBJECTS := $(patsubst $(SRCDIR)/%.c,   $(OBJDIR)/%.o, $(filter $(SRCDIR)/%.c,   $(SOURCE)))

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -351,9 +351,18 @@ endif
 
 # test for presence of SDL
 ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
-  ifeq ($(shell $(PKG_CONFIG) --modversion sdl2 2>/dev/null),)
-    $(error No SDL2 development libraries found!)
+  ifeq ($(shell $(PKG_CONFIG) --modversion sdl3 2>/dev/null),)
+    ifeq ($(shell $(PKG_CONFIG) --modversion sdl2 2>/dev/null),)
+      $(error No SDL3 or SDL2 development libraries found!)
+    endif
+    SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2)
+    SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl2)
+  else
+    SDL_CFLAGS += -DUSE_SDL3
+    SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl3)
+    SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl3)
   endif
+
   ifeq ($(NETPLAY), 1)
     ifeq ($(shell $(PKG_CONFIG) --modversion SDL2_net 2>/dev/null),)
       $(error No SDL2_net development libraries found!)
@@ -361,8 +370,6 @@ ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
     SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags SDL2_net)
     SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs SDL2_net)
   endif
-  SDL_CFLAGS += $(shell $(PKG_CONFIG) --cflags sdl2)
-  SDL_LDLIBS += $(shell $(PKG_CONFIG) --libs sdl2)
 endif
 CFLAGS += $(SDL_CFLAGS)
 LDLIBS += $(SDL_LDLIBS)

--- a/src/api/frontend.c
+++ b/src/api/frontend.c
@@ -24,7 +24,11 @@
  * outside of the core library.
  */
 
+#ifdef USE_SDL3
+#include <SDL3/SDL.h>
+#else
 #include <SDL.h>
+#endif 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/backends/api/video_capture_backend.c
+++ b/src/backends/api/video_capture_backend.c
@@ -28,12 +28,18 @@ extern const struct video_capture_backend_interface g_idummy_video_capture_backe
 #if defined(M64P_OPENCV)
 extern const struct video_capture_backend_interface g_iopencv_video_capture_backend;
 #endif
+#if defined(SDL3_CAMERA)
+extern const struct video_capture_backend_interface g_isdl3_video_capture_backend;
+#endif
 
 
 const struct video_capture_backend_interface* g_video_capture_backend_interfaces[] =
 {
 #if defined(M64P_OPENCV)
     &g_iopencv_video_capture_backend,
+#endif
+#if defined(SDL3_CAMERA)
+    &g_isdl3_video_capture_backend,
 #endif
     &g_idummy_video_capture_backend,
     NULL /* sentinel - must be last element */

--- a/src/backends/api/video_capture_backend.h
+++ b/src/backends/api/video_capture_backend.h
@@ -30,6 +30,8 @@
 #if !defined(DEFAULT_VIDEO_CAPTURE_BACKEND)
 #if defined(M64P_OPENCV)
 #define DEFAULT_VIDEO_CAPTURE_BACKEND "opencv"
+#elif defined(SDL3_CAMERA)
+#define DEFAULT_VIDEO_CAPTURE_BACKEND "sdl3"
 #else
 #define DEFAULT_VIDEO_CAPTURE_BACKEND ""
 #endif

--- a/src/backends/sdl3_video_capture.c
+++ b/src/backends/sdl3_video_capture.c
@@ -1,0 +1,282 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus - sdl3_video_capture.cpp                                  *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
+ *   Copyright (C) 2025 Rosalie Wanders                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <SDL3/SDL.h>
+
+struct sdl3_video_capture
+{
+    int init_sdl;
+
+    SDL_Camera* camera;
+    SDL_CameraID camera_id;
+
+    char* target_camera_name;
+
+    unsigned int width;
+    unsigned int height;
+};
+
+#include "backends/api/video_capture_backend.h"
+
+#define M64P_CORE_PROTOTYPES 1
+#include "api/callbacks.h"
+#include "api/m64p_types.h"
+#include "api/m64p_config.h"
+
+#include <stdlib.h>
+
+const struct video_capture_backend_interface g_isdl3_video_capture_backend;
+
+static m64p_error sdl3_init(void** vcap, const char* section)
+{
+    /* initialize data */
+    *vcap = malloc(sizeof(struct sdl3_video_capture));
+    if (*vcap == NULL)
+    {
+        return M64ERR_NO_MEMORY;
+    }
+
+    memset(*vcap, 0, sizeof(struct sdl3_video_capture));
+    struct sdl3_video_capture* sdl = (struct sdl3_video_capture*)(*vcap);
+
+    /* attempt to initialize SDL3 */
+    if (!SDL_WasInit(SDL_INIT_CAMERA))
+    {
+        if (!SDL_Init(SDL_INIT_CAMERA))
+        {
+            DebugMessage(M64MSG_ERROR, "Failed to initialize SDL camera subsystem: %s", SDL_GetError());
+            free(sdl);
+            return M64ERR_SYSTEM_FAIL;
+        }
+
+        sdl->init_sdl = 1;
+    }
+
+    /* default parameters */
+    const char* device = NULL;
+
+    if (section && strlen(section) > 0)
+    {
+        m64p_handle config = NULL;
+
+        if (ConfigOpenSection(section, &config) != M64ERR_SUCCESS)
+        {
+            DebugMessage(M64MSG_WARNING, "Failed to open video configuration section: %s, falling back to default video device", section);
+            return M64ERR_SUCCESS;
+        }
+
+        /* set default parameters */
+        ConfigSetDefaultString(config, "device", "", "Device name to use for capture or empty for default.");
+
+        /* get parameters */
+        device = ConfigGetParamString(config, "device");
+    }
+
+    /* store device name for later */
+    if (device != NULL && strlen(device) > 0)
+    {
+        sdl->target_camera_name = strdup(device);
+    }
+
+    return M64ERR_SUCCESS;
+}
+
+static void sdl3_release(void* vcap)
+{
+    struct sdl3_video_capture* sdl = (struct sdl3_video_capture*)(vcap);
+    if (sdl != NULL)
+    {
+        if (sdl->init_sdl && SDL_WasInit(SDL_INIT_CAMERA))
+        {
+            SDL_QuitSubSystem(SDL_INIT_CAMERA);
+        }
+
+        if (sdl->target_camera_name != NULL)
+        {
+            free(sdl->target_camera_name);
+        }
+
+        free(sdl);
+    }
+}
+
+static m64p_error sdl3_open(void* vcap, unsigned int width, unsigned int height)
+{
+    struct sdl3_video_capture* sdl = (struct sdl3_video_capture*)(vcap);
+    if (sdl == NULL)
+    {
+        return M64ERR_NOT_INIT;
+    }
+
+    sdl->width = width;
+    sdl->height = height;
+
+    int cameras_count = 0;
+    SDL_CameraID* cameras = SDL_GetCameras(&cameras_count);
+    if (cameras == NULL)
+    {
+        DebugMessage(M64MSG_ERROR, "Failed to retrieve list of video devices: %s", SDL_GetError());
+        return M64ERR_SYSTEM_FAIL;
+    }
+    if (cameras_count == 0)
+    {
+        DebugMessage(M64MSG_WARNING, "Failed to find video devices");
+        return M64ERR_INPUT_NOT_FOUND;
+    }
+
+    /* fallback to default camera */
+    sdl->camera_id = cameras[0];
+
+    /* print name of every camera to user, and 
+     * attempt to find the camera that the user
+     * specified in the config */
+    int found_camera = 0;
+    for (int i = 0; i < cameras_count; i++)
+    {
+        const char* name = SDL_GetCameraName(cameras[i]);
+        if (name == NULL)
+        {
+            DebugMessage(M64MSG_ERROR, "Failed to retrieve video device name: %s", SDL_GetError());
+            continue;
+        }
+
+        DebugMessage(M64MSG_INFO, "Found video device: \"%s\"", name);
+
+        if (sdl->target_camera_name != NULL &&
+            strcmp(sdl->target_camera_name, name) == 0)
+        {
+            sdl->camera_id = cameras[i];
+            found_camera = 1;
+            break;
+        }
+    }
+
+    /* show warning when device was not found */
+    if (sdl->target_camera_name != NULL && !found_camera)
+    {
+        DebugMessage(M64MSG_WARNING, "Failed to find video device with name \"%s\", falling back to default", sdl->target_camera_name);
+    }
+
+    SDL_free(cameras);
+
+    /* attempt to open camera */
+    sdl->camera = SDL_OpenCamera(sdl->camera_id, NULL);
+    if (sdl->camera == NULL)
+    {
+        DebugMessage(M64MSG_ERROR, "Failed to open video device: %s", SDL_GetError());
+        return M64ERR_SYSTEM_FAIL;
+    }
+
+    /* attempt to get permission for the camera */
+    int permission_state = SDL_GetCameraPermissionState(sdl->camera);
+    if (permission_state == 0)
+    {
+        DebugMessage(M64MSG_INFO, "Waiting until user has approved video access");
+        do
+        {
+            SDL_Delay(250);
+            permission_state = SDL_GetCameraPermissionState(sdl->camera);
+        } while (permission_state == 0);
+    }
+
+    if (permission_state == -1)
+    {
+        DebugMessage(M64MSG_ERROR, "Failed to open video device: permission denied");
+        return M64ERR_SYSTEM_FAIL;
+    }
+
+    DebugMessage(M64MSG_INFO, "Video successfully opened: %s", SDL_GetCameraName(sdl->camera_id));
+    return M64ERR_SUCCESS;
+}
+
+static void sdl3_close(void* vcap)
+{
+    struct sdl3_video_capture* sdl = (struct sdl3_video_capture*)(vcap);
+    if (sdl == NULL)
+    {
+        return;
+    }
+
+    if (sdl->camera != NULL)
+    {
+        SDL_CloseCamera(sdl->camera);
+    }
+
+    DebugMessage(M64MSG_INFO, "Video closed");
+}
+
+static m64p_error sdl3_grab_image(void* vcap, void* data)
+{
+    struct sdl3_video_capture* sdl = (struct sdl3_video_capture*)(vcap);
+    if (sdl == NULL || sdl->camera == NULL)
+    {
+        return M64ERR_NOT_INIT;
+    }
+
+    SDL_Surface* frame_surface = SDL_AcquireCameraFrame(sdl->camera, NULL);
+    if (frame_surface == NULL)
+    {
+        DebugMessage(M64MSG_ERROR, "Failed to grab video frame: %s", SDL_GetError());
+        return M64ERR_SYSTEM_FAIL;
+    }
+
+    SDL_Surface* target_surface = SDL_CreateSurface(sdl->width, sdl->height, SDL_PIXELFORMAT_BGR24);
+    if (target_surface == NULL)
+    {
+        DebugMessage(M64MSG_ERROR, "Failed to create target surface: %s\n", SDL_GetError());
+        SDL_ReleaseCameraFrame(sdl->camera, frame_surface);
+        return M64ERR_SYSTEM_FAIL;
+    }
+
+    int frame_size = SDL_min(frame_surface->w, frame_surface->h);
+    SDL_Rect frame_rect;
+    frame_rect.x = (frame_surface->w / 2) - (frame_size / 2);
+    frame_rect.y = 0;
+    frame_rect.w = frame_size;
+    frame_rect.h = frame_size;
+
+    if (!SDL_BlitSurfaceScaled(frame_surface, &frame_rect, target_surface, NULL, SDL_SCALEMODE_NEAREST))
+    {
+        DebugMessage(M64MSG_ERROR, "Failed to blit surface: %s", SDL_GetError());
+        SDL_ReleaseCameraFrame(sdl->camera, frame_surface);
+        SDL_DestroySurface(target_surface);
+        return M64ERR_SYSTEM_FAIL;
+    }
+
+    memcpy(data, target_surface->pixels, target_surface->w * target_surface->h * 3);
+
+    SDL_ReleaseCameraFrame(sdl->camera, frame_surface);
+    SDL_DestroySurface(target_surface);
+    return M64ERR_SUCCESS;
+}
+
+
+
+const struct video_capture_backend_interface g_isdl3_video_capture_backend =
+{
+    "sdl3",
+    sdl3_init,
+    sdl3_release,
+    sdl3_open,
+    sdl3_close,
+    sdl3_grab_image
+};
+

--- a/src/device/controllers/paks/biopak.c
+++ b/src/device/controllers/paks/biopak.c
@@ -28,7 +28,11 @@
 #include "api/m64p_types.h"
 #include "api/callbacks.h"
 
+#ifdef USE_SDL3
+#include <SDL3/SDL_timer.h>
+#else
 #include <SDL_timer.h>
+#endif
 
 #include <string.h>
 

--- a/src/device/gb/gb_cart.c
+++ b/src/device/gb/gb_cart.c
@@ -715,6 +715,9 @@ static void init_pocket_cam(struct pocket_cam* cam, uint8_t* ram, void* vcap, co
 
     cam->vcap = vcap;
     cam->ivcap = ivcap;
+
+    /* open video device */
+    cam->ivcap->open(cam->vcap,  M64282FP_SENSOR_W, M64282FP_SENSOR_H);
 }
 
 static void poweron_pocket_cam(struct pocket_cam* cam)

--- a/src/main/cheat.c
+++ b/src/main/cheat.c
@@ -22,8 +22,13 @@
 
 /* gameshark and xploder64 reference: http://doc.kodewerx.net/hacking_n64.html */
 
+#ifdef USE_SDL3
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_thread.h>
+#else
 #include <SDL.h>
 #include <SDL_thread.h>
+#endif
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -214,11 +219,13 @@ void cheat_apply_cheats(struct cheat_ctx* ctx, struct r4300_core* r4300, int ent
     if (list_empty(&ctx->active_cheats))
         return;
 
-    if (ctx->mutex == NULL || SDL_LockMutex(ctx->mutex) != 0)
+    if (ctx->mutex == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Internal error: failed to lock mutex in cheat_apply_cheats()");
         return;
     }
+
+    SDL_LockMutex(ctx->mutex);
 
     list_for_each_entry_t(cheat, &ctx->active_cheats, cheat_t, list) {
         if (cheat->enabled)
@@ -325,11 +332,13 @@ void cheat_delete_all(struct cheat_ctx* ctx)
     if (list_empty(&ctx->active_cheats))
         return;
 
-    if (ctx->mutex == NULL || SDL_LockMutex(ctx->mutex) != 0)
+    if (ctx->mutex == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Internal error: failed to lock mutex in cheat_delete_all()");
         return;
     }
+
+    SDL_LockMutex(ctx->mutex);
 
     list_for_each_entry_safe_t(cheat, safe_cheat, &ctx->active_cheats, cheat_t, list) {
         free(cheat->name);
@@ -352,11 +361,13 @@ int cheat_set_enabled(struct cheat_ctx* ctx, const char* name, int enabled)
     if (list_empty(&ctx->active_cheats))
         return 0;
 
-    if (ctx->mutex == NULL || SDL_LockMutex(ctx->mutex) != 0)
+    if (ctx->mutex == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Internal error: failed to lock mutex in cheat_set_enabled()");
         return 0;
     }
+
+    SDL_LockMutex(ctx->mutex);
 
     list_for_each_entry_t(cheat, &ctx->active_cheats, cheat_t, list) {
         if (strcmp(name, cheat->name) == 0)
@@ -376,11 +387,13 @@ int cheat_add_new(struct cheat_ctx* ctx, const char* name, m64p_cheat_code* code
     cheat_t *cheat;
     int i, j;
 
-    if (ctx->mutex == NULL || SDL_LockMutex(ctx->mutex) != 0)
+    if (ctx->mutex == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Internal error: failed to lock mutex in cheat_add_new()");
         return 0;
     }
+
+    SDL_LockMutex(ctx->mutex);
 
     /* create a new cheat function or erase the codes in an existing cheat function */
     cheat = find_or_create_cheat(ctx, name);

--- a/src/main/cheat.h
+++ b/src/main/cheat.h
@@ -36,7 +36,11 @@ struct r4300_core;
 
 struct cheat_ctx
 {
+#ifdef USE_SDL3
+    struct SDL_Mutex* mutex;
+#else
     struct SDL_mutex* mutex;
+#endif
     struct list_head active_cheats;
 };
 

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -334,8 +334,10 @@ static m64p_error init_video_capture_backend(const struct video_capture_backend_
         DebugMessage(M64MSG_INFO, "Using video capture backend: %s", (*ivcap)->name);
     }
     else {
-        DebugMessage(M64MSG_ERROR, "Failed to initialize video capture backend %s: %s", (*ivcap)->name, CoreErrorMessage(err));
-        *ivcap = NULL;
+        DebugMessage(M64MSG_ERROR, "Failed to initialize video capture backend %s: %s, falling back to dummy backend", (*ivcap)->name, CoreErrorMessage(err));
+        /* fallback to dummy backend */
+        *ivcap = get_video_capture_backend(NULL);
+        (*ivcap)->init(vcap, section);
     }
 
     free(section);
@@ -1704,10 +1706,7 @@ m64p_error main_run(void)
 
     /* init GbCamera backend specified in the configuration file */
     init_video_capture_backend(&igbcam_backend, &gbcam_backend,
-        g_CoreConfig, "GbCameraVideoCaptureBackend1");
-
-    /* open GB cam video device */
-    igbcam_backend->open(gbcam_backend, M64282FP_SENSOR_W, M64282FP_SENSOR_H);
+        g_CoreConfig, "GbCameraVideoCaptureBackend1");    
 
     /* open storage files, provide default content if not present */
     open_mpk_file(&mpk);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -28,7 +28,11 @@
  * if you want to implement an interface, you should look here
  */
 
+#ifdef USE_SDL3
+#include <SDL3/SDL.h>
+#else
 #include <SDL.h>
+#endif
 #include <assert.h>
 #include <stdarg.h>
 #include <stddef.h>

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -972,9 +972,9 @@ static void apply_speed_limiter(void)
     static unsigned long totalVIs = 0;
     static int resetOnce = 0;
     static int lastSpeedFactor = 100;
-    static unsigned int StartFPSTime = 0;
+    static uint64_t StartFPSTime = 0;
     static const double defaultSpeedFactor = 100.0;
-    unsigned int CurrentFPSTime = SDL_GetTicks();
+    uint64_t CurrentFPSTime = SDL_GetTicks();
 
     // calculate frame duration based upon ROM setting (50/60hz) and mupen64plus speed adjustment
     const double VILimitMilliseconds = 1000.0 / g_dev.vi.expected_refresh_rate;

--- a/src/main/netplay.c
+++ b/src/main/netplay.c
@@ -502,7 +502,7 @@ static int netplay_require_response(void* opaque)
     //We basically beg the server for input data.
     //After 10 seconds a timeout occurs, we assume we have lost connection to the server.
     uint8_t control_id = *(uint8_t*)opaque;
-    uint32_t timeout = SDL_GetTicks() + 10000;
+    uint64_t timeout = SDL_GetTicks() + 10000;
     while (!check_valid(control_id, l_cin_compats[control_id].netplay_count))
     {
         if (SDL_GetTicks() > timeout)

--- a/src/main/netplay.c
+++ b/src/main/netplay.c
@@ -40,6 +40,8 @@
 #include <netinet/ip.h>
 #endif
 
+#include <stdlib.h>
+
 /* small helper structures to wrap SDL2_net/SDL3_net */
 
 #ifdef USE_SDL3NET

--- a/src/main/netplay.c
+++ b/src/main/netplay.c
@@ -263,7 +263,7 @@ m64p_error netplay_start(const char* host, int port)
         return M64ERR_SYSTEM_FAIL;
     }
 
-    l_udpSocket = NET_CreateDatagramSocket(NULL, 0);
+    l_udpSocket = NET_CreateDatagramSocket(NULL, 0, 0);
     if (l_udpSocket == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Netplay: UDP socket creation failed: %s", SDL_GetError());
@@ -272,7 +272,7 @@ m64p_error netplay_start(const char* host, int port)
         return M64ERR_SYSTEM_FAIL;
     }
 
-    l_tcpSocket = NET_CreateClient(l_resolvedAddress, port);
+    l_tcpSocket = NET_CreateClient(l_resolvedAddress, port, 0);
     if (l_tcpSocket == NULL)
     {
         DebugMessage(M64MSG_ERROR, "Netplay: TCP socket connection failed: %s", SDL_GetError());

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -22,8 +22,13 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifdef USE_SDL3
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_thread.h>
+#else
 #include <SDL.h>
 #include <SDL_thread.h>
+#endif
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -68,7 +73,11 @@ static char *fname = NULL;
 static unsigned int slot = 0;
 static int autoinc_save_slot = 0;
 
+#ifdef USE_SDL3
+static SDL_Mutex *savestates_lock;
+#else
 static SDL_mutex *savestates_lock;
+#endif
 
 struct savestate_work {
     char *filepath;

--- a/src/main/screenshot.c
+++ b/src/main/screenshot.c
@@ -19,7 +19,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifdef USE_SDL3
+#include <SDL3/SDL.h>
+#else
 #include <SDL.h>
+#endif
 #include <ctype.h>
 #include <png.h>
 #include <setjmp.h>

--- a/src/main/sdl_key_converter.h
+++ b/src/main/sdl_key_converter.h
@@ -19,7 +19,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifdef USE_SDL3
+#include <SDL3/SDL.h>
+#else
 #include <SDL.h>
+#endif
 #include <stdint.h>
 
 #include "osal/preproc.h"

--- a/src/osd/osd.c
+++ b/src/osd/osd.c
@@ -23,9 +23,15 @@
 
 #include "oglft_c.h"
 
+#ifdef USE_SDL3
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_opengl.h>
+#include <SDL3/SDL_thread.h>
+#else
 #include <SDL.h>
 #include <SDL_opengl.h>
 #include <SDL_thread.h>
+#endif
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -56,7 +62,11 @@ static osd_message_t * osd_message_valid(osd_message_t *testmsg);
 
 static float fCornerScroll[OSD_NUM_CORNERS];
 
+#ifdef USE_SDL3
+static SDL_Mutex *osd_list_lock;
+#else
 static SDL_mutex *osd_list_lock;
+#endif
 
 // animation handlers
 static void (*l_animations[OSD_NUM_ANIM_TYPES])(osd_message_t *) = {

--- a/subprojects/oglft/OGLFT.h
+++ b/subprojects/oglft/OGLFT.h
@@ -30,7 +30,11 @@
 #include <vector>
 
 #define GL_GLEXT_PROTOTYPES
+#ifdef USE_SDL3
+#include <SDL3/SDL_opengl.h>
+#else
 #include <SDL_opengl.h>
+#endif
 #if defined(__MACOSX__)
 #include <OpenGL/glu.h>
 #elif defined(__MACOS__)


### PR DESCRIPTION
This patch makes mupen64plus-core support building with SDL3.

TODO:
[ ] joystick support for `eventloop.c`
[ ] SDL3 support for mupen64plus-input-sdl

Related PRs:
https://github.com/mupen64plus/mupen64plus-audio-sdl/pull/52
https://github.com/mupen64plus/mupen64plus-ui-console/pull/94