### PR TITLE
Fix controller hypersensitivity in Wipeout 64 (U)

### DIFF
--- a/data/mupen64plus.ini
+++ b/data/mupen64plus.ini
@@ -17762,11 +17762,10 @@ CountPerOp=1
 [73C6D87DBE50F73F3B44E0F237A546D7]
 GoodName=Wipeout 64 (U) [!]
 CRC=132D2732 C70E9118
+Players=4
 SaveType=None
 Mempak=Yes
 Rumble=Yes
-Players=4
-CountPerOp=1
 
 [361F65D37F41536CDE98F83CAD456217]
 GoodName=Wipeout 64 (U) [o1]


### PR DESCRIPTION
Fixes #1160

P.S: The European version behaves erratically and has a delay in the controller without `CountPerOp=1`