### PR TITLE
Add bounds checking to some DMA operations

### DIFF
--- a/src/device/cart/cart.c
+++ b/src/device/cart/cart.c
@@ -26,6 +26,8 @@
 
 #include "main/rom.h"
 
+#include "device/r4300/r4300_core.h"
+
 #include <stdint.h>
 #include <string.h>
 
@@ -129,10 +131,10 @@ void init_cart(struct cart* cart,
 
     init_flashram(&cart->flashram,
         flashram_type,
-        flashram_storage, iflashram_storage);
+        flashram_storage, iflashram_storage, r4300->rdram);
 
     init_sram(&cart->sram,
-        sram_storage, isram_storage);
+        sram_storage, isram_storage, r4300->rdram);
 
     if (ROM_SETTINGS.savetype == SAVETYPE_SRAM)
         cart->use_flashram = -1;

--- a/src/device/cart/cart_rom.c
+++ b/src/device/cart/cart_rom.c
@@ -28,6 +28,7 @@
 #include "device/memory/memory.h"
 #include "device/r4300/r4300_core.h"
 #include "device/rcp/pi/pi_controller.h"
+#include "device/rdram/rdram.h"
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -101,7 +102,7 @@ unsigned int cart_rom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr,
 
     if (cart_addr + length < cart_rom->rom_size)
     {
-        for(i = 0; i < length; ++i) {
+        for(i = 0; i < length && (dram_addr+i) < cart_rom->r4300->rdram->dram_size; ++i) {
             dram[(dram_addr+i)^S8] = mem[(cart_addr+i)^S8];
         }
     }
@@ -111,10 +112,10 @@ unsigned int cart_rom_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr,
             ? 0
             : cart_rom->rom_size - cart_addr;
 
-        for (i = 0; i < diff; ++i) {
+        for (i = 0; i < diff && (dram_addr+i) < cart_rom->r4300->rdram->dram_size; ++i) {
             dram[(dram_addr+i)^S8] = mem[(cart_addr+i)^S8];
         }
-        for (; i < length; ++i) {
+        for (; i < length && (dram_addr+i) < cart_rom->r4300->rdram->dram_size; ++i) {
             dram[(dram_addr+i)^S8] = 0;
         }
     }

--- a/src/device/cart/flashram.c
+++ b/src/device/cart/flashram.c
@@ -28,6 +28,7 @@
 #include "api/m64p_types.h"
 #include "backends/api/storage_backend.h"
 #include "device/memory/memory.h"
+#include "device/rdram/rdram.h"
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -122,12 +123,13 @@ static void flashram_command(struct flashram* flashram, uint32_t command)
 
 void init_flashram(struct flashram* flashram,
                    uint32_t flashram_id,
-                   void* storage, const struct storage_backend_interface* istorage)
+                   void* storage, const struct storage_backend_interface* istorage, struct rdram* rdram)
 {
     flashram->silicon_id[0] = FLASHRAM_TYPE_ID;
     flashram->silicon_id[1] = flashram_id;
     flashram->storage = storage;
     flashram->istorage = istorage;
+    flashram->rdram = rdram;
 }
 
 void poweron_flashram(struct flashram* flashram)
@@ -207,7 +209,7 @@ unsigned int flashram_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr,
         }
 
         /* do actual DMA */
-        for(i = 0; i < length; ++i) {
+        for(i = 0; i < length && (dram_addr+i) < flashram->rdram->dram_size; ++i) {
             dram[(dram_addr+i)^S8] = mem[(cart_addr+i)^S8];
         }
     }

--- a/src/device/cart/flashram.h
+++ b/src/device/cart/flashram.h
@@ -61,12 +61,13 @@ struct flashram
 
     void* storage;
     const struct storage_backend_interface* istorage;
+    struct rdram* rdram;
 };
 
 void init_flashram(struct flashram* flashram,
                    uint32_t flashram_id,
                    void* storage,
-                   const struct storage_backend_interface* istorage);
+                   const struct storage_backend_interface* istorage, struct rdram* rdram);
 
 void poweron_flashram(struct flashram* flashram);
 

--- a/src/device/cart/sram.c
+++ b/src/device/cart/sram.c
@@ -27,6 +27,7 @@
 
 #include "backends/api/storage_backend.h"
 #include "device/memory/memory.h"
+#include "device/rdram/rdram.h"
 
 #define SRAM_ADDR_MASK UINT32_C(0x0000ffff)
 
@@ -36,10 +37,11 @@ void format_sram(uint8_t* mem)
 }
 
 void init_sram(struct sram* sram,
-               void* storage, const struct storage_backend_interface* istorage)
+               void* storage, const struct storage_backend_interface* istorage, struct rdram* rdram)
 {
     sram->storage = storage;
     sram->istorage = istorage;
+    sram->rdram = rdram;
 }
 
 unsigned int sram_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length)
@@ -50,7 +52,7 @@ unsigned int sram_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr
 
     cart_addr &= SRAM_ADDR_MASK;
 
-    for (i = 0; i < length; ++i) {
+    for (i = 0; i < length && (cart_addr+i) < SRAM_SIZE; ++i) {
         mem[(cart_addr+i)^S8] = dram[(dram_addr+i)^S8];
     }
 
@@ -67,7 +69,7 @@ unsigned int sram_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uin
 
     cart_addr &= SRAM_ADDR_MASK;
 
-    for (i = 0; i < length; ++i) {
+    for (i = 0; i < length && (dram_addr+i) < sram->rdram->dram_size; ++i) {
         dram[(dram_addr+i)^S8] = mem[(cart_addr+i)^S8];
     }
 

--- a/src/device/cart/sram.h
+++ b/src/device/cart/sram.h
@@ -32,12 +32,13 @@ struct sram
 {
     void* storage;
     const struct storage_backend_interface* istorage;
+    struct rdram* rdram;
 };
 
 void format_sram(uint8_t* sram);
 
 void init_sram(struct sram* sram,
-               void* storage, const struct storage_backend_interface* istorage);
+               void* storage, const struct storage_backend_interface* istorage, struct rdram* rdram);
 
 unsigned int sram_dma_read(void* opaque, const uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);
 unsigned int sram_dma_write(void* opaque, uint8_t* dram, uint32_t dram_addr, uint32_t cart_addr, uint32_t length);


### PR DESCRIPTION
This patch is a backport from Logan's simple64.

Fixes #1083