### PR TITLE
Remove unused SDL_syswm header

### DIFF
--- a/src/main/eventloop.c
+++ b/src/main/eventloop.c
@@ -21,7 +21,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include <SDL.h>
-#include <SDL_syswm.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
With  #1094 merged this header is no longer used.