### PR TITLE
make: Fix compiling with MSYS2 CLANG64

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -253,7 +253,7 @@ ifeq ($(OS), OSX)
 endif
 ifeq ($(OS), MINGW)
   TARGET = mupen64plus$(POSTFIX).dll
-  ifeq ($(CC), clang)
+  ifeq (clang, $(word 1, $(shell $(CC) --version)))
     LDFLAGS += -shared -Wl,-export-all-symbols
   else
     LDFLAGS += -Wl,-Bsymbolic -shared -Wl,-export-all-symbols


### PR DESCRIPTION
The Makefile checks for `clang` as C compiler. This may not work using MSYS2 CLANG64, as the compiler may disguise itself as gcc. See: https://github.com/msys2/MINGW-packages/issues/9417#issuecomment-901039537

My idea for a fix is to check for the $MSYSTEM variable one way or another.
`ifeq ($(shell printenv MSYSTEM), CLANG64)` or `ifeq ($(shell echo $(MSYSTEM)), CLANG64)`