### PR TITLE
Derive VI timing from VI sync registers

### DIFF
--- a/src/device/rcp/vi/vi_controller.c
+++ b/src/device/rcp/vi/vi_controller.c
@@ -66,6 +66,26 @@ void set_vi_vertical_interrupt(struct vi_controller* vi)
     }
 }
 
+void vi_recalculate_timing(struct vi_controller* vi)
+{
+    unsigned int vtotal = vi->regs[VI_V_SYNC_REG] + 1;
+    unsigned int htotal = (vi->regs[VI_H_SYNC_REG] & UINT32_C(0x0fff)) + 1;
+
+    if (vtotal == 0 || htotal < 2)
+    {
+        vi->count_per_scanline = (vi->regs[VI_V_SYNC_REG] == 0)
+            ? 1500
+            : ((unsigned int) (((double) vi->clock / vi->expected_refresh_rate) / (double) vtotal));
+        vi->delay = vtotal * vi->count_per_scanline;
+        return;
+    }
+
+    vi->count_per_scanline = htotal / 2;
+    vi->delay = vtotal * vi->count_per_scanline;
+    vi->expected_refresh_rate = ((double) vi->clock * 2.0)
+        / ((double) vtotal * (double) htotal);
+}
+
 void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected_refresh_rate,
              struct mi_controller* mi, struct rdp_core* dp)
 {
@@ -142,9 +162,16 @@ void write_vi_regs(void* opaque, uint32_t address, uint32_t value, uint32_t mask
         if ((vi->regs[VI_V_SYNC_REG] & mask) != (value & mask))
         {
             masked_write(&vi->regs[VI_V_SYNC_REG], value, mask);
-            vi->count_per_scanline = (vi->clock / vi->expected_refresh_rate) / (vi->regs[VI_V_SYNC_REG] + 1);
-            vi->delay = (vi->regs[VI_V_SYNC_REG] + 1) * vi->count_per_scanline;
+            vi_recalculate_timing(vi);
             set_vi_vertical_interrupt(vi);
+        }
+        return;
+
+    case VI_H_SYNC_REG:
+        if ((vi->regs[VI_H_SYNC_REG] & mask) != (value & mask))
+        {
+            masked_write(&vi->regs[VI_H_SYNC_REG], value, mask);
+            vi_recalculate_timing(vi);
         }
         return;
 

--- a/src/device/rcp/vi/vi_controller.h
+++ b/src/device/rcp/vi/vi_controller.h
@@ -55,7 +55,7 @@ struct vi_controller
     unsigned int delay;
 
     unsigned int clock;
-    unsigned int expected_refresh_rate;
+    double expected_refresh_rate;
     unsigned int count_per_scanline;
 
     struct mi_controller* mi;
@@ -71,6 +71,7 @@ static osal_inline uint32_t vi_reg(uint32_t address)
 unsigned int vi_clock_from_tv_standard(m64p_system_type tv_standard);
 unsigned int vi_expected_refresh_rate_from_tv_standard(m64p_system_type tv_standard);
 void set_vi_vertical_interrupt(struct vi_controller* vi);
+void vi_recalculate_timing(struct vi_controller* vi);
 
 void init_vi(struct vi_controller* vi, unsigned int clock, unsigned int expected_refresh_rate,
              struct mi_controller* mi, struct rdp_core* dp);

--- a/src/main/savestates.c
+++ b/src/main/savestates.c
@@ -916,9 +916,7 @@ static int savestates_load_m64p(struct device* dev, char *filepath)
         setup_channels_format(&dev->pif);
 
         /* extra vi state */
-        dev->vi.count_per_scanline = (dev->vi.regs[VI_V_SYNC_REG] == 0)
-            ? 1500
-            : ((dev->vi.clock / dev->vi.expected_refresh_rate) / (dev->vi.regs[VI_V_SYNC_REG] + 1));
+        vi_recalculate_timing(&dev->vi);
 
         /* extra si state */
         dev->si.dma_dir = SI_NO_DMA;
@@ -1122,9 +1120,7 @@ static int savestates_load_pj64(struct device* dev,
     gfx.viStatusChanged();
     gfx.viWidthChanged();
 
-    dev->vi.count_per_scanline = (dev->vi.regs[VI_V_SYNC_REG] == 0)
-        ? 1500
-        : ((dev->vi.clock / dev->vi.expected_refresh_rate) / (dev->vi.regs[VI_V_SYNC_REG] + 1));
+    vi_recalculate_timing(&dev->vi);
 
     /* extra si state */
     dev->si.dma_dir = SI_NO_DMA;


### PR DESCRIPTION
Fixes #1176

The current VI timing path derives scanline timing from nominal region refresh
rates (PAL=50, NTSC/MPAL=60).

This patch derives VI timing from VI_V_SYNC_REG and VI_H_SYNC_REG instead,
and updates the cached expected refresh rate accordingly.

Changes:
- derive expected_refresh_rate from VI sync registers
- recalculate timing when VI_V_SYNC_REG changes
- recalculate timing when VI_H_SYNC_REG changes
- reuse the same timing recalculation when loading savestates

This keeps the existing VI flow intact, but avoids relying on nominal 50/60
region constants for VI timing.

Scope is intentionally small and limited to the VI timing path.

Done with the help of AI.