### PR TITLE
Fix transfer pak functionality

### DIFF
--- a/src/device/controllers/paks/transferpak.c
+++ b/src/device/controllers/paks/transferpak.c
@@ -35,9 +35,12 @@
 #include <string.h>
 
 
+#define RESET_MODE_CART_ENABLE_BIT UINT32_C(0x00000001)
+#define RESET_MODE_PAK_ENABLE_BIT UINT32_C(0x00000080)
+
 static uint16_t gb_cart_address(unsigned int bank, uint16_t address)
 {
-    return (address & 0x3fff) | ((bank & 0x3) * 0x4000) ;
+    return 0x4000 * bank + (address & 0x7fff) - 0x4000;
 }
 
 void init_transferpak(struct transferpak* tpk, struct gb_cart* gb_cart)
@@ -49,10 +52,8 @@ void poweron_transferpak(struct transferpak* tpk)
 {
     tpk->enabled = 0;
     tpk->bank = 0;
-    tpk->access_mode = (tpk->gb_cart == NULL)
-        ? CART_NOT_INSERTED
-        : CART_ACCESS_MODE_0;
-    tpk->access_mode_changed = 0x44;
+    tpk->cart_enabled = 0;
+    tpk->reset_state = 3;
 
     if (tpk->gb_cart != NULL) {
         poweron_gb_cart(tpk->gb_cart);
@@ -62,16 +63,13 @@ void poweron_transferpak(struct transferpak* tpk)
 void change_gb_cart(struct transferpak* tpk, struct gb_cart* gb_cart)
 {
     tpk->enabled = 0;
+    tpk->cart_enabled = 0;
+    tpk->reset_state = 3;
+    tpk->gb_cart = gb_cart;
 
-    if (gb_cart == NULL) {
-        tpk->access_mode = CART_NOT_INSERTED;
-    }
-    else {
-        tpk->access_mode = CART_ACCESS_MODE_0;
+    if (gb_cart != NULL) {
         poweron_gb_cart(gb_cart);
     }
-
-    tpk->gb_cart = gb_cart;
 }
 
 static void plug_transferpak(void* pak)
@@ -87,7 +85,7 @@ static void unplug_transferpak(void* pak)
 static void read_transferpak(void* pak, uint16_t address, uint8_t* data, size_t size)
 {
     struct transferpak* tpk = (struct transferpak*)pak;
-    uint8_t value;
+    uint8_t value = 0;
 
     DebugMessage(M64MSG_VERBOSE, "tpak read: %04x", address);
 
@@ -104,18 +102,29 @@ static void read_transferpak(void* pak, uint16_t address, uint8_t* data, size_t 
         break;
 
     case 0xb:
-        /* get gb cart access mode */
-        if (tpk->enabled)
-        {
-            DebugMessage(M64MSG_VERBOSE, "tpak get access mode: %02x", tpk->access_mode);
-            memset(data, tpk->access_mode, size);
-            if (tpk->access_mode != CART_NOT_INSERTED)
-            {
-                data[0] |= tpk->access_mode_changed;
-            }
-            tpk->access_mode_changed = 0;
+    {
+        if (tpk->gb_cart && tpk->cart_enabled) {
+            value |= RESET_MODE_CART_ENABLE_BIT;
         }
+
+        value |= (uint8_t)((tpk->reset_state & 3) << 2);
+ 
+        if (tpk->enabled) {
+            value |= RESET_MODE_PAK_ENABLE_BIT;
+        }
+ 
+        if (tpk->cart_enabled && tpk->reset_state == 3) {
+            tpk->reset_state = 2;
+        } else if (!tpk->cart_enabled && tpk->reset_state == 2) {
+            tpk->reset_state = 1;
+        } else if (!tpk->cart_enabled && tpk->reset_state == 1) {
+            tpk->reset_state = 0;
+        }
+ 
+        DebugMessage(M64MSG_VERBOSE, "tpak read 0xB => %02x", value);
+        memset(data, value, size);
         break;
+    }
 
     case 0xc:
     case 0xd:
@@ -176,18 +185,13 @@ static void write_transferpak(void* pak, uint16_t address, const uint8_t* data, 
         /* set gb cart access mode */
         if (tpk->enabled)
         {
-            tpk->access_mode_changed = 0x04;
-
-            tpk->access_mode = ((value & 1) == 0)
-                              ? CART_ACCESS_MODE_0
-                              : CART_ACCESS_MODE_1;
+            tpk->reset_state  = 3;
+            tpk->cart_enabled = 1;
 
             if ((value & 0xfe) != 0)
             {
                 DebugMessage(M64MSG_WARNING, "Unknown tpak write: %04x <- %02x", address, value);
             }
-
-            DebugMessage(M64MSG_VERBOSE, "tpak set access mode %02x", tpk->access_mode);
         }
         break;
 

--- a/src/device/controllers/paks/transferpak.h
+++ b/src/device/controllers/paks/transferpak.h
@@ -38,8 +38,9 @@ struct transferpak
 {
     unsigned int enabled;
     unsigned int bank;
-    unsigned int access_mode;
-    unsigned int access_mode_changed;
+
+    unsigned int cart_enabled;
+    unsigned int reset_state;
 
     struct gb_cart* gb_cart;
 };

--- a/src/device/gb/gb_cart.c
+++ b/src/device/gb/gb_cart.c
@@ -54,7 +54,7 @@ enum gbcart_extra_devices
 /* various helper functions for ram, rom, or MBC uses */
 
 
-static void read_rom(const void* rom_storage, const struct storage_backend_interface* irom_storage, uint16_t address, uint8_t* data, size_t size)
+static void read_rom(const void* rom_storage, const struct storage_backend_interface* irom_storage, uint32_t address, uint8_t* data, size_t size)
 {
     assert(size > 0);
 
@@ -68,7 +68,7 @@ static void read_rom(const void* rom_storage, const struct storage_backend_inter
 }
 
 
-static void read_ram(const void* ram_storage, const struct storage_backend_interface* iram_storage, unsigned int enabled, uint16_t address, uint8_t* data, size_t size, uint8_t mask)
+static void read_ram(const void* ram_storage, const struct storage_backend_interface* iram_storage, unsigned int enabled, uint32_t address, uint8_t* data, size_t size, uint8_t mask)
 {
     size_t i;
     assert(size > 0);

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -552,8 +552,8 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
 
             unsigned int enabled = ALIGNED_GETDATA(curr, uint32_t);
             unsigned int bank = ALIGNED_GETDATA(curr, uint32_t);
-            unsigned int access_mode = ALIGNED_GETDATA(curr, uint32_t);
-            unsigned int access_mode_changed = ALIGNED_GETDATA(curr, uint32_t);
+            unsigned int cart_enabled = ALIGNED_GETDATA(curr, uint32_t);
+            unsigned int reset_state = ALIGNED_GETDATA(curr, uint32_t);
             COPYARRAY(gb_fingerprint, curr, uint8_t, GB_CART_FINGERPRINT_SIZE);
             if (gb_fingerprint[0] != 0) {
                 rom_bank = ALIGNED_GETDATA(curr, uint32_t);
@@ -572,8 +572,8 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
                 /* init transferpak state if enabled and not controlled by input plugin */
                 dev->transferpaks[i].enabled = enabled;
                 dev->transferpaks[i].bank = bank;
-                dev->transferpaks[i].access_mode = access_mode;
-                dev->transferpaks[i].access_mode_changed = access_mode_changed;
+                dev->transferpaks[i].cart_enabled = cart_enabled;
+                dev->transferpaks[i].reset_state = reset_state;
 
                 /* if it holds a valid cartridge init gbcart */
                 if (dev->transferpaks[i].gb_cart != NULL
@@ -697,8 +697,8 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
 
             unsigned int enabled = GETDATA(curr, uint32_t);
             unsigned int bank = GETDATA(curr, uint32_t);
-            unsigned int access_mode = GETDATA(curr, uint32_t);
-            unsigned int access_mode_changed = GETDATA(curr, uint32_t);
+            unsigned int cart_enabled = GETDATA(curr, uint32_t);
+            unsigned int reset_state = GETDATA(curr, uint32_t);
             COPYARRAY(gb_fingerprint, curr, uint8_t, GB_CART_FINGERPRINT_SIZE);
             if (gb_fingerprint[0] != 0) {
                 rom_bank = GETDATA(curr, uint32_t);
@@ -717,8 +717,8 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
                 /* init transferpak state if enabled and not controlled by input plugin */
                 dev->transferpaks[i].enabled = enabled;
                 dev->transferpaks[i].bank = bank;
-                dev->transferpaks[i].access_mode = access_mode;
-                dev->transferpaks[i].access_mode_changed = access_mode_changed;
+                dev->transferpaks[i].cart_enabled = cart_enabled;
+                dev->transferpaks[i].reset_state = reset_state;
 
                 /* if it holds a valid cartridge init gbcart */
                 if (dev->transferpaks[i].gb_cart != NULL
@@ -1796,8 +1796,8 @@ static int savestates_save_m64p(const struct device* dev, char *filepath)
     for (i = 0; i < GAME_CONTROLLERS_COUNT; ++i) {
         PUTDATA(curr, uint32_t, dev->transferpaks[i].enabled);
         PUTDATA(curr, uint32_t, dev->transferpaks[i].bank);
-        PUTDATA(curr, uint32_t, dev->transferpaks[i].access_mode);
-        PUTDATA(curr, uint32_t, dev->transferpaks[i].access_mode_changed);
+        PUTDATA(curr, uint32_t, dev->transferpaks[i].cart_enabled);
+        PUTDATA(curr, uint32_t, dev->transferpaks[i].reset_state);
 
         if (dev->transferpaks[i].gb_cart == NULL) {
             uint8_t gb_fingerprint[GB_CART_FINGERPRINT_SIZE];


### PR DESCRIPTION
This fixes the GameBoy tower functionality in Pokemon Stadium 2 when using a LLE RSP plugin like static interpreter or parallel-rsp:

<img width="772" height="759" alt="Screenshot_20250926_224139" src="https://github.com/user-attachments/assets/a5919174-a6ab-41e1-a8e6-8d18a61fd33d" />




This patch also requires https://github.com/mupen64plus/mupen64plus-core/pull/1153

This patch makes the code match ares's implementation: https://github.com/ares-emulator/ares/blob/master/ares/n64/controller/gamepad/transfer-pak.cpp