### PR TITLE
Fix crashes and halts

### DIFF
--- a/src/device/r4300/idec.c
+++ b/src/device/r4300/idec.c
@@ -372,22 +372,22 @@ static const struct r4300_idec r4300_op_table[] = {
 /* TLB opcodes table
  * 176-239
  */
-    RESERVED,    TLBR,        TLBWI,       RESERVED,
-    RESERVED,    RESERVED,    TLBWR,       RESERVED,
-    TLBP,        RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    ERET,        RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
-    RESERVED,    RESERVED,    RESERVED,    RESERVED,
+    NOP,         TLBR,        TLBWI,       NOP,
+    NOP,         NOP,         TLBWR,       NOP,
+    TLBP,        NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    ERET,        NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
+    NOP,         NOP,         NOP,         NOP,
 /* COP1 opcodes table
  * 240-247
  */
@@ -430,7 +430,7 @@ static const struct r4300_idec r4300_op_table[] = {
 /* Pseudo opcodes
  * 336
  */
-	NOP
+    NOP
 };
 
 #define E_INV       {   0,  0, 0x00 }
@@ -459,7 +459,7 @@ struct r4300_op_escape {
 static const struct r4300_op_escape r4300_escapes_table[] = {
 
     /* 000000 - special */
-	E_SPECIAL, E_SPECIAL, E_SPECIAL, E_SPECIAL,
+    E_SPECIAL, E_SPECIAL, E_SPECIAL, E_SPECIAL,
 
     /* 000001 - regimm */
     E_REGIMM,  E_REGIMM,  E_REGIMM,  E_REGIMM,

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1220,8 +1220,12 @@ DECLARE_INSTRUCTION(TLBWR)
     DECLARE_R4300
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
     cp0_update_count(r4300);
-    cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % (32 - cp0_regs[CP0_WIRED_REG]))
+	if (cp0_regs[CP0_WIRED_REG] >= 32) {
+		cp0_regs[CP0_RANDOM_REG] = cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % 64;
+	} else {
+    	cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % (32 - cp0_regs[CP0_WIRED_REG]))
         + cp0_regs[CP0_WIRED_REG];
+	}
     TLBWrite(r4300, cp0_regs[CP0_RANDOM_REG]);
     ADD_TO_PC(1);
 }
@@ -1247,8 +1251,12 @@ DECLARE_INSTRUCTION(MFC0)
     {
     case CP0_RANDOM_REG:
         cp0_update_count(r4300);
-        cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % (32 - cp0_regs[CP0_WIRED_REG]))
-            + cp0_regs[CP0_WIRED_REG];
+		if (cp0_regs[CP0_WIRED_REG] >= 32) {
+			cp0_regs[CP0_RANDOM_REG] = cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % 64;
+		} else {
+			cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % (32 - cp0_regs[CP0_WIRED_REG]))
+			+ cp0_regs[CP0_WIRED_REG];
+		}
         rrt = SE32(cp0_regs[rfs]);
         break;
     case CP0_COUNT_REG:
@@ -1282,8 +1290,12 @@ DECLARE_INSTRUCTION(DMFC0)
     {
     case CP0_RANDOM_REG:
         cp0_update_count(r4300);
-        cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % (32 - cp0_regs[CP0_WIRED_REG]))
-            + cp0_regs[CP0_WIRED_REG];
+		if (cp0_regs[CP0_WIRED_REG] >= 32) {
+			cp0_regs[CP0_RANDOM_REG] = cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % 64;
+		} else {
+			cp0_regs[CP0_RANDOM_REG] = (cp0_regs[CP0_COUNT_REG]/r4300->cp0.count_per_op % (32 - cp0_regs[CP0_WIRED_REG]))
+			+ cp0_regs[CP0_WIRED_REG];
+		}
         rrt = cp0_regs[rfs];
         break;
     case CP0_COUNT_REG:

--- a/src/device/r4300/mips_instructions.def
+++ b/src/device/r4300/mips_instructions.def
@@ -1089,16 +1089,17 @@ DECLARE_INSTRUCTION(TLBR)
     DECLARE_R4300
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
 
-    int index;
-    index = cp0_regs[CP0_INDEX_REG] & UINT32_C(0x1F);
-    cp0_regs[CP0_PAGEMASK_REG] = r4300->cp0.tlb.entries[index].mask << 13;
-    cp0_regs[CP0_ENTRYHI_REG] = ((r4300->cp0.tlb.entries[index].vpn2 << 13) | r4300->cp0.tlb.entries[index].asid);
-    cp0_regs[CP0_ENTRYLO0_REG] = (r4300->cp0.tlb.entries[index].pfn_even << 6) | (r4300->cp0.tlb.entries[index].c_even << 3)
-        | (r4300->cp0.tlb.entries[index].d_even << 2) | (r4300->cp0.tlb.entries[index].v_even << 1)
-        | r4300->cp0.tlb.entries[index].g;
-    cp0_regs[CP0_ENTRYLO1_REG] = (r4300->cp0.tlb.entries[index].pfn_odd << 6) | (r4300->cp0.tlb.entries[index].c_odd << 3)
-        | (r4300->cp0.tlb.entries[index].d_odd << 2) | (r4300->cp0.tlb.entries[index].v_odd << 1)
-        | r4300->cp0.tlb.entries[index].g;
+    int index = cp0_regs[CP0_INDEX_REG] & UINT32_C(0x3F);
+	if (index < CP0_REGS_COUNT) {
+		cp0_regs[CP0_PAGEMASK_REG] = r4300->cp0.tlb.entries[index].mask << 13;
+		cp0_regs[CP0_ENTRYHI_REG] = ((r4300->cp0.tlb.entries[index].vpn2 << 13) | r4300->cp0.tlb.entries[index].asid);
+		cp0_regs[CP0_ENTRYLO0_REG] = (r4300->cp0.tlb.entries[index].pfn_even << 6) | (r4300->cp0.tlb.entries[index].c_even << 3)
+			| (r4300->cp0.tlb.entries[index].d_even << 2) | (r4300->cp0.tlb.entries[index].v_even << 1)
+			| r4300->cp0.tlb.entries[index].g;
+		cp0_regs[CP0_ENTRYLO1_REG] = (r4300->cp0.tlb.entries[index].pfn_odd << 6) | (r4300->cp0.tlb.entries[index].c_odd << 3)
+			| (r4300->cp0.tlb.entries[index].d_odd << 2) | (r4300->cp0.tlb.entries[index].v_odd << 1)
+			| r4300->cp0.tlb.entries[index].g;
+	}
     ADD_TO_PC(1);
 }
 
@@ -1235,7 +1236,9 @@ DECLARE_INSTRUCTION(TLBWI)
     DECLARE_R4300
     uint32_t* cp0_regs = r4300_cp0_regs(&r4300->cp0);
 
-    TLBWrite(r4300, cp0_regs[CP0_INDEX_REG] & UINT32_C(0x3F));
+	int index = cp0_regs[CP0_INDEX_REG] & UINT32_C(0x3F);
+	if (index < CP0_REGS_COUNT)
+    	TLBWrite(r4300, index);
     ADD_TO_PC(1);
 }
 
@@ -1335,11 +1338,6 @@ DECLARE_INSTRUCTION(MTC0)
     {
     case CP0_INDEX_REG:
         cp0_regs[CP0_INDEX_REG] = rrt32 & UINT32_C(0x8000003F);
-        if ((cp0_regs[CP0_INDEX_REG] & UINT32_C(0x3F)) > UINT32_C(31))
-        {
-            DebugMessage(M64MSG_ERROR, "MTC0 instruction writing Index register with TLB index > 31");
-            *r4300_stop(r4300)=1;
-        }
         break;
     case CP0_RANDOM_REG:
         break;
@@ -1411,7 +1409,7 @@ DECLARE_INSTRUCTION(MTC0)
     case CP0_PREVID_REG:
         break;
     case CP0_CONFIG_REG:
-        cp0_regs[CP0_CONFIG_REG] = (rrt32 & UINT32_C(0x0000000F)) 
+        cp0_regs[CP0_CONFIG_REG] = (rrt32 & UINT32_C(0x0000000F))
                 | (cp0_regs[CP0_CONFIG_REG] & UINT32_C(0x00008000))
                 | (cp0_regs[CP0_CONFIG_REG] & UINT32_C(0x7FFFFFFF));
         break;

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -467,9 +467,8 @@ void InterpretOpcode(struct r4300_core* r4300)
 			case 6: TLBWR(r4300, op); break;
 			case 8: TLBP(r4300, op); break;
 			case 24: ERET(r4300, op); break;
-			default: /* TLB sub-opcodes 0, 3..5, 7, 9..23, 25..63:
-			            Reserved Instructions */
-				RESERVED(r4300, op);
+			default: /* TLB sub-opcodes 0, 3..5, 7, 9..23, 25..63: undefined */
+				NOP(r4300, 0);
 				break;
 			} /* switch (op & 0x3F) for Coprocessor 0 TLB opcodes */
 			break;

--- a/src/device/r4300/pure_interp.c
+++ b/src/device/r4300/pure_interp.c
@@ -446,7 +446,21 @@ void InterpretOpcode(struct r4300_core* r4300)
 		case 5: /* Coprocessor 0 opcode 5: DMTC0 */
 			MTC0(r4300, op);
 			break;
-		case 16: /* Coprocessor 0 opcode 16: TLB */
+		case 2:
+		case 3:
+		case 6:
+		case 7:
+		case 8:
+		case 9:
+		case 10:
+		case 11:
+		case 12:
+		case 13:
+		case 14:
+		case 15: /* Coprocessor 0 opcodes 2..3, 6..15: Reserved Instructions */
+			RESERVED(r4300, op);
+			break;
+		default: /* Coprocessor 0 opcode 16..31: TLB */
 			switch (op & 0x3F) {
 			case 1: TLBR(r4300, op); break;
 			case 2: TLBWI(r4300, op); break;
@@ -458,10 +472,6 @@ void InterpretOpcode(struct r4300_core* r4300)
 				RESERVED(r4300, op);
 				break;
 			} /* switch (op & 0x3F) for Coprocessor 0 TLB opcodes */
-			break;
-		default: /* Coprocessor 0 opcodes 2..3, 5..15, 17..31:
-		            Reserved Instructions */
-			RESERVED(r4300, op);
 			break;
 		} /* switch ((op >> 21) & 0x1F) for the Coprocessor 0 prefix */
 		break;

--- a/src/device/rcp/pi/pi_controller.c
+++ b/src/device/rcp/pi/pi_controller.c
@@ -110,7 +110,7 @@ static void dma_pi_write(struct pi_controller* pi)
     if (length >= 0x7f && (length & 1))
         length += 1;
     if (length <= 0x80)
-        length -= dram_addr & 0x7;
+        length = length >= (dram_addr & 0x7) ? length - (dram_addr & 0x7) : 0;
     unsigned int cycles = handler->dma_write(opaque, dram, dram_addr, cart_addr, length);
 
     post_framebuffer_write(&pi->dp->fb, dram_addr, length);


### PR DESCRIPTION
This fixes a number of emulator stops or outright hardcrashes when certain instructions are executed. Noticed this when testing with n64-systemtest. There's still a lot of tests that fail to complete, like everything that calls `LLD` or `SCD` due to these opcodes being unimplemented, or basically the entirety of the rsp tests (see #1153).

Also, the new dynamic recompiler immediately crashes because it seems to reach an invalid memory address somehow (in [here](https://github.com/mupen64plus/mupen64plus-core/blob/53a08fceb71653000dd6640cac05eb390fba7885/src/device/r4300/new_dynarec/new_dynarec.c#L8883)) even when n64-systemtest is compiled with 0 tests, so it's impossible to test anything with that.