### PR TITLE
vidext: don't force compatibility profile over an ES context request

### DIFF
--- a/src/api/vidext.c
+++ b/src/api/vidext.c
@@ -605,6 +605,11 @@ EXPORT m64p_error CALL VidExt_GL_SetAttribute(m64p_GLattr Attr, int Value)
                 break;
             case M64P_GL_CONTEXT_PROFILE_ES:
                 Value = SDL_GL_CONTEXT_PROFILE_ES;
+#ifndef USE_GLES
+                /* an explicit ES profile request must not be overridden by
+                 * the default compatibility context at SetVideoMode */
+                l_ForceCompatibilityContext = 0;
+#endif
                 break;
             default:
                 Value = 0;


### PR DESCRIPTION
## Problem

`VidExt_GL_SetAttribute(M64P_GL_CONTEXT_PROFILE_MASK, ...)` clears the hidden `l_ForceCompatibilityContext` default only for `M64P_GL_CONTEXT_PROFILE_CORE`. An `M64P_GL_CONTEXT_PROFILE_ES` request sets the SDL attribute but leaves the force-flag armed, so `VidExt_SetVideoMode` re-sets the profile to `SDL_GL_CONTEXT_PROFILE_COMPATIBILITY` right before creating the window - clobbering the video plugin's ES request.

On platforms whose desktop GL support is limited this fails silently and is very hard to diagnose. Concrete case: Raspberry Pi 5 (Mesa V3D). Its desktop compatibility context only supports GLSL up to 1.40. A video plugin (GLideN64) that requested an OpenGL ES 3.1 context gets a desktop compatibility context instead, sees a non-ES context, emits `#version 310 core` / ES shaders, and every shader fails to compile:

```
GLSL 3.10 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.40, 1.00 ES, and 3.00 ES
```

In Release builds of the plugin nothing is logged at all - the user-visible symptom is just a black screen.

## Fix

Clear `l_ForceCompatibilityContext` in the `M64P_GL_CONTEXT_PROFILE_ES` case, exactly like the existing `M64P_GL_CONTEXT_PROFILE_CORE` case (same `#ifndef USE_GLES` guard, since the flag does not exist in GLES builds).

## Testing

Verified on Raspberry Pi 5 (Mesa V3D, Wayland/labwc, SDL2): with this change a GLideN64 build requesting `M64P_GL_CONTEXT_PROFILE_ES` 3.1 gets a proper ES 3.1 context and renders correctly; without it, the window comes up with a desktop compatibility context and all shaders fail.