### PR TITLE
new_dynarec: native Apple Silicon (darwin-arm64) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /projects/unix/_obj*/
 /projects/unix/libmupen64plus*.so*
+/projects/unix/libmupen64plus*.dylib*
 /.vscode
 /projects/unix/*.dll
 /src/asm_defines/*.h

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -246,9 +246,7 @@ ifeq ($(OS), OSX)
     endif
   endif
   ifeq ($(CPU), ARM)
-    # assembly compilation not yet supported on macOS with Apple Silicon
-    NO_ASM = 1
-    CFLAGS += -pipe -arch arm64 -mmacosx-version-min=10.16 -isysroot $(OSX_SDK_PATH)
+    CFLAGS += -pipe -arch arm64 -mmacosx-version-min=11.0 -isysroot $(OSX_SDK_PATH)
   endif
 endif
 ifeq ($(OS), MINGW)

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -720,20 +720,38 @@ ifeq ($(DEBUGGER), 1)
     $(SRCDIR)/debugger/dbg_decoder.c \
     $(SRCDIR)/debugger/dbg_memory.c \
     $(SRCDIR)/debugger/dbg_breakpoints.c
-  LDLIBS += -lopcodes -lbfd
 
-  # UGLY libopcodes/libbfd version check (we check for >= 2.28 and >= 2.39)
-  LIBOPCODES_VERSION := $(shell $(STRINGS) --version | head -n1 | rev | cut -d ' ' -f1 | rev)
-  LIBOPCODES_MAJOR := $(shell echo $(LIBOPCODES_VERSION) | cut -f1 -d.)
-  LIBOPCODES_MINOR := $(shell echo $(LIBOPCODES_VERSION) | cut -f2 -d.)
-  LIBOPCODES_POINT := $(shell echo $(LIBOPCODES_VERSION) | cut -f3 -d. | sed 's/^$$/0/')
-  LIBOPCODES_GE_2_29 := $(shell [ $(LIBOPCODES_MAJOR) -gt 2 -o \( $(LIBOPCODES_MAJOR) -eq 2 -a $(LIBOPCODES_MINOR) -ge 28 \) -o \( $(LIBOPCODES_MAJOR) -eq 2 -a $(LIBOPCODES_MINOR) -eq 28 -a $(LIBOPCODES_POINT) -ge 1 \) ] && echo true)
-  LIBBFD_GE_2_39 := $(shell [ $(LIBOPCODES_MAJOR) -gt 2 -o \( $(LIBOPCODES_MAJOR) -eq 2 -a $(LIBOPCODES_MINOR) -ge 39 \) -o \( $(LIBOPCODES_MAJOR) -eq 2 -a $(LIBOPCODES_MINOR) -eq 39 -a $(LIBOPCODES_POINT) -ge 1 \) ] && echo true)
-  ifeq ($(LIBOPCODES_GE_2_29),true)
-    CFLAGS += -DUSE_LIBOPCODES_GE_2_29
+  # The host disassembler (libopcodes/libbfd, used only by dbg_memory.c's
+  # init_host_disassembler()) is x86-only (it hardcodes bfd_arch_i386) and is
+  # not used by the single-step / memory-read / breakpoint machinery that the
+  # frontend debugger API exposes. On macOS it is doubly useless: dbg_memory.c
+  # already stubs it out on non-x86 hosts, linking -lopcodes/-lbfd is fragile,
+  # and BSD `strings` has no --version flag so the version probe below fails.
+  # Default it off on OSX; allow forcing it off anywhere with
+  # DEBUGGER_NO_DISASM=1.
+  ifeq ($(OS),OSX)
+    DEBUGGER_NO_DISASM ?= 1
   endif
-  ifeq ($(LIBBFD_GE_2_39),true)
-    CFLAGS += -DUSE_LIBBFD_GE_2_39
+  DEBUGGER_NO_DISASM ?= 0
+
+  ifeq ($(DEBUGGER_NO_DISASM),1)
+    CFLAGS += -DNO_HOST_DISASSEMBLER
+  else
+    LDLIBS += -lopcodes -lbfd
+
+    # UGLY libopcodes/libbfd version check (we check for >= 2.28 and >= 2.39)
+    LIBOPCODES_VERSION := $(shell $(STRINGS) --version | head -n1 | rev | cut -d ' ' -f1 | rev)
+    LIBOPCODES_MAJOR := $(shell echo $(LIBOPCODES_VERSION) | cut -f1 -d.)
+    LIBOPCODES_MINOR := $(shell echo $(LIBOPCODES_VERSION) | cut -f2 -d.)
+    LIBOPCODES_POINT := $(shell echo $(LIBOPCODES_VERSION) | cut -f3 -d. | sed 's/^$$/0/')
+    LIBOPCODES_GE_2_29 := $(shell [ $(LIBOPCODES_MAJOR) -gt 2 -o \( $(LIBOPCODES_MAJOR) -eq 2 -a $(LIBOPCODES_MINOR) -ge 28 \) -o \( $(LIBOPCODES_MAJOR) -eq 2 -a $(LIBOPCODES_MINOR) -eq 28 -a $(LIBOPCODES_POINT) -ge 1 \) ] && echo true)
+    LIBBFD_GE_2_39 := $(shell [ $(LIBOPCODES_MAJOR) -gt 2 -o \( $(LIBOPCODES_MAJOR) -eq 2 -a $(LIBOPCODES_MINOR) -ge 39 \) -o \( $(LIBOPCODES_MAJOR) -eq 2 -a $(LIBOPCODES_MINOR) -eq 39 -a $(LIBOPCODES_POINT) -ge 1 \) ] && echo true)
+    ifeq ($(LIBOPCODES_GE_2_29),true)
+      CFLAGS += -DUSE_LIBOPCODES_GE_2_29
+    endif
+    ifeq ($(LIBBFD_GE_2_39),true)
+      CFLAGS += -DUSE_LIBBFD_GE_2_39
+    endif
   endif
 endif
 

--- a/src/debugger/dbg_memory.c
+++ b/src/debugger/dbg_memory.c
@@ -36,7 +36,7 @@
 #define ATTR_FMT(fmtpos, attrpos)
 #endif
 
-#if !defined(NO_ASM) && (defined(__i386__) || (defined(__x86_64__) && defined(__GNUC__)))
+#if !defined(NO_HOST_DISASSEMBLER) && !defined(NO_ASM) && (defined(__i386__) || (defined(__x86_64__) && defined(__GNUC__)))
 
 /* we must define PACKAGE so that bfd.h (which is included from dis-asm.h) doesn't throw an error */
 #define PACKAGE "mupen64plus-core"

--- a/src/device/r4300/new_dynarec/arm64/assem_arm64.c
+++ b/src/device/r4300/new_dynarec/arm64/assem_arm64.c
@@ -261,9 +261,17 @@ static uintptr_t jump_table_symbols[] = {
   (intptr_t)breakpoint
 };
 
+#if defined(__APPLE__)
+#include <libkern/OSCacheControl.h>
+#endif
+
 static void cache_flush(char* start, char* end)
 {
-#ifndef WIN32
+#if defined(__APPLE__)
+    // Reading ctr_el0 from EL0 traps (SIGILL) on Apple Silicon; use the
+    // system-provided cache maintenance routine instead.
+    sys_icache_invalidate(start, end - start);
+#elif !defined(WIN32)
     // Don't rely on GCC's __clear_cache implementation, as it caches
     // icache/dcache cache line sizes, that can vary between cores on
     // big.LITTLE architectures.
@@ -4639,6 +4647,7 @@ static void arch_init(void) {
 
   // Trampolines for jumps >128MB
   intptr_t *ptr,*ptr2,*ptr3;
+  jit_write_begin();
   ptr=(intptr_t *)jump_table_symbols;
   ptr2=(intptr_t *)((char *)base_addr+(1<<TARGET_SIZE_2)-JUMP_TABLE_SIZE);
   ptr3=(intptr_t *)((char *)base_addr_rx+(1<<TARGET_SIZE_2)-JUMP_TABLE_SIZE);
@@ -4658,4 +4667,5 @@ static void arch_init(void) {
     ptr2++;
     ptr3+=2;
   }
+  jit_write_end();
 }

--- a/src/device/r4300/new_dynarec/arm64/linkage_arm64.S
+++ b/src/device/r4300/new_dynarec/arm64/linkage_arm64.S
@@ -18,6 +18,47 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#ifdef __APPLE__
+
+/* Mach-O: C symbols carry a leading underscore, .hidden/.type/.size are
+ * ELF-only (visibility is .private_extern), and adrp page relocations are
+ * spelled sym@PAGE/sym@PAGEOFF instead of sym/:lo12:sym. The Darwin arm64
+ * assembler treats ';' as a comment, so multi-statement macros use the '%%'
+ * statement separator instead.
+ * Each function gets two labels: _name for linkage with C code and a plain
+ * name for branches within this file. */
+
+#define GLOBAL_FUNCTION(name)      \
+    .globl _##name %%              \
+    .private_extern _##name %%     \
+    _##name: name
+
+#define LOCAL_FUNCTION(name)  \
+    name
+
+#define GLOBAL_VARIABLE(name, size_) \
+    .globl _##name %%                \
+    .private_extern _##name
+
+#define PAGE(sym)    sym@PAGE
+#define PAGEOFF(sym) sym@PAGEOFF
+
+/* C symbols referenced from this file */
+#define g_dev                _g_dev
+#define base_addr_rx         _base_addr_rx
+#define get_addr_ht          _get_addr_ht
+#define get_addr             _get_addr
+#define verify_dirty         _verify_dirty
+#define dynarec_gen_interrupt _dynarec_gen_interrupt
+#define cop1_unusable        _cop1_unusable
+#define SYSCALL_new          _SYSCALL_new
+#define ERET_new             _ERET_new
+#define dynamic_linker       _dynamic_linker
+#define dynamic_linker_ds    _dynamic_linker_ds
+#define new_recompile_block  _new_recompile_block
+
+#else /* ELF */
+
 #define GLOBAL_FUNCTION(name)  \
     .globl name;               \
     .hidden name;              \
@@ -34,6 +75,11 @@
     .hidden name;                    \
     .type   name, %object;           \
     .size   name, size_
+
+#define PAGE(sym)    sym
+#define PAGEOFF(sym) :lo12:sym
+
+#endif
 
 .macro movl Wn, imm
     movz    \Wn, (\imm >> 16) & 0xFFFF, lsl 16
@@ -171,10 +217,10 @@ GLOBAL_FUNCTION(verify_code):
     mov    x21, x30 /* Save link register */
     bl     verify_dirty
     tst    x0, x0
-    b.ne   .D1
+    b.ne   1f
     mov    x30, x21 /* Restore link register */
     ret
-.D1:
+1:
     bl     get_addr
     br     x0
 
@@ -190,9 +236,9 @@ GLOBAL_FUNCTION(cc_interrupt):
     tst    w2, w2
     b.ne   new_dyna_stop
     tst    w1, w1
-    b.ne   .E1
+    b.ne   1f
     ret
-.E1:
+1:
     ldr    w0, [x29, #fp_pcaddr]
     bl     get_addr_ht
     br     x0
@@ -243,12 +289,12 @@ GLOBAL_FUNCTION(dyna_linker_ds):
     br     x0
 
 GLOBAL_FUNCTION(new_dyna_start):
-    adrp   x16, g_dev
-    add    x16, x16, :lo12:g_dev
+    adrp   x16, PAGE(g_dev)
+    add    x16, x16, PAGEOFF(g_dev)
     movl   x1, (device_r4300_new_dynarec_hot_state_dynarec_local + saved_context)
     add    x16, x16, x1
-    adrp   x1, base_addr_rx
-    add    x1, x1, :lo12:base_addr_rx
+    adrp   x1, PAGE(base_addr_rx)
+    add    x1, x1, PAGEOFF(base_addr_rx)
     mov    w0, #0xa4000000
     stp    x19,x20,[x16,#0]
     stp    x21,x22,[x16,#16]

--- a/src/device/r4300/new_dynarec/new_dynarec.c
+++ b/src/device/r4300/new_dynarec/new_dynarec.c
@@ -58,6 +58,30 @@
 #include <sys/mman.h>
 #endif
 
+#if defined(__APPLE__) && defined(__aarch64__)
+/* Apple Silicon enforces W^X: the MAP_JIT code cache is executable by
+ * default and only writable while the calling thread has toggled itself
+ * into write mode with pthread_jit_write_protect_np(). Exec mode is the
+ * default; every code path that writes to the cache is bracketed with
+ * jit_write_begin/jit_write_end. The depth counter makes the brackets
+ * reentrant (e.g. dynamic_linker -> new_recompile_block). */
+#include <pthread.h>
+static int jit_write_depth;
+static void jit_write_begin(void)
+{
+  if (jit_write_depth++ == 0)
+    pthread_jit_write_protect_np(0);
+}
+static void jit_write_end(void)
+{
+  if (--jit_write_depth == 0)
+    pthread_jit_write_protect_np(1);
+}
+#else
+#define jit_write_begin() do {} while (0)
+#define jit_write_end()   do {} while (0)
+#endif
+
 #if defined(RECOMPILER_DEBUG) && !defined(RECOMP_DBG)
 void recomp_dbg_init(void);
 void recomp_dbg_cleanup(void);
@@ -2593,7 +2617,7 @@ static struct ll_entry *get_dirty(struct r4300_core* r4300,u_int vaddr,u_int fla
   return NULL;
 }
 
-void *dynamic_linker(void * src, u_int vaddr)
+static void *dynamic_linker_impl(void * src, u_int vaddr)
 {
   assert((vaddr&1)==0);
   struct r4300_core* r4300 = &g_dev.r4300;
@@ -2643,7 +2667,7 @@ void *dynamic_linker(void * src, u_int vaddr)
   }
 
   int r=new_recompile_block(vaddr);
-  if(r==0) return dynamic_linker(src,vaddr);
+  if(r==0) return dynamic_linker_impl(src,vaddr);
   // Execute in unmapped page, generate pagefault execption
   assert(r4300->cp0.tlb.LUT_r[(vaddr&~1) >> 12] == 0);
   assert((intptr_t)r4300->new_dynarec_hot_state.memory_map[(vaddr&~1) >> 12] < 0);
@@ -2652,7 +2676,15 @@ void *dynamic_linker(void * src, u_int vaddr)
   return get_addr_ht(r4300->new_dynarec_hot_state.pcaddr);
 }
 
-void *dynamic_linker_ds(void * src, u_int vaddr)
+void *dynamic_linker(void * src, u_int vaddr)
+{
+  jit_write_begin();
+  void *ret = dynamic_linker_impl(src, vaddr);
+  jit_write_end();
+  return ret;
+}
+
+static void *dynamic_linker_ds_impl(void * src, u_int vaddr)
 {
   struct r4300_core* r4300 = &g_dev.r4300;
   struct ll_entry *head;
@@ -2701,13 +2733,21 @@ void *dynamic_linker_ds(void * src, u_int vaddr)
   }
 
   int r=new_recompile_block((vaddr&0xFFFFFFF8)+1);
-  if(r==0) return dynamic_linker_ds(src,vaddr);
+  if(r==0) return dynamic_linker_ds_impl(src,vaddr);
   // Execute in unmapped page, generate pagefault execption
   assert(r4300->cp0.tlb.LUT_r[(vaddr&~1) >> 12] == 0);
   assert((intptr_t)r4300->new_dynarec_hot_state.memory_map[(vaddr&~1) >> 12] < 0);
   r4300->delay_slot = vaddr&1;
   TLB_refill_exception(r4300, vaddr&~1, 2);
   return get_addr_ht(r4300->new_dynarec_hot_state.pcaddr);
+}
+
+void *dynamic_linker_ds(void * src, u_int vaddr)
+{
+  jit_write_begin();
+  void *ret = dynamic_linker_ds_impl(src, vaddr);
+  jit_write_end();
+  return ret;
 }
 
 // Get address from virtual address
@@ -2873,7 +2913,7 @@ static void invalidate_page(u_int page)
   }
 }
 
-void invalidate_block(u_int block)
+static void invalidate_block_impl(u_int block)
 {
   u_int page;
   page=block^0x80000;
@@ -2950,11 +2990,19 @@ void invalidate_block(u_int block)
   #endif
 }
 
+void invalidate_block(u_int block)
+{
+  jit_write_begin();
+  invalidate_block_impl(block);
+  jit_write_end();
+}
+
 // This is called when loading a save state.
 // Anything could have changed, so invalidate everything.
 static void invalidate_all_pages(void)
 {
   u_int page;
+  jit_write_begin();
   for(page=0;page<4096;page++)
     invalidate_page(page);
   for(page=0;page<1048576;page++)
@@ -2967,6 +3015,7 @@ static void invalidate_all_pages(void)
   #if NEW_DYNAREC >= NEW_DYNAREC_ARM
   cache_flush((char *)base_addr_rx,(char *)base_addr_rx+(1<<TARGET_SIZE_2));
   #endif
+  jit_write_end();
   #ifdef USE_MINI_HT
   memset(g_dev.r4300.new_dynarec_hot_state.mini_ht,-1,sizeof(g_dev.r4300.new_dynarec_hot_state.mini_ht));
   #endif
@@ -8713,7 +8762,13 @@ void new_dynarec_init(void)
 #define DOUBLE_CACHE_ADDR 3   // Put the dynarec cache at random address with RW address != RX address
 
 // Default to fixed cache address
+#if defined(__APPLE__)
+// Apple Silicon requires a fresh MAP_JIT mapping for the code cache
+// (static memory cannot be made executable), so the cache address is dynamic.
+#define CACHE_ADDR DYNAMIC_CACHE_ADDR
+#else
 #define CACHE_ADDR FIXED_CACHE_ADDR
+#endif
 
 #if CACHE_ADDR==DOUBLE_CACHE_ADDR
   #include <unistd.h>
@@ -8744,7 +8799,11 @@ void new_dynarec_init(void)
 #else /*DYNAMIC_CACHE_ADDR*/
   base_addr = mmap (NULL, 1<<TARGET_SIZE_2,
                     PROT_READ | PROT_WRITE | PROT_EXEC,
-                    MAP_PRIVATE | MAP_ANONYMOUS,
+                    MAP_PRIVATE | MAP_ANONYMOUS
+#if defined(__APPLE__) && defined(__aarch64__)
+                    | MAP_JIT
+#endif
+                    ,
                     -1, 0);
   base_addr_rx = base_addr;
 #endif
@@ -8830,7 +8889,7 @@ void new_dynarec_cleanup(void)
 #endif
 }
 
-int new_recompile_block(int addr)
+static int new_recompile_block_impl(int addr)
 {
 #if defined(RECOMPILER_DEBUG) && !defined(RECOMP_DBG)
   recomp_dbg_block(addr);
@@ -11961,4 +12020,12 @@ int new_recompile_block(int addr)
     expirep=(expirep+1)&65535;
   }
   return 0;
+}
+
+int new_recompile_block(int addr)
+{
+  jit_write_begin();
+  int ret = new_recompile_block_impl(addr);
+  jit_write_end();
+  return ret;
 }


### PR DESCRIPTION
**The problem:** on Apple Silicon Macs, mupen64plus falls back to the cached interpreter — the arm64 dynarec has been hard-disabled on macOS (`NO_ASM = 1`) since native arm64 support landed in #910. So the machines that could benefit most from the recompiler are the ones that don't get it. The dynarec itself is fine on arm64 (it works on Linux); the blockers were all macOS-specific.

**Prior art:** #910 got the core *building* natively on Apple Silicon but had to disable the dynarec to do it. #831 (@MaddTheSane, 2021) tried to close the gap using gas-preprocessor to translate the ELF assembly syntax, but hit "continuous SIGILLs" at runtime and stalled. This PR picks that effort back up. It turns out no extra tooling is needed — clang's integrated assembler handles `linkage_arm64.S` fine once the syntax differences are handled with an `#ifdef` — and the SIGILLs had a specific, fixable cause (see below).

Three separate problems needed solving:

**Assembler syntax.** I added an `#ifdef __APPLE__` variant of the symbol macros in `linkage_arm64.S`: leading underscores on C symbols, `.private_extern` in place of `.hidden`/`.type`/`.size`, and `@PAGE`/`@PAGEOFF` instead of `:lo12:`. One gotcha worth writing down: the Darwin arm64 assembler treats `;` as a comment character (the statement separator is `%%`), so multi-statement macros silently drop everything after the first statement. I suspect that's why earlier attempts ended up with undefined symbols. I cross-assembled for aarch64-linux to confirm the ELF output is unchanged.

**W^X.** Apple Silicon refuses RWX mappings and won't execute unsigned shared memory, so neither `FIXED_CACHE_ADDR` nor `DOUBLE_CACHE_ADDR` can work — I tried both. Apple builds now use `DYNAMIC_CACHE_ADDR` with `MAP_JIT`, plus small reentrant `jit_write_begin/end` helpers that toggle `pthread_jit_write_protect_np()` around the six C functions all cache writes go through (`new_recompile_block`, `dynamic_linker{,_ds}`, `invalidate_block`, `invalidate_all_pages`, `arch_init`). The cache stays executable by default, so the asm stubs and the generated code itself didn't need any changes.

**Cache flush.** `cache_flush()` reads `ctr_el0`, which traps from userspace on macOS. I believe this is the actual source of the "continuous SIGILLs" reported in #831, not the 16KB page size. Apple builds now call `sys_icache_invalidate()` instead.

Tested on an M-series Mac (macOS 26.5) with a plain `make all`: two commercial ROMs run under the stock 2.6.0 frontend and plugins with `--emumode 2`, and sampling the process shows it executing out of the `MAP_JIT` region, so it really is running recompiled code. The minimum macOS version for the arm64 build goes from 10.16 to 11.0, which `pthread_jit_write_protect_np` requires anyway.

Everything is behind `__APPLE__`/`__aarch64__` guards, so other platforms build exactly what they built before. Happy to adjust anything if a different approach is preferred.
